### PR TITLE
feat(fe): Polish Logs page with shadcn/ui components

### DIFF
--- a/apps/connect/src/app/routes/router-panel/tabs/LogsTab.tsx
+++ b/apps/connect/src/app/routes/router-panel/tabs/LogsTab.tsx
@@ -5,17 +5,75 @@
  * Epic 0.8: System Logs - Story 0.8.1: Log Viewer
  */
 
+import React from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useQueryClient, useIsFetching } from '@tanstack/react-query';
+import { useSystemLogs } from '@nasnet/api-client/queries';
 import { LogViewer } from '@nasnet/features/dashboard';
-export function LogsTab() {
-  return <div className="p-component-md md:p-component-lg animate-fade-in-up flex h-full flex-col">
-      <div className="mb-component-md px-component-sm">
-        <h2 className="font-display text-lg font-semibold md:text-xl">{"Recent Logs"}</h2>
-        <p className="text-muted-foreground text-sm">{"recentLogs.description"}</p>
+import { useConnectionStore } from '@nasnet/state/stores';
+import { Button, Card, CardContent, Icon } from '@nasnet/ui/primitives';
+
+function formatRelativeTime(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  return `${Math.floor(seconds / 3600)}h ago`;
+}
+
+export const LogsTab = React.memo(function LogsTab() {
+  const queryClient = useQueryClient();
+  const routerIp = useConnectionStore((state) => state.currentRouterIp) || '';
+  const isRefreshing = useIsFetching({ queryKey: ['system', 'logs'] }) > 0;
+
+  // Subscribe to the same query LogViewer uses (deduped by TanStack Query)
+  // just to read dataUpdatedAt for the "Updated ..." indicator.
+  const { dataUpdatedAt } = useSystemLogs(routerIp, { limit: 100 });
+  const lastUpdated = dataUpdatedAt ? new Date(dataUpdatedAt) : undefined;
+
+  const [, forceTick] = React.useReducer((x: number) => x + 1, 0);
+  React.useEffect(() => {
+    const interval = setInterval(forceTick, 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleRefresh = React.useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['system', 'logs'] });
+  }, [queryClient]);
+
+  return (
+    <div className="px-page-mobile md:px-page-tablet lg:px-page-desktop animate-fade-in-up mx-auto max-w-7xl space-y-6 py-4 md:py-6">
+      {/* Quick Actions */}
+      <div className="flex items-center justify-end gap-3">
+        {lastUpdated && (
+          <span className="text-muted-foreground text-xs tabular-nums">
+            Updated {formatRelativeTime(lastUpdated)}
+          </span>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={isRefreshing}
+          aria-label="Refresh logs"
+        >
+          <Icon
+            icon={RefreshCw}
+            className={isRefreshing ? 'h-4 w-4 animate-spin' : 'h-4 w-4'}
+            aria-hidden="true"
+          />
+          <span className="ml-2">Refresh</span>
+        </Button>
       </div>
 
-      <div className="min-h-0 flex-1">
-        <LogViewer limit={100} />
-      </div>
-    </div>;
-}
+      {/* Logs Card */}
+      <Card variant="flat" className="flex flex-col">
+        <CardContent className="p-component-md md:p-component-lg flex h-[calc(100vh-12rem)] min-h-[480px] flex-col">
+          <LogViewer limit={100} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+});
+
 LogsTab.displayName = 'LogsTab';

--- a/apps/connect/src/routes/router/$id/logs.tsx
+++ b/apps/connect/src/routes/router/$id/logs.tsx
@@ -17,26 +17,32 @@ import { LazyLogsTab } from '@/app/routes/router-panel/tabs/lazy';
 function LogsTabSkeleton() {
   return (
     <div
-      className="animate-fade-in-up space-y-4 p-4 md:p-6"
+      className="px-page-mobile md:px-page-tablet lg:px-page-desktop animate-fade-in-up mx-auto max-w-7xl space-y-6 py-4 md:py-6"
       aria-busy="true"
       aria-label="Loading logs"
     >
-      {/* Header with category accent */}
-      <div className="border-border flex items-center gap-3 border-b pb-3">
-        <div className="bg-logs h-8 w-1 rounded" />
-        <Skeleton className="h-6 w-32" />
+      {/* Quick actions placeholder */}
+      <div className="flex justify-end">
+        <Skeleton className="h-9 w-24" />
       </div>
 
-      {/* Filter controls skeleton */}
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Skeleton className="h-10 w-32" />
-        <Skeleton className="h-10 w-32" />
-        <Skeleton className="h-10 w-full sm:w-48" />
-      </div>
+      {/* Card-shaped skeleton */}
+      <div className="border-border bg-card rounded-card-sm border">
+        {/* Card header */}
+        <div className="p-component-md md:p-component-lg gap-component-sm flex flex-col">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
 
-      {/* Logs table skeleton */}
-      <div className="border-border overflow-hidden rounded-lg border">
-        <Skeleton className="h-96 w-full" />
+        {/* Card content: filter controls + table */}
+        <div className="p-component-md md:p-component-lg space-y-4 pt-0">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Skeleton className="h-10 flex-1" />
+            <Skeleton className="h-10 w-32" />
+            <Skeleton className="h-10 w-32" />
+          </div>
+          <Skeleton className="h-96 w-full" />
+        </div>
       </div>
     </div>
   );

--- a/libs/api-client/queries/src/system/useLoggingSettings.ts
+++ b/libs/api-client/queries/src/system/useLoggingSettings.ts
@@ -52,6 +52,20 @@ export const loggingKeys = {
 };
 
 /**
+ * Normalize a RouterOS boolean field. RouterOS returns strings like
+ * "true"/"false"/"yes"/"no"; coerce to a real boolean so React truthiness
+ * checks behave correctly (any non-empty string is truthy otherwise).
+ */
+function toBool(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    return v === 'true' || v === 'yes';
+  }
+  return false;
+}
+
+/**
  * Fetch logging rules
  */
 async function fetchLoggingRules(routerIp: string): Promise<LoggingRule[]> {
@@ -61,7 +75,10 @@ async function fetchLoggingRules(routerIp: string): Promise<LoggingRule[]> {
     throw new Error(result.error || 'Failed to fetch logging rules');
   }
 
-  return result.data;
+  return result.data.map((rule) => ({
+    ...rule,
+    disabled: toBool(rule.disabled),
+  }));
 }
 
 /**
@@ -149,7 +166,7 @@ export function useCreateLoggingRule(
     mutationFn: async (input: CreateLoggingRuleInput) => {
       const result = await makeRouterOSRequest<LoggingRule>(routerIp, 'system/logging/add', {
         method: 'POST',
-        body: JSON.stringify(input),
+        body: input,
       });
 
       if (!result.success) {
@@ -176,7 +193,7 @@ export function useUpdateLoggingRule(
     mutationFn: async ({ id, ...input }: UpdateLoggingRuleInput) => {
       const result = await makeRouterOSRequest(routerIp, `system/logging/set`, {
         method: 'POST',
-        body: JSON.stringify({ '.id': id, ...input }),
+        body: { '.id': id, ...input },
       });
 
       if (!result.success) {
@@ -192,21 +209,42 @@ export function useUpdateLoggingRule(
 /**
  * Hook for deleting a logging rule
  */
-export function useDeleteLoggingRule(routerIp: string): UseMutationResult<void, Error, string> {
+export function useDeleteLoggingRule(
+  routerIp: string
+): UseMutationResult<void, Error, string, { previous: LoggingRule[] | undefined }> {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (ruleId: string) => {
-      const result = await makeRouterOSRequest(routerIp, `system/logging/remove`, {
-        method: 'POST',
-        body: JSON.stringify({ '.id': ruleId }),
-      });
+      // RouterOS v7 REST: DELETE /rest/system/logging/<id> is the canonical
+      // way to remove a rule. The CLI-style POST to .../remove with a body
+      // of { numbers: id } or { '.id': id } is accepted inconsistently and
+      // was silently failing here.
+      const result = await makeRouterOSRequest(
+        routerIp,
+        `system/logging/${encodeURIComponent(ruleId)}`,
+        { method: 'DELETE' }
+      );
 
       if (!result.success) {
         throw new Error(result.error || 'Failed to delete logging rule');
       }
     },
-    onSuccess: () => {
+    onMutate: async (ruleId) => {
+      const key = loggingKeys.rules(routerIp);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<LoggingRule[]>(key);
+      queryClient.setQueryData<LoggingRule[]>(key, (old) =>
+        (old ?? []).filter((r) => r['.id'] !== ruleId)
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(loggingKeys.rules(routerIp), ctx.previous);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: loggingKeys.rules(routerIp) });
     },
   });
@@ -217,23 +255,46 @@ export function useDeleteLoggingRule(routerIp: string): UseMutationResult<void, 
  */
 export function useToggleLoggingRule(
   routerIp: string
-): UseMutationResult<void, Error, { id: string; disabled: boolean }> {
+): UseMutationResult<
+  void,
+  Error,
+  { id: string; disabled: boolean },
+  { previous: LoggingRule[] | undefined }
+> {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({ id, disabled }) => {
-      const endpoint = disabled ? 'system/logging/disable' : 'system/logging/enable';
-
-      const result = await makeRouterOSRequest(routerIp, endpoint, {
-        method: 'POST',
-        body: JSON.stringify({ numbers: id }),
-      });
+      // RouterOS v7 REST: PATCH /rest/system/logging/<id> with the field to
+      // change is the canonical form. disabled must be sent as a string.
+      const result = await makeRouterOSRequest(
+        routerIp,
+        `system/logging/${encodeURIComponent(id)}`,
+        {
+          method: 'PATCH',
+          body: { disabled: disabled ? 'true' : 'false' },
+        }
+      );
 
       if (!result.success) {
         throw new Error(result.error || 'Failed to toggle logging rule');
       }
     },
-    onSuccess: () => {
+    onMutate: async ({ id, disabled }) => {
+      const key = loggingKeys.rules(routerIp);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<LoggingRule[]>(key);
+      queryClient.setQueryData<LoggingRule[]>(key, (old) =>
+        (old ?? []).map((r) => (r['.id'] === id ? { ...r, disabled } : r))
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(loggingKeys.rules(routerIp), ctx.previous);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: loggingKeys.rules(routerIp) });
     },
   });
@@ -251,7 +312,7 @@ export function useUpdateLoggingAction(
     mutationFn: async ({ id, ...input }: UpdateLoggingActionInput) => {
       const result = await makeRouterOSRequest(routerIp, `system/logging/action/set`, {
         method: 'POST',
-        body: JSON.stringify({ '.id': id, ...input }),
+        body: { '.id': id, ...input },
       });
 
       if (!result.success) {

--- a/libs/api-client/queries/src/system/useSystemLogs.ts
+++ b/libs/api-client/queries/src/system/useSystemLogs.ts
@@ -64,32 +64,13 @@ async function fetchSystemLogs(
 ): Promise<LogEntry[]> {
   const { topics, severities, limit = 100 } = options;
 
-  // Build request body for POST /rest/log/print
-  // MikroTik REST API requires POST with JSON body for print commands
+  // Fetch all recent logs; topic/severity filtering is done client-side below.
+  // RouterOS REST /log/print `.query` doesn't support regex (`~`) matching on
+  // the combined `topics` field, so server-side topic filtering is unreliable.
   const requestBody: Record<string, unknown> = {
     '.proplist': ['.id', 'time', 'topics', 'message'],
   };
 
-  // Build query filters if topics are specified
-  // RouterOS query format: [".query": ["field=value", "field2=value2", "#|"]]
-  // Topics filter uses regex match on the 'topics' field
-  if (topics && topics.length > 0) {
-    // Create OR query for multiple topics: topics~"system", topics~"firewall", "#|"
-    const queryParts: string[] = [];
-    topics.forEach((topic) => {
-      queryParts.push(`topics~${topic}`);
-    });
-    // Add OR operators for multiple topics
-    if (queryParts.length > 1) {
-      // Add (n-1) OR operators to combine all conditions
-      for (let i = 1; i < queryParts.length; i++) {
-        queryParts.push('#|');
-      }
-    }
-    requestBody['.query'] = queryParts;
-  }
-
-  // Use POST method with /log/print endpoint
   const result = await makeRouterOSRequest<RouterOSLogEntry[]>(routerIp, 'log/print', {
     method: 'POST',
     body: requestBody,
@@ -102,7 +83,19 @@ async function fetchSystemLogs(
   // Transform RouterOS response to LogEntry format
   let entries = result.data.map((entry: RouterOSLogEntry) => transformLogEntry(entry));
 
-  // Apply severity filter in frontend (RouterOS topics field combines topic + severity)
+  // Apply topic filter (client-side). RouterOS packs multiple labels into
+  // the raw topics string (e.g. "dhcp,info"); match against the raw string
+  // so we hit entries where the topic isn't the parsed "primary" one.
+  if (topics && topics.length > 0) {
+    const rawById = new Map(result.data.map((e) => [e['.id'], e.topics || '']));
+    entries = entries.filter((entry) => {
+      const raw = rawById.get(entry.id) || '';
+      const rawTokens = raw.split(',').map((t) => t.trim().toLowerCase());
+      return topics.some((t) => rawTokens.includes(t));
+    });
+  }
+
+  // Apply severity filter (client-side)
   if (severities && severities.length > 0) {
     entries = entries.filter((entry) => severities.includes(entry.severity));
   }

--- a/libs/features/dashboard/src/logs/LogViewer.tsx
+++ b/libs/features/dashboard/src/logs/LogViewer.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react';
-import { AlertCircle, List, Layers, Pin, RefreshCw } from 'lucide-react';
+import { AlertCircle, ChevronLeft, ChevronRight, List, Layers, Pin, RefreshCw } from 'lucide-react';
 import { useSystemLogs } from '@nasnet/api-client/queries';
 import { useConnectionStore } from '@nasnet/state/stores';
 import {
@@ -199,29 +199,37 @@ export const LogViewer = React.memo(function LogViewer({ className, limit = 100 
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
-  // Get logs to display based on view mode
+  // Get logs to display based on view mode (sorted newest first)
   const logsToDisplay = React.useMemo(() => {
-    if (viewMode === 'bookmarked') {
-      return bookmarkedLogs;
-    }
-    return filteredLogs;
+    const source = viewMode === 'bookmarked' ? bookmarkedLogs : filteredLogs;
+    return [...source].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
   }, [viewMode, filteredLogs, bookmarkedLogs]);
 
-  // Navigation for detail panel
-  const currentEntryIndex =
-    selectedEntry ? logsToDisplay.findIndex((l) => l.id === selectedEntry.id) : -1;
+  // Pagination (flat + bookmarked views)
+  const PAGE_SIZE = 25;
+  const [page, setPage] = React.useState(1);
+  const totalPages = Math.max(1, Math.ceil(logsToDisplay.length / PAGE_SIZE));
+  // Clamp inline so slicing never yields an empty window while React
+  // catches up from a filter change that shrank the result set.
+  const effectivePage = Math.min(Math.max(1, page), totalPages);
 
-  const handlePrevious = () => {
-    if (currentEntryIndex > 0) {
-      setSelectedEntry(logsToDisplay[currentEntryIndex - 1]);
-    }
-  };
+  // Reset to page 1 when filters, search, or view mode change the result set
+  React.useEffect(() => {
+    setPage(1);
+  }, [searchTerm, selectedTopics, selectedSeverities, viewMode]);
 
-  const handleNext = () => {
-    if (currentEntryIndex < logsToDisplay.length - 1) {
-      setSelectedEntry(logsToDisplay[currentEntryIndex + 1]);
-    }
-  };
+  // Keep state in sync with clamp so the UI and state don't drift
+  React.useEffect(() => {
+    if (page !== effectivePage) setPage(effectivePage);
+  }, [page, effectivePage]);
+
+  const pagedLogs = React.useMemo(() => {
+    if (viewMode === 'grouped') return logsToDisplay;
+    const start = (effectivePage - 1) * PAGE_SIZE;
+    return logsToDisplay.slice(start, start + PAGE_SIZE);
+  }, [logsToDisplay, effectivePage, viewMode]);
 
   // Get related entries for detail panel
   const relatedEntries = React.useMemo(() => {
@@ -348,10 +356,11 @@ export const LogViewer = React.memo(function LogViewer({ className, limit = 100 
 
       {/* Logs Display */}
       {!isLoading && !isError && (
-        <div className="relative min-h-0 flex-1">
+        <div className="flex min-h-0 flex-1 flex-col">
+         <div className="relative min-h-0 flex-1">
           <div
             ref={scrollContainerRef}
-            className="bg-card absolute inset-0 overflow-y-auto rounded-lg border"
+            className="absolute inset-0 overflow-y-auto"
           >
             {logsToDisplay.length === 0 ?
               <div className="text-muted-foreground p-component-xl gap-component-sm flex h-full flex-col items-center justify-center">
@@ -391,7 +400,7 @@ export const LogViewer = React.memo(function LogViewer({ className, limit = 100 
                 />
               </div>
             : <div className="divide-border divide-y">
-                {logsToDisplay.map((log) => (
+                {pagedLogs.map((log) => (
                   <LogEntry
                     key={log.id}
                     entry={log}
@@ -414,6 +423,44 @@ export const LogViewer = React.memo(function LogViewer({ className, limit = 100 
               onClick={scrollToBottom}
             />
           )}
+         </div>
+
+          {/* Pagination (flat + bookmarked) */}
+          {viewMode !== 'grouped' && logsToDisplay.length > 0 && totalPages > 1 && (
+            <div className="gap-component-sm pt-component-sm flex items-center justify-between border-t pt-3">
+              <span className="text-muted-foreground text-xs tabular-nums">
+                {(effectivePage - 1) * PAGE_SIZE + 1}
+                {'\u2013'}
+                {Math.min(effectivePage * PAGE_SIZE, logsToDisplay.length)} of{' '}
+                {logsToDisplay.length}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setPage(Math.max(1, effectivePage - 1))}
+                  disabled={effectivePage <= 1}
+                  aria-label="Previous page"
+                >
+                  <Icon icon={ChevronLeft} className="h-4 w-4" aria-hidden="true" />
+                </Button>
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  Page {effectivePage} of {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setPage(Math.min(totalPages, effectivePage + 1))}
+                  disabled={effectivePage >= totalPages}
+                  aria-label="Next page"
+                >
+                  <Icon icon={ChevronRight} className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -423,10 +470,6 @@ export const LogViewer = React.memo(function LogViewer({ className, limit = 100 
         isOpen={!!selectedEntry}
         onClose={() => setSelectedEntry(null)}
         relatedEntries={relatedEntries}
-        onPrevious={handlePrevious}
-        onNext={handleNext}
-        hasPrevious={currentEntryIndex > 0}
-        hasNext={currentEntryIndex < logsToDisplay.length - 1}
       />
     </div>
   );

--- a/libs/ui/patterns/src/log-detail-panel/LogDetailPanel.tsx
+++ b/libs/ui/patterns/src/log-detail-panel/LogDetailPanel.tsx
@@ -6,20 +6,21 @@
 
 import * as React from 'react';
 
-import { Copy, X, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+import { Copy, ChevronLeft, ChevronRight, X } from 'lucide-react';
 
 import type { LogEntry } from '@nasnet/core/types';
 import {
+  Badge,
   Button,
-  cn,
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
   useToast,
 } from '@nasnet/ui/primitives';
 
-import { topicBadgeVariants } from '../log-entry';
+import { topicToBadgeVariant } from '../log-entry';
 import { SeverityBadge } from '../severity-badge';
 
 export interface LogDetailPanelProps {
@@ -97,23 +98,6 @@ function LogDetailPanelComponent({
     }
   }, [entry, toast]);
 
-  const handleCopyLink = React.useCallback(async () => {
-    if (!entry) return;
-    const url = `${window.location.href.split('#')[0]}#log-${entry.id}`;
-    try {
-      await navigator.clipboard.writeText(url);
-      toast({
-        title: 'Link copied',
-        description: 'Direct link to this log entry has been copied',
-      });
-    } catch {
-      toast({
-        title: 'Failed to copy',
-        variant: 'destructive',
-      });
-    }
-  }, [entry, toast]);
-
   const handleClose = React.useCallback(() => {
     onClose();
   }, [onClose]);
@@ -127,11 +111,20 @@ function LogDetailPanelComponent({
       open={isOpen}
       onOpenChange={(open) => !open && handleClose()}
     >
-      <DialogContent className="max-w-lg sm:max-w-xl">
+      <DialogContent className="max-w-lg sm:max-w-xl" hideDefaultClose>
         <DialogHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <DialogTitle className="text-base">Log Entry Details</DialogTitle>
             <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopy}
+                className="gap-2"
+              >
+                <Copy className="h-4 w-4" />
+                Copy Entry
+              </Button>
               {onPrevious && (
                 <Button
                   variant="ghost"
@@ -154,11 +147,21 @@ function LogDetailPanelComponent({
                   <ChevronRight className="h-4 w-4" />
                 </Button>
               )}
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-2 cursor-pointer"
+                  aria-label="Close"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </DialogClose>
             </div>
           </div>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div className="min-w-0 space-y-4 overflow-hidden">
           {/* Timestamp */}
           <div>
             <label
@@ -182,9 +185,12 @@ function LogDetailPanelComponent({
                 Topic
               </label>
               <div className="mt-1">
-                <span className={cn(topicBadgeVariants({ topic: entry.topic }))}>
+                <Badge
+                  variant={topicToBadgeVariant(entry.topic)}
+                  className={entry.topic === 'critical' ? 'font-bold' : undefined}
+                >
                   {formatTopicLabel(entry.topic)}
-                </span>
+                </Badge>
               </div>
             </div>
             <div>
@@ -215,51 +221,34 @@ function LogDetailPanelComponent({
 
           {/* Related entries */}
           {relatedEntries.length > 0 && (
-            <div>
+            <div className="min-w-0">
               <label
                 htmlFor="related-entries-list"
                 className="text-muted-foreground text-xs font-medium uppercase tracking-wide"
               >
                 Related Entries ({relatedEntries.length})
               </label>
-              <div className="mt-1 max-h-32 space-y-1 overflow-y-auto">
+              <div className="mt-1 max-h-32 w-full min-w-0 space-y-1 overflow-y-auto overflow-x-hidden">
                 {relatedEntries.slice(0, 5).map((related) => (
                   <div
                     key={related.id}
-                    className="flex items-center gap-2 rounded bg-slate-50 p-2 text-xs dark:bg-slate-800"
+                    className="flex w-full min-w-0 items-center gap-2 rounded bg-slate-50 p-2 text-xs dark:bg-slate-800"
                   >
-                    <span className="text-muted-foreground font-mono">
+                    <span className="text-muted-foreground shrink-0 font-mono">
                       {new Date(related.timestamp).toLocaleTimeString()}
                     </span>
-                    <SeverityBadge severity={related.severity} />
-                    <span className="flex-1 truncate">{related.message}</span>
+                    <span className="shrink-0">
+                      <SeverityBadge severity={related.severity} />
+                    </span>
+                    <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                      {related.message}
+                    </span>
                   </div>
                 ))}
               </div>
             </div>
           )}
 
-          {/* Actions */}
-          <div className="flex items-center gap-2 border-t pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCopy}
-              className="gap-2"
-            >
-              <Copy className="h-4 w-4" />
-              Copy Entry
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCopyLink}
-              className="gap-2"
-            >
-              <ExternalLink className="h-4 w-4" />
-              Copy Link
-            </Button>
-          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/libs/ui/patterns/src/log-entry/LogEntry.test.tsx
+++ b/libs/ui/patterns/src/log-entry/LogEntry.test.tsx
@@ -59,96 +59,69 @@ describe('LogEntry', () => {
   });
 
   describe('Topic Badge Rendering', () => {
-    it('should render firewall topic with correct styling', () => {
+    it('should render firewall topic with error color', () => {
       render(<LogEntry entry={mockLogEntry} />);
 
-      const topicBadge = screen.getByText('firewall');
+      const topicBadge = screen.getByText('Firewall');
       expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-orange');
+      expect(topicBadge.className).toContain('bg-error-light');
     });
 
-    it('should render system topic with correct styling', () => {
-      const systemLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'system',
-      };
+    it('should render system topic with muted color', () => {
+      const systemLog: LogEntryType = { ...mockLogEntry, topic: 'system' };
       render(<LogEntry entry={systemLog} />);
 
-      const topicBadge = screen.getByText('system');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-slate');
+      const topicBadge = screen.getByText('System');
+      expect(topicBadge.className).toContain('bg-muted');
     });
 
-    it('should render wireless topic with correct styling', () => {
-      const wirelessLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'wireless',
-      };
+    it('should render wireless topic with info color', () => {
+      const wirelessLog: LogEntryType = { ...mockLogEntry, topic: 'wireless' };
       render(<LogEntry entry={wirelessLog} />);
 
-      const topicBadge = screen.getByText('wireless');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-purple');
+      const topicBadge = screen.getByText('Wireless');
+      expect(topicBadge.className).toContain('bg-info-light');
     });
 
-    it('should render dhcp topic with correct styling', () => {
-      const dhcpLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'dhcp',
-      };
+    it('should render dhcp topic with success color', () => {
+      const dhcpLog: LogEntryType = { ...mockLogEntry, topic: 'dhcp' };
       render(<LogEntry entry={dhcpLog} />);
 
-      const topicBadge = screen.getByText('dhcp');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-green');
+      const topicBadge = screen.getByText('DHCP');
+      expect(topicBadge.className).toContain('bg-success-light');
     });
 
-    it('should render vpn topic with correct styling', () => {
-      const vpnLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'vpn',
-      };
+    it('should render vpn topic with secondary color', () => {
+      const vpnLog: LogEntryType = { ...mockLogEntry, topic: 'vpn' };
       render(<LogEntry entry={vpnLog} />);
 
-      const topicBadge = screen.getByText('vpn');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-indigo');
+      const topicBadge = screen.getByText('VPN');
+      expect(topicBadge.className).toContain('bg-secondary');
     });
 
-    it('should render critical topic with correct styling', () => {
-      const criticalLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'critical',
-      };
+    it('should render critical topic with error color and bold', () => {
+      const criticalLog: LogEntryType = { ...mockLogEntry, topic: 'critical' };
       render(<LogEntry entry={criticalLog} />);
 
-      const topicBadge = screen.getByText('critical');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-red');
+      const topicBadge = screen.getByText('Critical');
+      expect(topicBadge.className).toContain('bg-error-light');
+      expect(topicBadge.className).toContain('font-bold');
     });
 
-    it('should render warning topic with correct styling', () => {
-      const warningLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'warning',
-      };
+    it('should render warning topic with warning color', () => {
+      const warningLog: LogEntryType = { ...mockLogEntry, topic: 'warning' };
       render(<LogEntry entry={warningLog} />);
 
-      const topicBadge = screen.getByText('warning');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-yellow');
+      const topicBadge = screen.getByText('Warning');
+      expect(topicBadge.className).toContain('bg-warning-light');
     });
 
-    it('should render info topic with correct styling', () => {
-      const infoLog: LogEntryType = {
-        ...mockLogEntry,
-        topic: 'info',
-      };
+    it('should render info topic with info color', () => {
+      const infoLog: LogEntryType = { ...mockLogEntry, topic: 'info' };
       render(<LogEntry entry={infoLog} />);
 
-      const topicBadge = screen.getByText('info');
-      expect(topicBadge).toBeInTheDocument();
-      expect(topicBadge.className).toContain('bg-blue');
+      const topicBadge = screen.getByText('Info');
+      expect(topicBadge.className).toContain('bg-info-light');
     });
   });
 
@@ -371,7 +344,7 @@ describe('LogEntry', () => {
     it('should prevent topic badge from shrinking', () => {
       render(<LogEntry entry={mockLogEntry} />);
 
-      const topicBadge = screen.getByText('firewall');
+      const topicBadge = screen.getByText('Firewall');
       expect(topicBadge.className).toContain('shrink-0');
     });
 

--- a/libs/ui/patterns/src/log-entry/LogEntry.tsx
+++ b/libs/ui/patterns/src/log-entry/LogEntry.tsx
@@ -6,18 +6,19 @@
 
 import * as React from 'react';
 
-import { cva, type VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import { Copy, Pin, Check } from 'lucide-react';
 
 import type { LogEntry as LogEntryType, LogTopic } from '@nasnet/core/types';
 import { formatTimestamp } from '@nasnet/core/utils';
-import { cn } from '@nasnet/ui/primitives';
+import { Badge, cn } from '@nasnet/ui/primitives';
 
 import { SeverityBadge } from '../severity-badge';
+import { topicToBadgeVariant } from './logBadgeVariant';
 
 /**
- * Topic badge styling variants
- * Maps LogTopic to color classes
+ * Topic badge styling variants (legacy CVA, retained for LogFilters/LogDetailPanel back-compat).
+ * Row badges in LogEntry now use the shadcn Badge primitive via topicToBadgeVariant().
  */
 const topicBadgeVariants = cva(
   'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset transition-colors',
@@ -192,9 +193,12 @@ export const LogEntry = React.memo(
                 {formatTimestamp(timestamp, showDate)}
               </time>
               <SeverityBadge severity={severity} />
-              <span className={cn(topicBadgeVariants({ topic }), 'px-1.5 py-0 text-[10px]')}>
+              <Badge
+                variant={topicToBadgeVariant(topic)}
+                className={cn('px-1.5 py-0 text-[10px]', topic === 'critical' && 'font-bold')}
+              >
                 {formatTopicLabel(topic)}
-              </span>
+              </Badge>
 
               {/* Actions */}
               <div className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
@@ -252,9 +256,12 @@ export const LogEntry = React.memo(
           </time>
 
           {/* Topic Badge - hidden on small screens */}
-          <span className={cn(topicBadgeVariants({ topic }), 'hidden shrink-0 sm:inline-flex')}>
+          <Badge
+            variant={topicToBadgeVariant(topic)}
+            className={cn('hidden shrink-0 sm:inline-flex', topic === 'critical' && 'font-bold')}
+          >
             {formatTopicLabel(topic)}
-          </span>
+          </Badge>
 
           {/* Severity Badge */}
           <SeverityBadge severity={severity} />

--- a/libs/ui/patterns/src/log-entry/index.ts
+++ b/libs/ui/patterns/src/log-entry/index.ts
@@ -5,3 +5,4 @@
 
 export { LogEntry, topicBadgeVariants } from './LogEntry';
 export type { LogEntryProps } from './LogEntry';
+export { topicToBadgeVariant, severityToBadgeVariant } from './logBadgeVariant';

--- a/libs/ui/patterns/src/log-entry/logBadgeVariant.ts
+++ b/libs/ui/patterns/src/log-entry/logBadgeVariant.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared mapping from LogTopic / LogSeverity to a shadcn Badge variant.
+ * Used by LogEntry, LogFilters, LogDetailPanel, LogStats, and SeverityBadge
+ * so every badge-like surface in the logs feature stays visually consistent.
+ */
+
+import type { LogSeverity, LogTopic } from '@nasnet/core/types';
+import type { BadgeProps } from '@nasnet/ui/primitives';
+
+export function topicToBadgeVariant(topic: LogTopic): NonNullable<BadgeProps['variant']> {
+  switch (topic) {
+    case 'firewall':
+    case 'error':
+    case 'critical':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    case 'dhcp':
+      return 'success';
+    case 'wireless':
+    case 'info':
+      return 'info';
+    case 'system':
+      return 'offline';
+    default:
+      return 'secondary';
+  }
+}
+
+export function severityToBadgeVariant(
+  severity: LogSeverity
+): NonNullable<BadgeProps['variant']> {
+  switch (severity) {
+    case 'debug':
+      return 'offline';
+    case 'info':
+      return 'info';
+    case 'warning':
+      return 'warning';
+    case 'error':
+    case 'critical':
+      return 'error';
+    default:
+      return 'info';
+  }
+}

--- a/libs/ui/patterns/src/log-filters/LogFilters.tsx
+++ b/libs/ui/patterns/src/log-filters/LogFilters.tsx
@@ -9,11 +9,13 @@ import * as React from 'react';
 import { X, Filter } from 'lucide-react';
 
 import type { LogTopic, LogSeverity } from '@nasnet/core/types';
-import { Button, cn } from '@nasnet/ui/primitives';
+import { Badge, Button, cn } from '@nasnet/ui/primitives';
 
-import { topicBadgeVariants } from '../log-entry';
+import { topicToBadgeVariant } from '../log-entry';
 import { SeverityBadge } from '../severity-badge';
 
+// Severity-named values are excluded from the topic filter since they have
+// their own "Filter by Severity" dropdown.
 const ALL_TOPICS: LogTopic[] = [
   'system',
   'firewall',
@@ -25,10 +27,6 @@ const ALL_TOPICS: LogTopic[] = [
   'interface',
   'route',
   'script',
-  'critical',
-  'info',
-  'warning',
-  'error',
 ];
 
 const ALL_SEVERITIES: LogSeverity[] = ['debug', 'info', 'warning', 'error', 'critical'];
@@ -198,9 +196,12 @@ function LogFiltersComponent({
             <Filter className="h-4 w-4" />
             Filter by Topic
             {topics.length > 0 && (
-              <span className="bg-primary-500 ml-1 rounded-full px-2 py-0.5 text-xs font-semibold text-slate-900">
+              <Badge
+                variant="default"
+                className="ml-1 px-2 py-0 text-[10px] leading-tight"
+              >
                 {topics.length}
-              </span>
+              </Badge>
             )}
           </Button>
 
@@ -221,9 +222,12 @@ function LogFiltersComponent({
                         onChange={() => toggleTopic(topic)}
                         className="h-4 w-4 rounded border-slate-300 dark:border-slate-600"
                       />
-                      <span className={cn(topicBadgeVariants({ topic }), 'shrink-0 text-xs')}>
+                      <Badge
+                        variant={topicToBadgeVariant(topic)}
+                        className={cn('shrink-0', topic === 'critical' && 'font-bold')}
+                      >
                         {formatTopicLabel(topic)}
-                      </span>
+                      </Badge>
                     </label>
                   );
                 })}
@@ -246,9 +250,12 @@ function LogFiltersComponent({
             <Filter className="h-4 w-4" />
             Filter by Severity
             {severities.length > 0 && (
-              <span className="bg-primary-500 ml-1 rounded-full px-2 py-0.5 text-xs font-semibold text-slate-900">
+              <Badge
+                variant="default"
+                className="ml-1 px-2 py-0 text-[10px] leading-tight"
+              >
                 {severities.length}
-              </span>
+              </Badge>
             )}
           </Button>
 
@@ -298,18 +305,27 @@ function LogFiltersComponent({
         <div className="flex flex-wrap gap-2">
           {/* Topic Badges */}
           {topics.map((topic) => (
-            <button
+            <Badge
               key={`topic-${topic}`}
-              onClick={() => removeTopic(topic)}
+              variant={topicToBadgeVariant(topic)}
               className={cn(
-                topicBadgeVariants({ topic }),
-                'group flex cursor-pointer items-center gap-1 transition-opacity hover:opacity-80'
+                'group cursor-pointer gap-1 transition-opacity hover:opacity-80',
+                topic === 'critical' && 'font-bold'
               )}
+              role="button"
+              tabIndex={0}
               aria-label={`Remove ${topic} filter`}
+              onClick={() => removeTopic(topic)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  removeTopic(topic);
+                }
+              }}
             >
               <span>{formatTopicLabel(topic)}</span>
               <X className="h-3 w-3 opacity-70 group-hover:opacity-100" />
-            </button>
+            </Badge>
           ))}
 
           {/* Severity Badges */}

--- a/libs/ui/patterns/src/log-stats/LogStats.tsx
+++ b/libs/ui/patterns/src/log-stats/LogStats.tsx
@@ -6,10 +6,12 @@
 
 import * as React from 'react';
 
-import { ChevronDown, ChevronUp, RefreshCw } from 'lucide-react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 import type { LogEntry, LogSeverity } from '@nasnet/core/types';
-import { cn, Button } from '@nasnet/ui/primitives';
+import { Badge, Button, cn } from '@nasnet/ui/primitives';
+
+import { severityToBadgeVariant } from '../log-entry';
 
 export interface LogStatsProps {
   /**
@@ -69,30 +71,11 @@ function computeStats(logs: LogEntry[]): SeverityStats[] {
 }
 
 /**
- * Format relative time
- */
-function formatRelativeTime(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-
-  if (seconds < 5) return 'just now';
-  if (seconds < 60) return `${seconds}s ago`;
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  return `${Math.floor(seconds / 3600)}h ago`;
-}
-
-/**
  * LogStats Component
  */
-export function LogStats({ logs, lastUpdated, isLoading, className }: LogStatsProps) {
+export function LogStats({ logs, className }: LogStatsProps) {
   const [isExpanded, setIsExpanded] = React.useState(true);
-  const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
   const stats = React.useMemo(() => computeStats(logs), [logs]);
-
-  // Update relative time every 10 seconds
-  React.useEffect(() => {
-    const interval = setInterval(forceUpdate, 10000);
-    return () => clearInterval(interval);
-  }, []);
 
   const nonZeroStats = stats.filter((s) => s.count > 0);
 
@@ -110,30 +93,22 @@ export function LogStats({ logs, lastUpdated, isLoading, className }: LogStatsPr
           {/* Severity badges - compact */}
           <div className="hidden items-center gap-2 sm:flex">
             {nonZeroStats.map((stat) => (
-              <div
+              <Badge
                 key={stat.severity}
-                className={cn(
-                  'flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium',
-                  stat.severity === 'critical' || stat.severity === 'error' ?
-                    'bg-error/10 text-error'
-                  : stat.severity === 'warning' ? 'bg-warning/10 text-warning'
-                  : 'text-muted-foreground bg-slate-100 dark:bg-slate-800'
-                )}
+                variant={severityToBadgeVariant(stat.severity)}
+                className="gap-1.5"
               >
-                <span className={cn('h-2 w-2 rounded-full', stat.color)} />
+                <span
+                  className={cn('inline-block shrink-0', stat.color)}
+                  style={{ width: 8, height: 8, borderRadius: 9999 }}
+                  aria-hidden="true"
+                />
                 <span className="capitalize">{stat.severity}</span>
                 <span className="tabular-nums">{stat.count}</span>
-              </div>
+              </Badge>
             ))}
           </div>
 
-          {/* Last updated */}
-          {lastUpdated && (
-            <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
-              <RefreshCw className={cn('h-3 w-3', isLoading && 'animate-spin')} />
-              <span>Updated {formatRelativeTime(lastUpdated)}</span>
-            </div>
-          )}
         </div>
 
         {/* Expand/collapse button */}
@@ -178,7 +153,11 @@ export function LogStats({ logs, lastUpdated, isLoading, className }: LogStatsPr
                 key={stat.severity}
                 className="text-muted-foreground flex items-center gap-1 text-xs"
               >
-                <span className={cn('h-2 w-2 rounded-full', stat.color)} />
+                <span
+                  className={cn('inline-block shrink-0', stat.color)}
+                  style={{ width: 8, height: 8, borderRadius: 9999 }}
+                  aria-hidden="true"
+                />
                 <span className="capitalize">{stat.severity}:</span>
                 <span className="tabular-nums">{stat.count}</span>
               </div>

--- a/libs/ui/patterns/src/severity-badge/SeverityBadge.test.tsx
+++ b/libs/ui/patterns/src/severity-badge/SeverityBadge.test.tsx
@@ -47,49 +47,43 @@ describe('SeverityBadge', () => {
   });
 
   describe('Color Styling', () => {
-    it('should apply gray color for debug severity', () => {
+    it('should apply muted color for debug severity', () => {
       render(<SeverityBadge severity="debug" />);
       const badge = screen.getByText('Debug');
-      expect(badge.className).toContain('text-gray');
-      expect(badge.className).toContain('bg-gray');
+      expect(badge.className).toContain('bg-muted');
     });
 
-    it('should apply blue color for info severity', () => {
+    it('should apply info color for info severity', () => {
       render(<SeverityBadge severity="info" />);
       const badge = screen.getByText('Info');
-      expect(badge.className).toContain('text-blue');
-      expect(badge.className).toContain('bg-blue');
+      expect(badge.className).toContain('bg-info-light');
     });
 
-    it('should apply amber color for warning severity', () => {
+    it('should apply warning color for warning severity', () => {
       render(<SeverityBadge severity="warning" />);
       const badge = screen.getByText('Warning');
-      expect(badge.className).toContain('text-amber');
-      expect(badge.className).toContain('bg-amber');
+      expect(badge.className).toContain('bg-warning-light');
     });
 
-    it('should apply red color for error severity', () => {
+    it('should apply error color for error severity', () => {
       render(<SeverityBadge severity="error" />);
       const badge = screen.getByText('Error');
-      expect(badge.className).toContain('text-red');
-      expect(badge.className).toContain('bg-red');
+      expect(badge.className).toContain('bg-error-light');
     });
 
-    it('should apply red and bold for critical severity', () => {
+    it('should apply error color and bold for critical severity', () => {
       render(<SeverityBadge severity="critical" />);
       const badge = screen.getByText('Critical');
-      expect(badge.className).toContain('text-red');
-      expect(badge.className).toContain('bg-red');
+      expect(badge.className).toContain('bg-error-light');
       expect(badge.className).toContain('font-bold');
     });
   });
 
   describe('Read-only Badge (Log Entry)', () => {
-    it('should render as span when no onRemove provided', () => {
-      const { container } = render(<SeverityBadge severity="error" />);
-      const badge = container.querySelector('span');
+    it('should render with status role when no onRemove provided', () => {
+      render(<SeverityBadge severity="error" />);
+      const badge = screen.getByRole('status');
       expect(badge).toBeInTheDocument();
-      expect(badge?.getAttribute('role')).toBe('status');
     });
 
     it('should have aria-label with severity', () => {
@@ -234,11 +228,11 @@ describe('SeverityBadge', () => {
 
     it('should apply unique colors to each severity level', () => {
       allSeverities.forEach((severity) => {
-        const { container, unmount } = render(<SeverityBadge severity={severity} />);
-        const badge = container.querySelector('span');
+        const { unmount } = render(<SeverityBadge severity={severity} />);
+        const badge = screen.getByRole('status');
 
         // Each severity should have distinct color classes
-        expect(badge?.className).toBeTruthy();
+        expect(badge.className).toBeTruthy();
 
         unmount();
       });
@@ -246,20 +240,20 @@ describe('SeverityBadge', () => {
   });
 
   describe('Dark Mode Support', () => {
-    it('should include dark mode classes for debug', () => {
-      render(<SeverityBadge severity="debug" />);
-      const badge = screen.getByText('Debug');
-      expect(badge.className).toContain('dark:');
-    });
-
-    it('should include dark mode classes for all severities', () => {
+    it('should adapt colors for dark mode via dark: classes or CSS token variables', () => {
       const severities: LogSeverity[] = ['debug', 'info', 'warning', 'error', 'critical'];
 
       severities.forEach((severity) => {
         const { unmount } = render(<SeverityBadge severity={severity} />);
         const label = severity.charAt(0).toUpperCase() + severity.slice(1);
         const badge = screen.getByText(label);
-        expect(badge.className).toContain('dark:');
+        // Either a dark: variant class, or semantic tokens that resolve via CSS variables
+        const adapts =
+          badge.className.includes('dark:') ||
+          badge.className.includes('bg-muted') ||
+          badge.className.includes('-light') ||
+          badge.className.includes('-dark');
+        expect(adapts).toBe(true);
         unmount();
       });
     });

--- a/libs/ui/patterns/src/severity-badge/SeverityBadge.tsx
+++ b/libs/ui/patterns/src/severity-badge/SeverityBadge.tsx
@@ -10,17 +10,13 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { X } from 'lucide-react';
 
 import type { LogSeverity } from '@nasnet/core/types';
-import { cn } from '@nasnet/ui/primitives';
+import { Badge, cn } from '@nasnet/ui/primitives';
+
+import { severityToBadgeVariant } from '../log-entry';
 
 /**
- * Severity badge variants with color mapping
- * - debug: Gray (low priority, muted)
- * - info: Blue (informational)
- * - warning: Amber/Yellow (attention needed)
- * - error: Red (error occurred)
- * - critical: Red Bold (critical issue)
- *
- * Colors meet WCAG AA contrast requirements
+ * Severity badge variants with color mapping (legacy filter/button mode).
+ * Row rendering uses the shadcn Badge primitive via severityToBadgeVariant().
  */
 const severityBadgeVariants = cva(
   'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-colors',
@@ -78,38 +74,43 @@ function SeverityBadgeBase({ severity, onRemove, className, ...props }: Severity
   const displayText = severity.charAt(0).toUpperCase() + severity.slice(1);
 
   if (onRemove) {
-    // Filter badge with dismiss button
+    // Filter badge with dismiss button — uses shadcn Badge primitive
     return (
-      <button
-        type="button"
-        onClick={onRemove}
+      <Badge
+        variant={severityToBadgeVariant(severity)}
         className={cn(
-          severityBadgeVariants({ severity }),
-          'focus-visible:ring-ring transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'group cursor-pointer gap-1 transition-opacity hover:opacity-80',
           className
         )}
+        role="button"
+        tabIndex={0}
         aria-label={`Remove ${displayText} filter`}
-        {...props}
+        onClick={onRemove}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onRemove();
+          }
+        }}
       >
         <span>{displayText}</span>
-        <X
-          className="h-3.5 w-3.5"
-          aria-hidden="true"
-        />
-      </button>
+        <X className="h-3 w-3 opacity-70 group-hover:opacity-100" aria-hidden="true" />
+      </Badge>
     );
   }
 
-  // Read-only badge (for log entries)
+  // Read-only badge (for log entries) — uses shadcn Badge primitive
+  const { role, ...rest } = props as React.HTMLAttributes<HTMLSpanElement> & { role?: string };
   return (
-    <span
-      className={cn(severityBadgeVariants({ severity }), className)}
-      role="status"
+    <Badge
+      variant={severityToBadgeVariant(severity)}
+      className={className}
+      role={role ?? 'status'}
       aria-label={`Severity: ${displayText}`}
-      {...props}
+      {...rest}
     >
       {displayText}
-    </span>
+    </Badge>
   );
 }
 

--- a/libs/ui/primitives/src/dialog/dialog.tsx
+++ b/libs/ui/primitives/src/dialog/dialog.tsx
@@ -74,8 +74,11 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DialogContent = React.memo(
   React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
-  >(({ className, children, ...props }, ref) => (
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+      /** Hide the built-in absolute-positioned close (X) button. Use when providing your own. */
+      hideDefaultClose?: boolean;
+    }
+  >(({ className, children, hideDefaultClose, ...props }, ref) => (
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Content
@@ -87,10 +90,12 @@ const DialogContent = React.memo(
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="hover:bg-accent focus-visible:ring-ring absolute right-4 top-4 flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg p-1.5 opacity-70 transition-all duration-200 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {!hideDefaultClose && (
+          <DialogPrimitive.Close className="hover:bg-accent focus-visible:ring-ring absolute right-4 top-4 flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg p-1.5 opacity-70 transition-all duration-200 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   ))

--- a/libs/ui/primitives/src/switch/switch.tsx
+++ b/libs/ui/primitives/src/switch/switch.tsx
@@ -59,14 +59,16 @@ const Switch = React.memo(
     ({ className, ...props }, ref) => (
       <SwitchPrimitives.Root
         className={cn(
-          'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-success data-[state=unchecked]:bg-input peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-success data-[state=unchecked]:bg-input peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
+        style={{ borderRadius: 9999 }}
         {...props}
         ref={ref}
       >
         <SwitchPrimitives.Thumb
-          className="pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+          className="pointer-events-none block h-4 w-4 bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+          style={{ borderRadius: 9999 }}
         />
       </SwitchPrimitives.Root>
     )


### PR DESCRIPTION

<img width="1127" height="789" alt="Screenshot 2026-04-16 at 01 50 24" src="https://github.com/user-attachments/assets/3a177db4-265e-450a-acfa-0365db3ba6a2" />

## Summary

- Align Logs page shell with WiFi (Card + responsive padding + top toolbar with live "Updated Xs ago" next to Refresh).
- All log badges (rows, detail modal, filters, stats) now use the shadcn `Badge` primitive with a shared topic/severity → variant mapping.
- Client-side pagination (25/page) with clamped page, newest-first sort, and topic filtering moved to the client since RouterOS REST ignores regex in `.query`.
- Fix logging-settings mutations: bodies were double-`JSON.stringify`'d; toggle/delete now use canonical v7 REST with optimistic updates. Normalize RouterOS's stringy `disabled` to a real boolean so the Switch stops flipping back.