### PR TITLE
introduced DNS endpoints

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -312,6 +312,131 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/dns/info": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve DNS configuration from RouterOS device",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DNS"
+                ],
+                "summary": "Get DNS information",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RouterOS host address",
+                        "name": "X-RouterOS-Host",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "DNS information",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Update DNS servers and DoH configuration on RouterOS device",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DNS"
+                ],
+                "summary": "Update DNS configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RouterOS host address",
+                        "name": "X-RouterOS-Host",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "DNS configuration",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.UpdateDNSRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "DNS updated",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/firewall/rules": {
             "get": {
                 "security": [
@@ -1768,6 +1893,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.UpdateDNSRequest": {
+            "type": "object",
+            "properties": {
+                "dohServer": {
+                    "type": "string"
+                },
+                "servers": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -310,6 +310,131 @@
                 }
             }
         },
+        "/api/dns/info": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve DNS configuration from RouterOS device",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DNS"
+                ],
+                "summary": "Get DNS information",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RouterOS host address",
+                        "name": "X-RouterOS-Host",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "DNS information",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Update DNS servers and DoH configuration on RouterOS device",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "DNS"
+                ],
+                "summary": "Update DNS configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RouterOS host address",
+                        "name": "X-RouterOS-Host",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "DNS configuration",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.UpdateDNSRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "DNS updated",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/firewall/rules": {
             "get": {
                 "security": [
@@ -1766,6 +1891,17 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.UpdateDNSRequest": {
+            "type": "object",
+            "properties": {
+                "dohServer": {
+                    "type": "string"
+                },
+                "servers": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -63,6 +63,13 @@ definitions:
       name:
         type: string
     type: object
+  handler.UpdateDNSRequest:
+    properties:
+      dohServer:
+        type: string
+      servers:
+        type: string
+    type: object
   handler.UpdateWiFiInterfaceRequest:
     properties:
       enabled:
@@ -272,6 +279,89 @@ paths:
       summary: List DHCP servers
       tags:
       - DHCP
+  /api/dns/info:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve DNS configuration from RouterOS device
+      parameters:
+      - description: RouterOS host address
+        in: header
+        name: X-RouterOS-Host
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: DNS information
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BasicAuth: []
+      summary: Get DNS information
+      tags:
+      - DNS
+    put:
+      consumes:
+      - application/json
+      description: Update DNS servers and DoH configuration on RouterOS device
+      parameters:
+      - description: RouterOS host address
+        in: header
+        name: X-RouterOS-Host
+        required: true
+        type: string
+      - description: DNS configuration
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.UpdateDNSRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: DNS updated
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BasicAuth: []
+      summary: Update DNS configuration
+      tags:
+      - DNS
   /api/firewall/rules:
     get:
       consumes:

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -1,0 +1,124 @@
+package handler
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"nasnet-panel/pkg/routeros"
+
+	"github.com/labstack/echo/v4"
+)
+
+// HandleGetDNSInfo godoc
+// @Summary Get DNS information
+// @Description Retrieve DNS configuration from RouterOS device
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Success 200 {object} map[string]interface{} "DNS information"
+// @Failure 400 {object} map[string]interface{} "Bad request"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Failure 500 {object} map[string]interface{} "Internal server error"
+// @Router /api/dns/info [get].
+func HandleGetDNSInfo(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	info, err := client.GetDNSInfo()
+	if err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to get DNS info", err)
+	}
+
+	response := convertDNSInfoResponse(info)
+	return SuccessResponse(c, http.StatusOK, "DNS information retrieved", response)
+}
+
+// HandleUpdateDNS godoc
+// @Summary Update DNS configuration
+// @Description Update DNS servers and DoH configuration on RouterOS device
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param body body UpdateDNSRequest true "DNS configuration"
+// @Success 200 {object} map[string]interface{} "DNS updated"
+// @Failure 400 {object} map[string]interface{} "Bad request"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Failure 500 {object} map[string]interface{} "Internal server error"
+// @Router /api/dns/info [put].
+func HandleUpdateDNS(c echo.Context) error {
+	var req UpdateDNSRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+	}
+
+	if req.Servers == nil && req.DOHServer == nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Either servers or dohServer must be provided", nil)
+	}
+
+	if req.Servers != nil && *req.Servers != "" {
+		if err := validateDNSServers(*req.Servers); err != nil {
+			return ErrorResponse(c, http.StatusBadRequest, "Invalid DNS server(s)", err)
+		}
+	}
+
+	if req.DOHServer != nil && *req.DOHServer != "" {
+		if _, err := url.ParseRequestURI(*req.DOHServer); err != nil {
+			return ErrorResponse(c, http.StatusBadRequest, "Invalid DoH server URL", err)
+		}
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	var servers *string
+	var dohServer *string
+	if req.Servers != nil {
+		servers = req.Servers
+	}
+	if req.DOHServer != nil {
+		dohServer = req.DOHServer
+	}
+
+	config := routeros.DNSUpdateConfig{
+		Servers:   servers,
+		DOHServer: dohServer,
+	}
+	if err := client.UpdateDNSConfig(config); err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update DNS configuration", err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS configuration updated successfully", nil)
+}
+
+func validateDNSServers(servers string) error {
+	for _, server := range strings.Split(servers, ",") {
+		server = strings.TrimSpace(server)
+		if server == "" {
+			continue
+		}
+
+		if net.ParseIP(server) == nil {
+			return fmt.Errorf("invalid IP address: %s", server)
+		}
+	}
+	return nil
+}

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"nasnet-panel/pkg/routeros"
+	"nasnet-panel/pkg/routeros" //nolint:misspell // intentional package name
 
 	"github.com/labstack/echo/v4"
 )
