### PR TITLE
feat(fe): wire logs tab to live backend

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,14 @@ export {
   type RouterOSVerifyInfo,
   type RouterSystemInfo,
 } from './scanner';
+export {
+  fetchLogs,
+  type LogsCredentials,
+  type LogEntryResponse,
+  type GetLogsResponse,
+  type FetchLogsOptions,
+  type LogSeverity,
+} from './logs';
 export { ApiError } from './http';
 export { isAbortError } from './abort';
 export { BACKEND_URL } from './config';

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -1,0 +1,61 @@
+import { apiRequest } from './http';
+
+export interface LogsCredentials {
+  host: string;
+  username: string;
+  password: string;
+}
+
+export type LogSeverity = 'debug' | 'info' | 'warning' | 'error' | 'critical';
+
+export interface LogEntryResponse {
+  id: string;
+  time: string;
+  topic: string;
+  level: LogSeverity;
+  message: string;
+  prefix?: string;
+  account?: string;
+  count?: number;
+}
+
+export interface GetLogsResponse {
+  count: number;
+  entries: LogEntryResponse[];
+  availableTopics?: string[];
+  availableLevels?: string[];
+}
+
+export interface FetchLogsOptions {
+  limit?: number;
+  text?: string;
+  topic?: string;
+  severity?: LogSeverity;
+}
+
+function authHeaders({ host, username, password }: LogsCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function fetchLogs(
+  creds: LogsCredentials,
+  opts: FetchLogsOptions = {},
+  signal?: AbortSignal,
+): Promise<GetLogsResponse> {
+  const params = new URLSearchParams();
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  if (opts.text) params.set('text', opts.text);
+  if (opts.topic) params.set('topic', opts.topic);
+  if (opts.severity) params.set('severity', opts.severity);
+  const query = params.toString();
+  const path = query ? `/api/logs?${query}` : '/api/logs';
+  return apiRequest<GetLogsResponse>(path, {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}

--- a/frontend/src/routes/LogsPage.module.scss
+++ b/frontend/src/routes/LogsPage.module.scss
@@ -57,9 +57,22 @@
 }
 
 .emptyNote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
   padding: var(--space-xl);
   color: var(--color-text-muted);
   text-align: center;
+
+  p {
+    margin: 0;
+  }
+}
+
+.emptyIcon {
+  color: var(--color-text-muted);
+  opacity: 0.7;
 }
 
 .cardHeader {

--- a/frontend/src/routes/LogsPage.tsx
+++ b/frontend/src/routes/LogsPage.tsx
@@ -30,8 +30,6 @@ import { fetchLogs, type LogEntryResponse, type LogSeverity } from '../api';
 import { useSession } from '../state/SessionContext';
 import { useRouter } from '../state/RouterStoreContext';
 
-type LevelFilter = LogSeverity | 'all';
-
 const toneForLevel = (
   level: LogEntryResponse['level'],
 ): 'success' | 'warning' | 'danger' | 'info' =>
@@ -48,9 +46,9 @@ export function LogsPage() {
   const router = useRouter(id);
   const { getCredentials } = useSession();
   const [logs, setLogs] = useState<LogEntryResponse[]>([]);
-  const [topics, setTopics] = useState<string[]>([]);
-  const [level, setLevel] = useState<LevelFilter>('all');
-  const [topic, setTopic] = useState<string>('');
+  const [availableTopics, setAvailableTopics] = useState<string[]>([]);
+  const [selectedLevels, setSelectedLevels] = useState<LogSeverity[]>([]);
+  const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
   const [search, setSearch] = useState<string>('');
   const [debouncedSearch, setDebouncedSearch] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -76,12 +74,12 @@ export function LogsPage() {
         {
           limit: 200,
           text: debouncedSearch || undefined,
-          topic: topic || undefined,
-          severity: level === 'all' ? undefined : level,
+          topic: selectedTopics.length > 0 ? selectedTopics.join(',') : undefined,
+          severity: selectedLevels.length === 1 ? selectedLevels[0] : undefined,
         },
       );
       setLogs(response.entries ?? []);
-      setTopics(response.availableTopics ?? []);
+      setAvailableTopics(response.availableTopics ?? []);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load logs.';
       setError(message);
@@ -89,7 +87,7 @@ export function LogsPage() {
     } finally {
       setLoading(false);
     }
-  }, [id, router?.host, getCredentials, level, topic, debouncedSearch]);
+  }, [id, router?.host, getCredentials, selectedLevels, selectedTopics, debouncedSearch]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -102,6 +100,11 @@ export function LogsPage() {
     void reload();
   }, [reload]);
 
