### PR TITLE
feat(devops): add nilaway static analysis to backend

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Branch is up-to-date."
 
   frontend:
-    name: Frontend (lint · format · typecheck · build)
+    name: Frontend (format · typecheck · build)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: up-to-date
@@ -44,14 +44,26 @@ jobs:
       - name: Prettier (format:check)
         run: npm run format:check
 
-      - name: ESLint
-        run: npm run lint
-
       - name: TypeScript typecheck
         run: npm run typecheck
 
       - name: Webpack production build
         run: npm run build
+
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: up-to-date
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-node-workspace
+        with:
+          node-version: '20'
+
+      - name: ESLint
+        run: npm run lint
 
   backend:
     name: Backend (fmt · vet · lint · build · test)
@@ -69,9 +81,6 @@ jobs:
       - name: Install golangci-lint v2
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
-      - name: Install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
-
       - name: Format check (gofmt + goimports)
         working-directory: backend
         run: golangci-lint fmt --diff
@@ -84,10 +93,6 @@ jobs:
         working-directory: backend
         run: golangci-lint run --timeout=5m
 
-      - name: nilaway
-        working-directory: backend
-        run: nilaway ./...
-
       - name: go build
         working-directory: backend
         run: go build ./...
@@ -95,6 +100,23 @@ jobs:
       - name: go test
         working-directory: backend
         run: go test -vet=off ./...
+
+  nilaway:
+    name: Nilaway
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: up-to-date
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-go-backend
+
+      - name: Install nilaway
+        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+
+      - name: nilaway
+        working-directory: backend
+        run: nilaway ./...
 
   e2e:
     name: E2E (Playwright)
@@ -137,16 +159,18 @@ jobs:
   status:
     name: PR Status
     runs-on: ubuntu-latest
-    needs: [up-to-date, frontend, backend, e2e]
+    needs: [up-to-date, frontend, eslint, backend, nilaway, e2e]
     if: always()
     steps:
       - name: Check job results
         run: |
           echo "Up-to-date: ${{ needs.up-to-date.result }}"
           echo "Frontend:   ${{ needs.frontend.result }}"
+          echo "ESLint:     ${{ needs.eslint.result }}"
           echo "Backend:    ${{ needs.backend.result }}"
+          echo "Nilaway:    ${{ needs.nilaway.result }}"
           echo "E2E:        ${{ needs.e2e.result }}"
-          if [[ "${{ needs.up-to-date.result }}" != "success" || "${{ needs.frontend.result }}" != "success" || "${{ needs.backend.result }}" != "success" || "${{ needs.e2e.result }}" != "success" ]]; then
+          if [[ "${{ needs.up-to-date.result }}" != "success" || "${{ needs.frontend.result }}" != "success" || "${{ needs.eslint.result }}" != "success" || "${{ needs.backend.result }}" != "success" || "${{ needs.nilaway.result }}" != "success" || "${{ needs.e2e.result }}" != "success" ]]; then
             echo "::error::One or more checks failed"
             exit 1
           fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Install golangci-lint v2
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
+      - name: Install nilaway
+        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+
       - name: Format check (gofmt + goimports)
         working-directory: backend
         run: golangci-lint fmt --diff
@@ -80,6 +83,10 @@ jobs:
       - name: golangci-lint
         working-directory: backend
         run: golangci-lint run --timeout=5m
+
+      - name: nilaway
+        working-directory: backend
+        run: nilaway ./...
 
       - name: go build
         working-directory: backend

--- a/backend/internal/scanner/discovery.go
+++ b/backend/internal/scanner/discovery.go
@@ -120,7 +120,7 @@ func CheckRouterOSAPI(ctx context.Context, ip string, port int, timeout time.Dur
 	req.SetBasicAuth("admin", "")
 
 	resp, err := client.Do(req) //nolint:gosec // G704: URL is constructed from trusted configuration
-	if err != nil {
+	if err != nil || resp == nil {
 		return nil
 	}
 	defer resp.Body.Close()

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -186,7 +186,11 @@ func ParseIPRange(subnet string) ([]string, error) {
 			return nil, fmt.Errorf("parse CIDR: %w", err)
 		}
 
-		for ip := ipNet.IP.Mask(ipNet.Mask); ipNet.Contains(ip); IncIP(ip) {
+		ip := ipNet.IP.Mask(ipNet.Mask)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid CIDR mask")
+		}
+		for ; ipNet.Contains(ip); IncIP(ip) {
 			ips = append(ips, ip.String())
 			if len(ips) > 1000 {
 				break


### PR DESCRIPTION
## Summary
- Adds nilaway to the backend CI job (installed via `go install`, runs after golangci-lint).
- Fixes the two nil-flow issues nilaway currently reports in `internal/scanner`: guards `client.Do` response and the `ipNet.IP.Mask(...)` result.