@@ -95,7 +95,7 @@ func HandleUpdateDNS(c echo.Context) error {
 		dohServer = req.DOHServer
 	}
 
-	config := routeros.DNSUpdateConfig{
+	config := routeros.DNSUpdateConfig{ //nolint:misspell // intentional package name
 		Servers:   servers,
 		DOHServer: dohServer,
 	}

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -1,0 +1,26 @@
+package handler
+
+import "nasnet-panel/pkg/routeros"
+
+type DNSInfoResponse struct {
+	Servers        []string `json:"servers"`
+	DynamicServers []string `json:"dynamicServers"`
+	DOHServer      string   `json:"dohServer"`
+}
+
+type UpdateDNSRequest struct {
+	Servers   *string `json:"servers" description:"DNS server(s) - single IP or comma-separated list (e.g., '8.8.8.8' or '8.8.8.8,8.8.4.4'). Set to empty string to clear."`
+	DOHServer *string `json:"dohServer" description:"DoH server URL (e.g., 'https://dns.google/dns-query'). Set to empty string to clear."`
+}
+
+func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse {
+	if info == nil {
+		return nil
+	}
+
+	return &DNSInfoResponse{
+		Servers:        info.Servers,
+		DynamicServers: info.DynamicServers,
+		DOHServer:      info.DOHServer,
+	}
+}

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -1,19 +1,21 @@
 package handler
 
-import "nasnet-panel/pkg/routeros"
+import "nasnet-panel/pkg/routeros" //nolint:misspell // intentional package name
 
+// DNSInfoResponse represents the DNS information response.
 type DNSInfoResponse struct {
 	Servers        []string `json:"servers"`
 	DynamicServers []string `json:"dynamicServers"`
 	DOHServer      string   `json:"dohServer"`
 }
 
+// UpdateDNSRequest represents the DNS update request.
 type UpdateDNSRequest struct {
 	Servers   *string `json:"servers" description:"DNS server(s) - single IP or comma-separated list (e.g., '8.8.8.8' or '8.8.8.8,8.8.4.4'). Set to empty string to clear."`
 	DOHServer *string `json:"dohServer" description:"DoH server URL (e.g., 'https://dns.google/dns-query'). Set to empty string to clear."`
 }
 
-func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse {
+func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse { //nolint:misspell // intentional package name
 	if info == nil {
 		return nil
 	}

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -69,4 +69,11 @@ func RegisterRoutes(e *echo.Echo) {
 	{
 		logsGroup.GET("", handler.HandleGetLogs)
 	}
+
+	dnsGroup := e.Group("/api/dns")
+	dnsGroup.Use(middleware.RouterOSAuth)
+	{
+		dnsGroup.GET("/info", handler.HandleGetDNSInfo)
+		dnsGroup.PUT("/info", handler.HandleUpdateDNS)
+	}
 }

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -72,8 +72,6 @@ func RegisterRoutes(e *echo.Echo) {
 
 	dnsGroup := e.Group("/api/dns")
 	dnsGroup.Use(middleware.RouterOSAuth)
-	{
-		dnsGroup.GET("/info", handler.HandleGetDNSInfo)
-		dnsGroup.PUT("/info", handler.HandleUpdateDNS)
-	}
+	dnsGroup.GET("/info", handler.HandleGetDNSInfo)
+	dnsGroup.PUT("/info", handler.HandleUpdateDNS)
 }

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -1,0 +1,76 @@
+package routeros
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DNSInfo struct {
+	Servers        []string `json:"servers"`
+	DynamicServers []string `json:"dynamicServers"`
+	DOHServer      string   `json:"dohServer"`
+}
+
+type DNSUpdateConfig struct {
+	Servers   *string
+	DOHServer *string
+}
+
+// GetDNSInfo retrieves DNS configuration from RouterOS.
+func (c *Client) GetDNSInfo() (*DNSInfo, error) {
+	result, err := c.GetFirst("/ip/dns")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DNS info: %w", err)
+	}
+
+	servers := parseStringList(result["servers"])
+	dynamicServers := parseStringList(result["dynamic-servers"])
+	dohServer := result["use-doh-server"]
+
+	return &DNSInfo{
+		Servers:        servers,
+		DynamicServers: dynamicServers,
+		DOHServer:      dohServer,
+	}, nil
+}
+
+// UpdateDNSConfig updates DNS configuration on RouterOS.
+func (c *Client) UpdateDNSConfig(config DNSUpdateConfig) error {
+	args := []string{}
+
+	if config.Servers != nil {
+		args = append(args, "=servers="+*config.Servers)
+	}
+
+	if config.DOHServer != nil {
+		args = append(args, "=use-doh-server="+*config.DOHServer)
+		args = append(args, "=verify-doh-cert=no")
+		args = append(args, "=allow-remote-requests=yes")
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("no configuration parameters provided")
+	}
+
+	_, err := c.Set("/ip/dns", args...)
+	if err != nil {
+		return fmt.Errorf("failed to update DNS configuration on RouterOS: %w", err)
+	}
+
+	return nil
+}
+
+func parseStringList(value string) []string {
+	if value == "" {
+		return []string{}
+	}
+
+	var items []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -1,16 +1,18 @@
-package routeros
+package routeros //nolint:misspell // intentional package name
 
 import (
 	"fmt"
 	"strings"
 )
 
+// DNSInfo represents DNS configuration information.
 type DNSInfo struct {
 	Servers        []string `json:"servers"`
 	DynamicServers []string `json:"dynamicServers"`
 	DOHServer      string   `json:"dohServer"`
 }
 
+// DNSUpdateConfig represents DNS configuration to update.
 type DNSUpdateConfig struct {
 	Servers   *string
 	DOHServer *string
@@ -43,9 +45,7 @@ func (c *Client) UpdateDNSConfig(config DNSUpdateConfig) error {
 	}
 
 	if config.DOHServer != nil {
-		args = append(args, "=use-doh-server="+*config.DOHServer)
-		args = append(args, "=verify-doh-cert=no")
-		args = append(args, "=allow-remote-requests=yes")
+		args = append(args, "=use-doh-server="+*config.DOHServer, "=verify-doh-cert=no", "=allow-remote-requests=yes")
 	}
 
 	if len(args) == 0 {


### PR DESCRIPTION
   1. backend/pkg/routeros/dns.go - Added UpdateDNSConfig() function
   - Accepts DNSUpdateConfig struct with Servers and DOHServer fields
   - Validates that at least one parameter is provided
   - When DOHServer is supplied, automatically adds:
   - verify-doh-cert=false
   - allow-remote-requests=true
   - Executes /ip/dns set command via RouterOS
   2. backend/internal/handler/dns_dto.go - Added UpdateDNSRequest struct
   - Servers field: single value or comma-separated list
   - DOHServer field: DoH server URL
   3. backend/internal/handler/dns.go - Added HandleUpdateDNS() function
   - HTTP PUT handler with proper error handling
   - URL validation for dohServer parameter
   - Validates at least one parameter is provided
   - RouterOS authentication via middleware
   - Swagger documentation included
   4. backend/internal/routes/routes.go
   - Added PUT route to DNS group: PUT /api/dns/info
   - updates dns setting on router, sets dns servers or DoH on router
   - if empty params supplied, removes it, if not supplied ignores and does noting to it
