### PR TITLE
feat(fe): hide Store and Services tabs

### DIFF
--- a/apps/connect/src/app/routes/router-panel/components/TabNavigation.tsx
+++ b/apps/connect/src/app/routes/router-panel/components/TabNavigation.tsx
@@ -74,19 +74,21 @@ const tabs: TabDefinition[] = [{
   icon: ScrollText,
   ariaLabel: 'System logs',
   preload: preloadLogsTab
-}, {
-  value: 'plugins',
-  label: 'Store',
-  icon: Store,
-  ariaLabel: 'Plugin store',
-  preload: preloadPluginStoreTab
-}, {
-  value: 'services',
-  label: 'Services',
-  mobileLabel: 'Svc',
-  icon: Boxes,
-  ariaLabel: 'Service management'
-}];
+}
+// }, {
+//   value: 'plugins',
+//   label: 'Store',
+//   icon: Store,
+//   ariaLabel: 'Plugin store',
+//   preload: preloadPluginStoreTab
+// }, {
+//   value: 'services',
+//   label: 'Services',
+//   mobileLabel: 'Svc',
+//   icon: Boxes,
+//   ariaLabel: 'Service management'
+// }
+];
 
 /**
  * Tab Navigation Component


### PR DESCRIPTION
## Summary
- Comment out the Store and Services entries in the router panel's `TabNavigation` so they no longer render.
- Imports and preload references kept intact for easy re-enable.