### PR TITLE
feat(fe): use path param for scan status endpoint

### DIFF
--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -27,7 +27,7 @@ async function startScanTask(subnet: string, signal?: AbortSignal): Promise<stri
 }
 
 async function getScanStatus(taskId: string, signal?: AbortSignal): Promise<ScanStatusData> {
-  return apiRequest<ScanStatusData>(`/api/scan/status?task_id=${encodeURIComponent(taskId)}`, {
+  return apiRequest<ScanStatusData>(`/api/scan/status/${encodeURIComponent(taskId)}`, {
     method: 'GET',
     signal,
   });


### PR DESCRIPTION
## Summary
- Update `getScanStatus` in `frontend/src/api/scanner.ts` to call `/api/scan/status/{taskId}` instead of `/api/scan/status?task_id=…`, matching the backend change in #73.