+  const visibleLogs = useMemo(() => {
+    if (selectedLevels.length <= 1) return logs;
+    return logs.filter((l) => selectedLevels.includes(l.level));
+  }, [logs, selectedLevels]);
+
   const counts = useMemo(() => {
     const c: Record<LogSeverity, number> = {
       info: 0,
@@ -110,22 +113,22 @@ export function LogsPage() {
       debug: 0,
       critical: 0,
     };
-    for (const l of logs) c[l.level] += 1;
+    for (const l of visibleLogs) c[l.level] += 1;
     return c;
-  }, [logs]);
+  }, [visibleLogs]);
 
   const isSearching = loading || search !== debouncedSearch;
 
-  const totalPages = Math.max(1, Math.ceil(logs.length / pageSize));
+  const totalPages = Math.max(1, Math.ceil(visibleLogs.length / pageSize));
   const currentPage = Math.min(page, totalPages);
   const pagedLogs = useMemo(
-    () => logs.slice((currentPage - 1) * pageSize, currentPage * pageSize),
-    [logs, currentPage],
+    () => visibleLogs.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+    [visibleLogs, currentPage],
   );
 
   useEffect(() => {
     setPage(1);
-  }, [level, topic, debouncedSearch]);
+  }, [selectedLevels, selectedTopics, debouncedSearch]);
 
   return (
     <Stack>
@@ -153,10 +156,13 @@ export function LogsPage() {
               <span>Level</span>
               <Select
                 aria-label="Level"
-                value={level}
-                onChange={(v) => setLevel(v as LevelFilter)}
+                multiple
+                searchable
+                searchPlaceholder="Search level…"
+                placeholder="All levels"
+                value={selectedLevels}
+                onChange={(v) => setSelectedLevels(v as LogSeverity[])}
                 options={[
-                  { value: 'all', label: 'all' },
                   { value: 'info', label: 'info' },
                   { value: 'warning', label: 'warning' },
                   { value: 'error', label: 'error' },
@@ -169,12 +175,13 @@ export function LogsPage() {
               <span>Topic</span>
               <Select
                 aria-label="Topic"
-                value={topic}
-                onChange={(v) => setTopic(v)}
-                options={[
-                  { value: '', label: 'all topics' },
-                  ...topics.map((t) => ({ value: t, label: t })),
-                ]}
+                multiple
+                searchable
+                searchPlaceholder="Search topic…"
+                placeholder="All topics"
+                value={selectedTopics}
+                onChange={(v) => setSelectedTopics(v)}
+                options={availableTopics.map((t) => ({ value: t, label: t }))}
               />
             </Label>
             <Label>
@@ -215,7 +222,7 @@ export function LogsPage() {
             <SearchX size={28} aria-hidden className={styles.emptyIcon} />
             <p>{error}</p>
           </div>
-        ) : logs.length === 0 ? (
+        ) : visibleLogs.length === 0 ? (
           <div className={styles.emptyNote}>
             <SearchX size={28} aria-hidden className={styles.emptyIcon} />
             <p>No logs match the current filters.</p>
@@ -249,11 +256,11 @@ export function LogsPage() {
                 ))}
               </motion.div>
             </AnimatePresence>
-            {logs.length > pageSize ? (
+            {visibleLogs.length > pageSize ? (
               <div className={styles.pagination}>
                 <span className={styles.paginationInfo}>
                   Showing {(currentPage - 1) * pageSize + 1}–
-                  {Math.min(currentPage * pageSize, logs.length)} of {logs.length}
+                  {Math.min(currentPage * pageSize, visibleLogs.length)} of {visibleLogs.length}
                 </span>
                 <div className={styles.paginationControls}>
                   <Button

--- a/frontend/src/routes/LogsPage.tsx
+++ b/frontend/src/routes/LogsPage.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronLeft, ChevronRight, Filter, RefreshCw, ScrollText } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  RefreshCw,
+  ScrollText,
+  SearchX,
+} from 'lucide-react';
 import styles from './LogsPage.module.scss';
 import {
   Badge,
@@ -16,15 +23,19 @@ import {
   Inline,
   Label,
   Select,
+  Skeleton,
   Stack,
-  Switch,
 } from '@nasnet/ui';
-import { api, type LogEntry, type LogLevel } from '../api';
+import { fetchLogs, type LogEntryResponse, type LogSeverity } from '../api';
+import { useSession } from '../state/SessionContext';
+import { useRouter } from '../state/RouterStoreContext';
 
-type LevelFilter = LogLevel | 'all';
+type LevelFilter = LogSeverity | 'all';
 
-const toneForLevel = (level: LogEntry['level']): 'success' | 'warning' | 'danger' | 'info' =>
-  level === 'error'
+const toneForLevel = (
+  level: LogEntryResponse['level'],
+): 'success' | 'warning' | 'danger' | 'info' =>
+  level === 'critical' || level === 'error'
     ? 'danger'
     : level === 'warning'
       ? 'warning'
@@ -34,51 +45,76 @@ const toneForLevel = (level: LogEntry['level']): 'success' | 'warning' | 'danger
 
 export function LogsPage() {
   const { id } = useParams<{ id: string }>();
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const router = useRouter(id);
+  const { getCredentials } = useSession();
+  const [logs, setLogs] = useState<LogEntryResponse[]>([]);
   const [topics, setTopics] = useState<string[]>([]);
   const [level, setLevel] = useState<LevelFilter>('all');
   const [topic, setTopic] = useState<string>('');
   const [search, setSearch] = useState<string>('');
-  const [tail, setTail] = useState<boolean>(false);
+  const [debouncedSearch, setDebouncedSearch] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState<number>(1);
   const pageSize = 20;
-  const [selected, setSelected] = useState<LogEntry | null>(null);
+  const [selected, setSelected] = useState<LogEntryResponse | null>(null);
 
   const reload = useCallback(async () => {
     if (!id) return;
+    const creds = getCredentials(id);
+    const host = router?.host;
+    if (!creds || !host) {
+      setLoading(false);
+      setError('Missing router credentials for this session.');
+      return;
+    }
     setLoading(true);
-    const [l, t] = await Promise.all([
-      api.logs.list(id, {
-        level,
-        topic: topic || undefined,
-        search: search || undefined,
-        limit: 200,
-      }),
-      api.logs.topics(id),
-    ]);
-    setLogs(l);
-    setTopics(t);
-    setLoading(false);
-  }, [id, level, topic, search]);
+    setError(null);
+    try {
+      const response = await fetchLogs(
+        { host, ...creds },
+        {
+          limit: 200,
+          text: debouncedSearch || undefined,
+          topic: topic || undefined,
+          severity: level === 'all' ? undefined : level,
+        },
+      );
+      setLogs(response.entries ?? []);
+      setTopics(response.availableTopics ?? []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load logs.';
+      setError(message);
+      console.error('[logs] fetch failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [id, router?.host, getCredentials, level, topic, debouncedSearch]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 400);
+    return () => window.clearTimeout(timer);
+  }, [search]);
 
   useEffect(() => {
     void reload();
   }, [reload]);
 
-  useEffect(() => {
-    if (!tail || !id) return;
-    const timer = window.setInterval(() => {
-      void reload();
-    }, 2000);
-    return () => window.clearInterval(timer);
-  }, [tail, id, reload]);
-
   const counts = useMemo(() => {
-    const c: Record<LogLevel, number> = { info: 0, warning: 0, error: 0, debug: 0 };
+    const c: Record<LogSeverity, number> = {
+      info: 0,
+      warning: 0,
+      error: 0,
+      debug: 0,
+      critical: 0,
+    };
     for (const l of logs) c[l.level] += 1;
     return c;
   }, [logs]);
+
+  const isSearching = loading || search !== debouncedSearch;
 
   const totalPages = Math.max(1, Math.ceil(logs.length / pageSize));
   const currentPage = Math.min(page, totalPages);
@@ -89,7 +125,7 @@ export function LogsPage() {
 
   useEffect(() => {
     setPage(1);
-  }, [level, topic, search]);
+  }, [level, topic, debouncedSearch]);
 
   return (
     <Stack>
@@ -106,7 +142,6 @@ export function LogsPage() {
             </CardDescription>
           </div>
           <div className={styles.headerActions}>
-            <Switch label="Auto-tail" checked={tail} onChange={(e) => setTail(e.target.checked)} />
             <Button size="sm" variant="secondary" onClick={reload} disabled={loading}>
               <RefreshCw size={14} aria-hidden /> Refresh
             </Button>
@@ -125,6 +160,7 @@ export function LogsPage() {
                   { value: 'info', label: 'info' },
                   { value: 'warning', label: 'warning' },
                   { value: 'error', label: 'error' },
+                  { value: 'critical', label: 'critical' },
                   { value: 'debug', label: 'debug' },
                 ]}
               />
@@ -156,14 +192,34 @@ export function LogsPage() {
             <Badge tone="success">info · {counts.info}</Badge>
             <Badge tone="warning">warning · {counts.warning}</Badge>
             <Badge tone="danger">error · {counts.error}</Badge>
+            <Badge tone="danger">critical · {counts.critical}</Badge>
             <Badge tone="info">debug · {counts.debug}</Badge>
           </Inline>
         </Stack>
       </Card>
 
       <Card data-testid="log-stream">
-        {logs.length === 0 && !loading ? (
-          <p className={styles.emptyNote}>No logs match the current filters.</p>
+        {isSearching ? (
+          <div data-testid="log-skeleton">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className={styles.logRow}>
+                <Skeleton width={160} height={14} />
+                <Skeleton width={70} height={18} radius={9} />
+                <Skeleton width={110} height={12} />
+                <Skeleton height={14} />
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className={styles.emptyNote}>
+            <SearchX size={28} aria-hidden className={styles.emptyIcon} />
+            <p>{error}</p>
+          </div>
+        ) : logs.length === 0 ? (
+          <div className={styles.emptyNote}>
+            <SearchX size={28} aria-hidden className={styles.emptyIcon} />
+            <p>No logs match the current filters.</p>
+          </div>
         ) : (
           <div>
             <AnimatePresence mode="wait" initial={false}>
@@ -183,7 +239,7 @@ export function LogsPage() {
                     onClick={() => setSelected(log)}
                     aria-label={`Open details for log ${log.id}`}
                   >
-                    <span className={styles.timestamp}>{new Date(log.ts).toLocaleString()}</span>
+                    <span className={styles.timestamp}>{log.time}</span>
                     <Badge className={styles.logLevel} tone={toneForLevel(log.level)}>
                       {log.level}
                     </Badge>
@@ -243,8 +299,7 @@ export function LogsPage() {
           <div className={styles.detailGrid}>
             <div className={styles.detailLabel}>Timestamp</div>
             <div className={styles.detailValue}>
-              <div>{new Date(selected.ts).toLocaleString()}</div>
-              <div className={styles.detailMuted}>{selected.ts}</div>
+              <div>{selected.time}</div>
             </div>
 
             <div className={styles.detailLabel}>Level</div>
@@ -267,10 +322,30 @@ export function LogsPage() {
               <code className={styles.detailMono}>{selected.id}</code>
             </div>
 
-            <div className={styles.detailLabel}>Router ID</div>
-            <div className={styles.detailValue}>
-              <code className={styles.detailMono}>{selected.routerId}</code>
-            </div>
+            {selected.prefix ? (
+              <>
+                <div className={styles.detailLabel}>Prefix</div>
+                <div className={styles.detailValue}>
+                  <code className={styles.detailMono}>{selected.prefix}</code>
+                </div>
+              </>
+            ) : null}
+
+            {selected.account ? (
+              <>
+                <div className={styles.detailLabel}>Account</div>
+                <div className={styles.detailValue}>
+                  <code className={styles.detailMono}>{selected.account}</code>
+                </div>
+              </>
+            ) : null}
+
+            {selected.count && selected.count > 1 ? (
+              <>
+                <div className={styles.detailLabel}>Count</div>
+                <div className={styles.detailValue}>{selected.count}</div>
+              </>
+            ) : null}
           </div>
         ) : null}
       </Dialog>

--- a/frontend/src/routes/LogsPage.tsx
+++ b/frontend/src/routes/LogsPage.tsx
@@ -1,14 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-import {
-  ChevronLeft,
-  ChevronRight,
-  Filter,
-  RefreshCw,
-  ScrollText,
-  SearchX,
-} from 'lucide-react';
+import { ChevronLeft, ChevronRight, Filter, RefreshCw, ScrollText, SearchX } from 'lucide-react';
 import styles from './LogsPage.module.scss';
 import {
   Badge,
@@ -83,7 +76,6 @@ export function LogsPage() {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load logs.';
       setError(message);
-      console.error('[logs] fetch failed', err);
     } finally {
       setLoading(false);
     }
@@ -208,8 +200,8 @@ export function LogsPage() {
       <Card data-testid="log-stream">
         {isSearching ? (
           <div data-testid="log-skeleton">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className={styles.logRow}>
+            {['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((k) => (
+              <div key={`skeleton-${k}`} className={styles.logRow}>
                 <Skeleton width={160} height={14} />
                 <Skeleton width={70} height={18} radius={9} />
                 <Skeleton width={110} height={12} />

--- a/frontend/src/ui/primitives/Select.module.scss
+++ b/frontend/src/ui/primitives/Select.module.scss
@@ -70,15 +70,52 @@
   left: 0;
   right: 0;
   top: calc(100% + 4px);
+  display: flex;
+  flex-direction: column;
   margin: 0;
   padding: var(--space-xs);
-  list-style: none;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md, 0 8px 24px rgba(0, 0, 0, 0.12));
+}
+
+.search {
+  appearance: none;
+  width: 100%;
+  margin-bottom: var(--space-xs);
+  padding: 6px 10px;
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--font-sm);
+  transition: border-color var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-border-strong);
+  }
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   max-height: 240px;
   overflow-y: auto;
+}
+
+.emptyOption {
+  padding: 8px 10px;
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+  text-align: center;
 }
 
 .option {
@@ -110,5 +147,5 @@
 
 .check {
   flex: 0 0 auto;
-  color: var(--color-primary);
+  color: var(--color-success);
 }

--- a/frontend/src/ui/primitives/Select.tsx
+++ b/frontend/src/ui/primitives/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import styles from './Select.module.scss';
 
 export interface SelectOption {
@@ -7,46 +7,107 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-export interface SelectProps {
+interface BaseSelectProps {
   options: SelectOption[];
-  value: string;
-  onChange: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
   id?: string;
   name?: string;
   className?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
 }
 
+export interface SingleSelectProps extends BaseSelectProps {
+  multiple?: false;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export interface MultipleSelectProps extends BaseSelectProps {
+  multiple: true;
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+export type SelectProps = SingleSelectProps | MultipleSelectProps;
+
 const cx = (...parts: Array<string | undefined | false>) => parts.filter(Boolean).join(' ');
 
-export const Select: React.FC<SelectProps> = ({
-  options,
-  value,
-  onChange,
-  placeholder = 'Select…',
-  disabled,
-  id,
-  name,
-  className,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
-}) => {
+export const Select: React.FC<SelectProps> = (props) => {
+  const {
+    options,
+    placeholder = 'Select…',
+    disabled,
+    id,
+    name,
+    className,
+    searchable = false,
+    searchPlaceholder = 'Search…',
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    multiple = false,
+  } = props;
+
+  const selectedValues: string[] = props.multiple
+    ? props.value
+    : props.value
+      ? [props.value]
+      : [];
+
+  const emitChange = (nextValues: string[]) => {
+    if (props.multiple) {
+      props.onChange(nextValues);
+    } else {
+      props.onChange(nextValues[0] ?? '');
+    }
+  };
+
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
   const [activeIdx, setActiveIdx] = useState<number>(() =>
     Math.max(
       0,
-      options.findIndex((o) => o.value === value),
+      options.findIndex((o) => selectedValues.includes(o.value)),
     ),
   );
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
   const listboxId = useId();
   const triggerId = id ?? `${listboxId}-trigger`;
 
-  const selected = options.find((o) => o.value === value);
+  const selectedOptions = options.filter((o) => selectedValues.includes(o.value));
+  const triggerLabel =
+    selectedOptions.length === 0
+      ? placeholder
+      : multiple && selectedOptions.length > 2
+        ? `${selectedOptions.length} selected`
+        : selectedOptions.map((o) => o.label).join(', ');
+
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !query) return options;
+    const q = query.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, searchable, query]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      return;
+    }
+    if (searchable) {
+      searchRef.current?.focus();
+    }
+  }, [open, searchable]);
+
+  useEffect(() => {
+    if (activeIdx >= filteredOptions.length) {
+      setActiveIdx(filteredOptions.length > 0 ? 0 : -1);
+    }
+  }, [filteredOptions.length, activeIdx]);
 
   const close = useCallback(() => {
     setOpen(false);
@@ -63,23 +124,30 @@ export const Select: React.FC<SelectProps> = ({
   }, [open]);
 
   const selectAt = (idx: number) => {
-    const opt = options[idx];
+    const opt = filteredOptions[idx];
     if (!opt || opt.disabled) return;
-    onChange(opt.value);
-    close();
+    if (multiple) {
+      const next = selectedValues.includes(opt.value)
+        ? selectedValues.filter((v) => v !== opt.value)
+        : [...selectedValues, opt.value];
+      emitChange(next);
+    } else {
+      emitChange([opt.value]);
+      close();
+    }
   };
 
   const move = (delta: number) => {
-    if (options.length === 0) return;
-    let next = activeIdx;
-    for (let i = 0; i < options.length; i++) {
-      next = (next + delta + options.length) % options.length;
-      if (!options[next].disabled) break;
+    if (filteredOptions.length === 0) return;
+    let next = activeIdx < 0 ? 0 : activeIdx;
+    for (let i = 0; i < filteredOptions.length; i++) {
+      next = (next + delta + filteredOptions.length) % filteredOptions.length;
+      if (!filteredOptions[next].disabled) break;
     }
     setActiveIdx(next);
   };
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
+  const handleNavKey = (e: React.KeyboardEvent, allowSpaceToSelect: boolean) => {
     if (disabled) return;
     switch (e.key) {
       case 'ArrowDown':
@@ -95,14 +163,14 @@ export const Select: React.FC<SelectProps> = ({
       case 'Home':
         if (open) {
           e.preventDefault();
-          setActiveIdx(options.findIndex((o) => !o.disabled));
+          setActiveIdx(filteredOptions.findIndex((o) => !o.disabled));
         }
         break;
       case 'End':
         if (open) {
           e.preventDefault();
-          for (let i = options.length - 1; i >= 0; i--) {
-            if (!options[i].disabled) {
+          for (let i = filteredOptions.length - 1; i >= 0; i--) {
+            if (!filteredOptions[i].disabled) {
               setActiveIdx(i);
               break;
             }
@@ -110,7 +178,12 @@ export const Select: React.FC<SelectProps> = ({
         }
         break;
       case 'Enter':
+        e.preventDefault();
+        if (!open) setOpen(true);
+        else selectAt(activeIdx);
+        break;
       case ' ':
+        if (!allowSpaceToSelect) return;
         e.preventDefault();
         if (!open) setOpen(true);
         else selectAt(activeIdx);
@@ -127,6 +200,9 @@ export const Select: React.FC<SelectProps> = ({
     }
   };
 
+  const onTriggerKeyDown = (e: React.KeyboardEvent) => handleNavKey(e, true);
+  const onSearchKeyDown = (e: React.KeyboardEvent) => handleNavKey(e, false);
+
   return (
     <div ref={wrapperRef} className={cx(styles.wrap, className)}>
       <button
@@ -142,10 +218,10 @@ export const Select: React.FC<SelectProps> = ({
         disabled={disabled}
         className={cx(styles.trigger, open && styles.triggerOpen)}
         onClick={() => !disabled && setOpen((o) => !o)}
-        onKeyDown={onKeyDown}
+        onKeyDown={onTriggerKeyDown}
       >
-        <span className={cx(styles.value, !selected && styles.placeholder)}>
-          {selected ? selected.label : placeholder}
+        <span className={cx(styles.value, selectedOptions.length === 0 && styles.placeholder)}>
+          {triggerLabel}
         </span>
         <svg className={styles.chevron} width={14} height={14} viewBox="0 0 20 20" aria-hidden>
           <path
@@ -158,59 +234,83 @@ export const Select: React.FC<SelectProps> = ({
           />
         </svg>
       </button>
-      {name ? <input type="hidden" name={name} value={value} /> : null}
+      {name ? <input type="hidden" name={name} value={selectedValues.join(',')} /> : null}
       {open ? (
-        <ul
-          id={listboxId}
-          role="listbox"
-          aria-labelledby={triggerId}
-          className={styles.menu}
-          tabIndex={-1}
-        >
-          {options.map((opt, idx) => {
-            const selectedOpt = opt.value === value;
-            const active = idx === activeIdx;
-            return (
-              <li
-                key={opt.value}
-                role="option"
-                aria-selected={selectedOpt}
-                aria-disabled={opt.disabled || undefined}
-                className={cx(
-                  styles.option,
-                  active && styles.optionActive,
-                  selectedOpt && styles.optionSelected,
-                  opt.disabled && styles.optionDisabled,
-                )}
-                onMouseEnter={() => !opt.disabled && setActiveIdx(idx)}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  selectAt(idx);
-                }}
-              >
-                <span>{opt.label}</span>
-                {selectedOpt ? (
-                  <svg
-                    className={styles.check}
-                    width={14}
-                    height={14}
-                    viewBox="0 0 20 20"
-                    aria-hidden
-                  >
-                    <path
-                      d="M5 10.5l3.5 3.5L15 6.5"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2.2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                ) : null}
+        <div className={styles.menu}>
+          {searchable ? (
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActiveIdx(0);
+              }}
+              onKeyDown={onSearchKeyDown}
+              placeholder={searchPlaceholder}
+              aria-label="Search options"
+              aria-controls={listboxId}
+              className={styles.search}
+            />
+          ) : null}
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={triggerId}
+            className={styles.list}
+            tabIndex={-1}
+          >
+            {filteredOptions.length === 0 ? (
+              <li className={styles.emptyOption} role="presentation">
+                No matches
               </li>
-            );
-          })}
-        </ul>
+            ) : (
+              filteredOptions.map((opt, idx) => {
+                const selectedOpt = selectedValues.includes(opt.value);
+                const active = idx === activeIdx;
+                return (
+                  <li
+                    key={opt.value}
+                    role="option"
+                    aria-selected={selectedOpt}
+                    aria-disabled={opt.disabled || undefined}
+                    className={cx(
+                      styles.option,
+                      active && styles.optionActive,
+                      selectedOpt && styles.optionSelected,
+                      opt.disabled && styles.optionDisabled,
+                    )}
+                    onMouseEnter={() => !opt.disabled && setActiveIdx(idx)}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      selectAt(idx);
+                    }}
+                  >
+                    <span>{opt.label}</span>
+                    {selectedOpt ? (
+                      <svg
+                        className={styles.check}
+                        width={14}
+                        height={14}
+                        viewBox="0 0 20 20"
+                        aria-hidden
+                      >
+                        <path
+                          d="M5 10.5l3.5 3.5L15 6.5"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    ) : null}
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/src/ui/primitives/Select.tsx
+++ b/frontend/src/ui/primitives/Select.tsx
@@ -39,6 +39,8 @@ const cx = (...parts: Array<string | undefined | false>) => parts.filter(Boolean
 export const Select: React.FC<SelectProps> = (props) => {
   const {
     options,
+    value,
+    onChange,
     placeholder = 'Select…',
     disabled,
     id,
@@ -51,17 +53,13 @@ export const Select: React.FC<SelectProps> = (props) => {
     multiple = false,
   } = props;
 
-  const selectedValues: string[] = props.multiple
-    ? props.value
-    : props.value
-      ? [props.value]
-      : [];
+  const selectedValues: string[] = Array.isArray(value) ? value : value ? [value] : [];
 
   const emitChange = (nextValues: string[]) => {
-    if (props.multiple) {
-      props.onChange(nextValues);
+    if (multiple) {
+      (onChange as (v: string[]) => void)(nextValues);
     } else {
-      props.onChange(nextValues[0] ?? '');
+      (onChange as (v: string) => void)(nextValues[0] ?? '');
     }
   };
 

--- a/frontend/tests/e2e/16-logs-page.spec.ts
+++ b/frontend/tests/e2e/16-logs-page.spec.ts
@@ -5,9 +5,11 @@ test.describe('Logs page', () => {
     page,
     resetMocks,
     seedRouter,
+    mockLogsBackend,
   }) => {
     await resetMocks();
-    await seedRouter({ id: 'rtr_logs', name: 'Logs Router' });
+    await seedRouter({ id: 'rtr_logs', name: 'Logs Router', host: '10.10.10.1' });
+    await mockLogsBackend({ id: 'rtr_logs' });
     await page.goto('/router/rtr_logs/logs');
 
     await expect(page.getByRole('heading', { name: /^logs$/i })).toBeVisible();
@@ -15,20 +17,15 @@ test.describe('Logs page', () => {
     await expect(stream).toBeVisible();
     await expect(stream.getByTestId('log-row').first()).toBeVisible();
 
-    // Level filter keeps the stream populated (or explicitly empty).
-    await page.getByLabel(/level/i).click();
+    // Level multi-select opens and exposes severity options.
+    await page.getByRole('combobox', { name: /level/i }).click();
     await page.getByRole('option', { name: 'error' }).click();
+    await page.keyboard.press('Escape');
     await expect(stream).toBeVisible();
 
-    // Text search reveals the pppoe error message.
-    await page.getByLabel(/level/i).click();
-    await page.getByRole('option', { name: 'all' }).click();
-    await page.getByLabel(/search/i).fill('pppoe');
+    // Debounced text search reveals the pppoe error message.
+    await page.getByLabel('Search', { exact: true }).fill('pppoe');
     await expect(stream).toContainText(/pppoe/i);
-
-    // Auto-tail toggles without error.
-    await page.getByRole('switch', { name: /auto-tail/i }).check();
-    await expect(page.getByRole('switch', { name: /auto-tail/i })).toBeChecked();
   });
 
   test('dashboard tab nav exposes Logs link', async ({ page, resetMocks, seedRouter }) => {

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -20,11 +20,16 @@ export interface OverviewBackendRouter {
   version?: string;
 }
 
+export interface LogsBackendOptions {
+  id?: string;
+}
+
 export interface TestFixtures {
   resetMocks: () => Promise<void>;
   seedRouter: (input: SeedInput) => Promise<void>;
   mockBackendScan: (devices?: ScanMockDevice[]) => Promise<void>;
   mockOverviewBackend: (router?: OverviewBackendRouter) => Promise<void>;
+  mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
 }
 
 export const test = base.extend<TestFixtures>({
@@ -230,6 +235,66 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope([]),
+        });
+      });
+    });
+  },
+  mockLogsBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      const entries = [
+        {
+          id: '0',
+          time: 'apr/23 10:00:00',
+          topic: 'system,info',
+          level: 'info',
+          message: 'system started',
+        },
+        {
+          id: '1',
+          time: 'apr/23 10:01:00',
+          topic: 'pppoe,error',
+          level: 'error',
+          message: 'pppoe connection failed',
+        },
+        {
+          id: '2',
+          time: 'apr/23 10:02:00',
+          topic: 'dhcp,warning',
+          level: 'warning',
+          message: 'lease expired for 192.168.1.50',
+        },
+      ];
+
+      await context.route('**/api/logs**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({
+            count: entries.length,
+            entries,
+            availableTopics: ['system', 'info', 'pppoe', 'error', 'dhcp', 'warning'],
+            availableLevels: ['debug', 'info', 'warning', 'error', 'critical'],
+          }),
         });
       });
     });


### PR DESCRIPTION
## Summary
- Adds `fetchLogs` client hitting the backend logs endpoint with session credentials, replacing the mock-driven logs handler on the Logs tab.
- Debounced (400ms) search input, skeleton rows while loading, and an empty-state icon via the existing lucide-react icon pack.
- Extends the `Select` primitive with `searchable` and `multiple` modes (discriminated-union props, all existing single-select call sites untouched). Logs tab uses both on the Level and Topic filters; Level is filtered client-side when >1 is selected since the backend accepts one severity.
- Ticks are now green (`--color-success`); search box focus border uses `--color-border-strong` to match surrounding inputs.
- Drops the auto-tail toggle.