### PR TITLE
feat(fe): wire firewall tab to live backend

### DIFF
--- a/backend/internal/handler/firewall.go
+++ b/backend/internal/handler/firewall.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"nasnet-panel/pkg/routeros" //nolint:misspell // intentional package name
+
 	"github.com/labstack/echo/v4"
 )
 
@@ -21,11 +23,30 @@ import (
 // @Failure 500 {object} map[string]interface{} "Internal server error"
 // @Router /api/firewall/rules [get]
 func HandleListFirewallRules(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
 	chain := c.QueryParam("chain")
 
-	filter := ""
+	var rules []routeros.FirewallRule //nolint:misspell // intentional package name
 	if chain != "" {
-		filter = " (chain: " + chain + ")"
+		rules, err = client.GetFirewallRulesByChain(chain)
+	} else {
+		rules, err = client.ListFirewallRules()
 	}
-	return SuccessResponse(c, http.StatusOK, "Firewall rules"+filter, []FirewallRuleResponse{})
+	if err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list firewall rules", err)
+	}
+
+	response := ToFirewallRulesResponse(rules)
+	if response == nil {
+		response = []FirewallRuleResponse{}
+	}
+	return SuccessResponse(c, http.StatusOK, "Firewall rules retrieved", response)
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { LogsPage } from './routes/LogsPage';
 import { UpdatesPage } from './routes/UpdatesPage';
 import { DHCPPage } from './routes/DHCPPage';
 import { DNSPage } from './routes/DNSPage';
+import { FirewallPage } from './routes/FirewallPage';
 
 function AddRouterEntry() {
   const [params] = useSearchParams();
@@ -57,6 +58,7 @@ export function App() {
                   <Route path="logs" element={<LogsPage />} />
                   <Route path="dhcp" element={<DHCPPage />} />
                   <Route path="dns" element={<DNSPage />} />
+                  <Route path="firewall" element={<FirewallPage />} />
                 </Route>
                 <Route
                   path="/updates"

--- a/frontend/src/api/firewall.ts
+++ b/frontend/src/api/firewall.ts
@@ -1,0 +1,47 @@
+import { apiRequest } from './http';
+
+export interface FirewallCredentials {
+  host: string;
+  username: string;
+  password: string;
+}
+
+export interface FirewallRule {
+  id: string;
+  chain: string;
+  action: string;
+  protocol?: string;
+  srcAddress?: string;
+  dstAddress?: string;
+  srcPort?: string;
+  dstPort?: string;
+  inInterface?: string;
+  outInterface?: string;
+  disabled: boolean;
+  log: boolean;
+  comment?: string;
+  bytes?: string;
+  packets?: string;
+}
+
+function authHeaders({ host, username, password }: FirewallCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function fetchFirewallRules(
+  creds: FirewallCredentials,
+  chain?: string,
+  signal?: AbortSignal,
+): Promise<FirewallRule[]> {
+  const query = chain ? `?${new URLSearchParams({ chain }).toString()}` : '';
+  const rules = await apiRequest<FirewallRule[] | null>(`/api/firewall/rules${query}`, {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+  return rules ?? [];
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -71,11 +71,7 @@ export {
   type DhcpServer,
   type DhcpLeaseAction,
 } from './dhcp';
-export {
-  fetchFirewallRules,
-  type FirewallCredentials,
-  type FirewallRule,
-} from './firewall';
+export { fetchFirewallRules, type FirewallCredentials, type FirewallRule } from './firewall';
 export { ApiError } from './http';
 export { isAbortError } from './abort';
 export { BACKEND_URL } from './config';

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -71,6 +71,11 @@ export {
   type DhcpServer,
   type DhcpLeaseAction,
 } from './dhcp';
+export {
+  fetchFirewallRules,
+  type FirewallCredentials,
+  type FirewallRule,
+} from './firewall';
 export { ApiError } from './http';
 export { isAbortError } from './abort';
 export { BACKEND_URL } from './config';

--- a/frontend/src/layout/RouterTabBar.tsx
+++ b/frontend/src/layout/RouterTabBar.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import {
+  Flame,
   Globe,
   LayoutGrid,
   Network,
@@ -20,6 +21,7 @@ export const ROUTER_TABS: Array<TabItem & { path: string }> = [
   { id: 'vpn', label: 'VPN', path: 'vpn', icon: <Shield size={16} /> },
   { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },
   { id: 'dns', label: 'DNS', path: 'dns', icon: <Globe size={16} /> },
+  { id: 'firewall', label: 'Firewall', path: 'firewall', icon: <Flame size={16} /> },
   { id: 'logs', label: 'Logs', path: 'logs', icon: <ScrollText size={16} /> },
   { id: 'users', label: 'Users', path: 'users', icon: <UsersIcon size={16} /> },
   { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },

--- a/frontend/src/routes/FirewallPage.module.scss
+++ b/frontend/src/routes/FirewallPage.module.scss
@@ -1,0 +1,287 @@
+.flowBoard {
+  width: 85vw;
+  margin-left: calc(-42.5vw + 50%);
+  margin-right: calc(-42.5vw + 50%);
+  margin-top: calc(var(--space-xl) * -1);
+  margin-bottom: 30px;
+  padding: var(--space-md) var(--space-lg) var(--space-sm);
+}
+
+@media (max-width: 768px) {
+  .flowBoard {
+    display: none;
+  }
+}
+
+.board {
+  position: relative;
+  width: 100%;
+  max-width: 1800px;
+  aspect-ratio: 1800 / 280;
+  margin: 0 auto;
+  overflow: visible;
+}
+
+.boardSvg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.boardLine {
+  stroke: var(--color-border);
+  stroke-width: 2;
+  fill: none;
+}
+
+.arrowHead {
+  fill: var(--color-border);
+}
+
+.flowDot {
+  fill: var(--color-success, #16a34a);
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--color-success, #16a34a) 70%, transparent));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flowDot {
+    display: none;
+  }
+}
+
+.boardNodeCircle {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.boardNodeEndpoint {
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+.boardNodeChain {
+  color: var(--color-text-muted);
+  border-color: var(--color-success, #16a34a);
+}
+
+.boardNodeInteractive {
+  cursor: pointer;
+
+  * {
+    cursor: pointer;
+  }
+
+  &:hover,
+  &:focus-within,
+  &:focus-visible {
+    outline: none;
+    transform: scale(1.08);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+    border-color: var(--color-success, #16a34a);
+  }
+}
+
+.boardNodeIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.boardNodeLabel,
+.boardNodeLabelAbove {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold, 600);
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.boardNodeLabel {
+  top: calc(100% + 6px);
+}
+
+.boardNodeLabelAbove {
+  bottom: calc(100% + 6px);
+}
+
+.boardNodeChain .boardNodeLabel,
+.boardNodeChain .boardNodeLabelAbove {
+  color: var(--color-text);
+}
+
+.boardNodeInteractive:hover .boardNodeLabel,
+.boardNodeInteractive:focus-within .boardNodeLabel,
+.boardNodeInteractive:hover .boardNodeLabelAbove,
+.boardNodeInteractive:focus-within .boardNodeLabelAbove {
+  color: var(--color-success, #16a34a);
+}
+
+.boardPopoverBelow,
+.boardPopoverAbove {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 260px;
+  max-width: 320px;
+  padding: var(--space-sm);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity 120ms ease;
+}
+
+.boardPopoverBelow {
+  top: calc(100% + 28px);
+}
+
+.boardPopoverAbove {
+  bottom: calc(100% + 8px);
+}
+
+.boardNodeInteractive:hover .boardPopoverBelow,
+.boardNodeInteractive:focus-within .boardPopoverBelow,
+.boardNodeInteractive:hover .boardPopoverAbove,
+.boardNodeInteractive:focus-within .boardPopoverAbove {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.boardPopoverHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding-bottom: var(--space-xs);
+  margin-bottom: var(--space-xs);
+  border-bottom: 1px dashed var(--color-border);
+}
+
+.boardPopoverTitle {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold, 600);
+  text-transform: capitalize;
+}
+
+.boardPopoverMeta {
+  font-size: 10px;
+  color: var(--color-text-muted);
+}
+
+.flowRuleList {
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.flowRuleItem,
+.flowRuleItemDisabled {
+  display: grid;
+  grid-template-columns: auto 72px 1fr;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-xs);
+}
+
+.flowRuleItemDisabled {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+.flowRuleProto {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--color-text-muted);
+}
+
+.flowRuleComment {
+  color: var(--color-text);
+}
+
+.flowEmpty {
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+  padding: 0 var(--space-sm);
+  font-style: italic;
+}
+
+.cardHeader {
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.headerActions {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+.chainField {
+  min-width: 160px;
+}
+
+.chainLabel {
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+}
+
+.errorBanner {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  background: var(--color-danger-surface, rgba(239, 68, 68, 0.08));
+  color: var(--color-danger, #ef4444);
+  font-size: var(--font-sm);
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--font-xs);
+}
+
+.muted {
+  color: var(--color-text-muted);
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xl);
+  color: var(--color-text-muted);
+  text-align: center;
+  font-size: var(--font-sm);
+}
+
+.emptyIcon {
+  color: var(--color-text-muted);
+  opacity: 0.7;
+}
+
+.skeletonRow {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: var(--space-md);
+  padding: 10px var(--space-sm);
+  border-bottom: 1px dashed var(--color-border);
+}

--- a/frontend/src/routes/FirewallPage.module.scss
+++ b/frontend/src/routes/FirewallPage.module.scss
@@ -59,7 +59,10 @@
   border: 2px solid var(--color-border);
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
 }
 
 .boardNodeEndpoint {

--- a/frontend/src/routes/FirewallPage.tsx
+++ b/frontend/src/routes/FirewallPage.tsx
@@ -9,12 +9,10 @@ import {
   Cpu,
   Flame,
   Globe,
-  RefreshCw,
   ShieldOff,
 } from 'lucide-react';
 import {
   Badge,
-  Button,
   Card,
   CardDescription,
   CardHeader,
@@ -297,28 +295,34 @@ export function FirewallPage() {
     return { host, username: c.username, password: c.password };
   }, [id, router?.host, getCredentials]);
 
-  const reload = useCallback(async () => {
-    if (!creds) {
-      setLoading(false);
-      setError('Missing router credentials for this session.');
-      return;
-    }
-    if (inFlightRef.current) return;
-    inFlightRef.current = true;
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchFirewallRules(creds);
-      setRules(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load firewall rules.';
-      setError(message);
-      setRules([]);
-    } finally {
-      inFlightRef.current = false;
-      setLoading(false);
-    }
-  }, [creds]);
+  const reload = useCallback(
+    async (silent = false) => {
+      if (!creds) {
+        setLoading(false);
+        setError('Missing router credentials for this session.');
+        return;
+      }
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      if (!silent) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const data = await fetchFirewallRules(creds);
+        setRules(data);
+        if (silent) setError(null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load firewall rules.';
+        setError(message);
+        if (!silent) setRules([]);
+      } finally {
+        inFlightRef.current = false;
+        setLoading(false);
+      }
+    },
+    [creds],
+  );
 
   const visibleRules = useMemo(
     () => (chain ? rules.filter((r) => r.chain === chain) : rules),
@@ -327,6 +331,10 @@ export function FirewallPage() {
 
   useEffect(() => {
     void reload();
+    const interval = window.setInterval(() => {
+      void reload(true);
+    }, 3000);
+    return () => window.clearInterval(interval);
   }, [reload]);
 
   const columns: DataTableColumn<FirewallRule>[] = [
@@ -477,9 +485,6 @@ export function FirewallPage() {
                 options={CHAIN_OPTIONS}
               />
             </Label>
-            <Button size="sm" variant="secondary" onClick={reload} disabled={loading}>
-              <RefreshCw size={14} aria-hidden /> Refresh
-            </Button>
           </div>
         </CardHeader>
 

--- a/frontend/src/routes/FirewallPage.tsx
+++ b/frontend/src/routes/FirewallPage.tsx
@@ -1,0 +1,501 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import {
+  ArrowRightFromLine,
+  ArrowRightLeft,
+  ArrowRightToLine,
+  Cloud,
+  Cpu,
+  Flame,
+  Globe,
+  RefreshCw,
+  ShieldOff,
+} from 'lucide-react';
+import {
+  Badge,
+  Button,
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DataTable,
+  type DataTableColumn,
+  Inline,
+  Label,
+  Select,
+  Skeleton,
+  Stack,
+} from '@nasnet/ui';
+import styles from './FirewallPage.module.scss';
+import { fetchFirewallRules, type FirewallCredentials, type FirewallRule } from '../api';
+import { useSession } from '../state/SessionContext';
+import { useRouter } from '../state/RouterStoreContext';
+
+const CHAIN_OPTIONS = [
+  { value: '', label: 'All chains' },
+  { value: 'input', label: 'input' },
+  { value: 'forward', label: 'forward' },
+  { value: 'output', label: 'output' },
+];
+
+function actionTone(action: string): 'success' | 'danger' | 'warning' | 'info' {
+  const a = action.toLowerCase();
+  if (a === 'accept') return 'success';
+  if (a === 'drop' || a === 'reject') return 'danger';
+  if (a === 'log') return 'warning';
+  return 'info';
+}
+
+function addrWithPort(address?: string, port?: string): string {
+  if (address && port) return `${address}:${port}`;
+  return address || port || '';
+}
+
+interface FlowNodeSpec {
+  id: string;
+  icon: ReactNode;
+  label: string;
+  x: number;
+  y: number;
+  rules?: FirewallRule[];
+  popoverPlacement?: 'above' | 'below';
+}
+
+const FLOW_W = 1800;
+const FLOW_H = 280;
+const NODE_SIZE = 64;
+const NODE_R = NODE_SIZE / 2;
+
+const P = {
+  'net-in': { x: 120, y: 110 },
+  input: { x: 480, y: 110 },
+  router: { x: 900, y: 110 },
+  output: { x: 1320, y: 110 },
+  'net-out': { x: 1680, y: 110 },
+  forward: { x: 900, y: 230 },
+} as const;
+
+interface Connector {
+  id: string;
+  d: string;
+  dotBegin: string;
+}
+
+const CONNECTORS: Connector[] = [
+  {
+    id: 'net-in-input',
+    d: `M ${P['net-in'].x + NODE_R} ${P['net-in'].y} H ${P.input.x - NODE_R}`,
+    dotBegin: '0s',
+  },
+  {
+    id: 'input-router',
+    d: `M ${P.input.x + NODE_R} ${P.input.y} H ${P.router.x - NODE_R}`,
+    dotBegin: '0.7s',
+  },
+  {
+    id: 'router-output',
+    d: `M ${P.router.x + NODE_R} ${P.router.y} H ${P.output.x - NODE_R}`,
+    dotBegin: '1.4s',
+  },
+  {
+    id: 'output-net-out',
+    d: `M ${P.output.x + NODE_R} ${P.output.y} H ${P['net-out'].x - NODE_R}`,
+    dotBegin: '2.1s',
+  },
+  {
+    id: 'fwd-in',
+    d: `M ${P['net-in'].x} ${P['net-in'].y + NODE_R} V ${P.forward.y} H ${P.forward.x - NODE_R}`,
+    dotBegin: '0.3s',
+  },
+  {
+    id: 'fwd-out',
+    d: `M ${P.forward.x + NODE_R} ${P.forward.y} H ${P['net-out'].x} V ${P['net-out'].y + NODE_R}`,
+    dotBegin: '1.8s',
+  },
+];
+
+interface PacketFlowBoardProps {
+  rulesByChain: { input: FirewallRule[]; forward: FirewallRule[]; output: FirewallRule[] };
+  loading: boolean;
+}
+
+function PacketFlowBoard({ rulesByChain, loading }: PacketFlowBoardProps) {
+  const nodes: FlowNodeSpec[] = [
+    { id: 'net-in', icon: <Globe size={26} aria-hidden />, label: 'Ingress', ...P['net-in'] },
+    {
+      id: 'input',
+      icon: <ArrowRightToLine size={26} aria-hidden />,
+      label: 'Input',
+      ...P.input,
+      rules: rulesByChain.input,
+      popoverPlacement: 'below',
+    },
+    { id: 'router', icon: <Cpu size={26} aria-hidden />, label: 'Router', ...P.router },
+    {
+      id: 'output',
+      icon: <ArrowRightFromLine size={26} aria-hidden />,
+      label: 'Output',
+      ...P.output,
+      rules: rulesByChain.output,
+      popoverPlacement: 'below',
+    },
+    { id: 'net-out', icon: <Cloud size={26} aria-hidden />, label: 'Egress', ...P['net-out'] },
+    {
+      id: 'forward',
+      icon: <ArrowRightLeft size={26} aria-hidden />,
+      label: 'Forward',
+      ...P.forward,
+      rules: rulesByChain.forward,
+      popoverPlacement: 'above',
+    },
+  ];
+
+  return (
+    <div className={styles.board} role="img" aria-label="Firewall packet flow diagram">
+      <svg
+        className={styles.boardSvg}
+        viewBox={`0 0 ${FLOW_W} ${FLOW_H}`}
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden
+      >
+        <defs>
+          <marker
+            id="fw-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" className={styles.arrowHead} />
+          </marker>
+        </defs>
+
+        {CONNECTORS.map((c) => (
+          <path
+            key={c.id}
+            d={c.d}
+            className={styles.boardLine}
+            fill="none"
+            markerEnd="url(#fw-arrow)"
+          />
+        ))}
+
+        {!loading
+          ? CONNECTORS.map((c) => (
+              <circle key={`dot-${c.id}`} r="5" className={styles.flowDot}>
+                <animateMotion dur="3s" repeatCount="indefinite" begin={c.dotBegin} path={c.d} />
+              </circle>
+            ))
+          : null}
+      </svg>
+
+      {nodes.map((n) => {
+        const pct = (v: number, total: number) => `${(v / total) * 100}%`;
+        const hasPopover = n.rules !== undefined;
+        const chainClass =
+          n.id === 'input' || n.id === 'forward' || n.id === 'output'
+            ? styles.boardNodeChain
+            : styles.boardNodeEndpoint;
+        return (
+          <div
+            key={n.id}
+            className={`${styles.boardNodeCircle} ${chainClass} ${hasPopover ? styles.boardNodeInteractive : ''}`}
+            style={{
+              left: pct(n.x - NODE_R, FLOW_W),
+              top: pct(n.y - NODE_R, FLOW_H),
+              width: pct(NODE_SIZE, FLOW_W),
+              height: pct(NODE_SIZE, FLOW_H),
+            }}
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+            tabIndex={hasPopover ? 0 : undefined}
+            role={hasPopover ? 'button' : undefined}
+            aria-label={
+              hasPopover && n.rules
+                ? `${n.label}, ${n.rules.length} rule${n.rules.length === 1 ? '' : 's'}`
+                : n.label
+            }
+          >
+            <div className={styles.boardNodeIcon}>{n.icon}</div>
+            <span
+              className={
+                n.id === 'net-in' || n.id === 'net-out'
+                  ? styles.boardNodeLabelAbove
+                  : styles.boardNodeLabel
+              }
+            >
+              {n.label}
+            </span>
+            {hasPopover ? (
+              <div
+                role="tooltip"
+                className={
+                  n.popoverPlacement === 'above'
+                    ? styles.boardPopoverAbove
+                    : styles.boardPopoverBelow
+                }
+              >
+                <div className={styles.boardPopoverHeader}>
+                  <span className={styles.boardPopoverTitle}>{n.label}</span>
+                  <span className={styles.boardPopoverMeta}>
+                    {loading ? '…' : `${n.rules!.length} rule${n.rules!.length === 1 ? '' : 's'}`}
+                  </span>
+                </div>
+                {loading ? (
+                  <div className={styles.flowEmpty}>
+                    <Skeleton height={12} />
+                  </div>
+                ) : (
+                  <RuleSummary rules={n.rules!} />
+                )}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RuleSummary({ rules }: { rules: FirewallRule[] }) {
+  if (rules.length === 0) {
+    return <div className={styles.flowEmpty}>No rules</div>;
+  }
+  return (
+    <ul className={styles.flowRuleList}>
+      {rules.map((r) => (
+        <li key={r.id} className={r.disabled ? styles.flowRuleItemDisabled : styles.flowRuleItem}>
+          <Badge tone={actionTone(r.action)}>{r.action}</Badge>
+          <span className={styles.flowRuleProto}>{r.protocol || 'any'}</span>
+          <span className={styles.flowRuleComment}>
+            {r.comment || <span className={styles.muted}>(no comment)</span>}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function FirewallPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter(id);
+  const { getCredentials } = useSession();
+
+  const [rules, setRules] = useState<FirewallRule[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [chain, setChain] = useState<string>('');
+  const inFlightRef = useRef(false);
+
+  const creds = useMemo<FirewallCredentials | null>(() => {
+    if (!id) return null;
+    const c = getCredentials(id);
+    const host = router?.host;
+    if (!c || !host) return null;
+    return { host, username: c.username, password: c.password };
+  }, [id, router?.host, getCredentials]);
+
+  const reload = useCallback(async () => {
+    if (!creds) {
+      setLoading(false);
+      setError('Missing router credentials for this session.');
+      return;
+    }
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchFirewallRules(creds);
+      setRules(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load firewall rules.';
+      setError(message);
+      setRules([]);
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
+  }, [creds]);
+
+  const visibleRules = useMemo(
+    () => (chain ? rules.filter((r) => r.chain === chain) : rules),
+    [rules, chain],
+  );
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const columns: DataTableColumn<FirewallRule>[] = [
+    {
+      key: 'chain',
+      header: 'Chain',
+      render: (r) => <Badge tone="info">{r.chain}</Badge>,
+    },
+    {
+      key: 'action',
+      header: 'Action',
+      render: (r) => <Badge tone={actionTone(r.action)}>{r.action}</Badge>,
+    },
+    {
+      key: 'protocol',
+      header: 'Proto',
+      render: (r) => r.protocol || <span className={styles.muted}>any</span>,
+    },
+    {
+      key: 'src',
+      header: 'Source',
+      render: (r) => {
+        const v = addrWithPort(r.srcAddress, r.srcPort);
+        return v ? (
+          <span className={styles.mono}>{v}</span>
+        ) : (
+          <span className={styles.muted}>any</span>
+        );
+      },
+    },
+    {
+      key: 'dst',
+      header: 'Destination',
+      render: (r) => {
+        const v = addrWithPort(r.dstAddress, r.dstPort);
+        return v ? (
+          <span className={styles.mono}>{v}</span>
+        ) : (
+          <span className={styles.muted}>any</span>
+        );
+      },
+    },
+    {
+      key: 'in',
+      header: 'In',
+      render: (r) =>
+        r.inInterface ? (
+          <span className={styles.mono}>{r.inInterface}</span>
+        ) : (
+          <span className={styles.muted}>—</span>
+        ),
+    },
+    {
+      key: 'out',
+      header: 'Out',
+      render: (r) =>
+        r.outInterface ? (
+          <span className={styles.mono}>{r.outInterface}</span>
+        ) : (
+          <span className={styles.muted}>—</span>
+        ),
+    },
+    {
+      key: 'bytes',
+      header: 'Bytes',
+      render: (r) =>
+        r.bytes ? (
+          <span className={styles.mono}>{r.bytes}</span>
+        ) : (
+          <span className={styles.muted}>0</span>
+        ),
+    },
+    {
+      key: 'packets',
+      header: 'Packets',
+      render: (r) =>
+        r.packets ? (
+          <span className={styles.mono}>{r.packets}</span>
+        ) : (
+          <span className={styles.muted}>0</span>
+        ),
+    },
+    {
+      key: 'comment',
+      header: 'Comment',
+      render: (r) => (r.comment ? r.comment : <span className={styles.muted}>—</span>),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (r) => (
+        <Inline>
+          {r.disabled ? (
+            <Badge tone="warning">disabled</Badge>
+          ) : (
+            <Badge tone="success">enabled</Badge>
+          )}
+          {r.log ? <Badge tone="info">log</Badge> : null}
+        </Inline>
+      ),
+    },
+  ];
+
+  const skeletonRows = (
+    <div data-testid="firewall-skeleton">
+      {['a', 'b', 'c', 'd'].map((k) => (
+        <div key={`skeleton-${k}`} className={styles.skeletonRow}>
+          {Array.from({ length: 8 }, (_, i) => (
+            <Skeleton key={`${k}-${i}`} height={14} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <Stack>
+      <div className={styles.flowBoard} data-testid="firewall-flow">
+        <PacketFlowBoard
+          rulesByChain={{
+            input: rules.filter((r) => r.chain === 'input'),
+            forward: rules.filter((r) => r.chain === 'forward'),
+            output: rules.filter((r) => r.chain === 'output'),
+          }}
+          loading={loading}
+        />
+      </div>
+
+      <Card data-testid="firewall-rules">
+        <CardHeader className={styles.cardHeader}>
+          <div>
+            <CardTitle>
+              <Inline>
+                <Flame size={16} aria-hidden /> Firewall rules
+              </Inline>
+            </CardTitle>
+            <CardDescription>
+              Active filter rules on this router, ordered by priority.
+            </CardDescription>
+          </div>
+          <div className={styles.headerActions}>
+            <Label className={styles.chainField}>
+              <span className={styles.chainLabel}>Chain</span>
+              <Select
+                aria-label="Chain filter"
+                value={chain}
+                onChange={setChain}
+                options={CHAIN_OPTIONS}
+              />
+            </Label>
+            <Button size="sm" variant="secondary" onClick={reload} disabled={loading}>
+              <RefreshCw size={14} aria-hidden /> Refresh
+            </Button>
+          </div>
+        </CardHeader>
+
+        {error ? <div className={styles.errorBanner}>{error}</div> : null}
+
+        {loading ? (
+          skeletonRows
+        ) : visibleRules.length === 0 ? (
+          <div className={styles.empty}>
+            <ShieldOff size={22} aria-hidden className={styles.emptyIcon} />
+            <p>No firewall rules configured{chain ? ` in the ${chain} chain` : ''}.</p>
+          </div>
+        ) : (
+          <DataTable columns={columns} rows={visibleRules} rowKey={(r) => r.id} />
+        )}
+      </Card>
+    </Stack>
+  );
+}

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
+  Flame,
   Globe,
   LayoutGrid,
   Network,
@@ -21,6 +22,7 @@ const TABS: Array<TabItem & { path: string }> = [
   { id: 'vpn', label: 'VPN', path: 'vpn', icon: <Shield size={16} /> },
   { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },
   { id: 'dns', label: 'DNS', path: 'dns', icon: <Globe size={16} /> },
+  { id: 'firewall', label: 'Firewall', path: 'firewall', icon: <Flame size={16} /> },
   { id: 'logs', label: 'Logs', path: 'logs', icon: <ScrollText size={16} /> },
   { id: 'users', label: 'Users', path: 'users', icon: <UsersIcon size={16} /> },
   { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },


### PR DESCRIPTION
## Summary

- Added a new **Firewall** tab in the router dashboard that lists `/ip/firewall/filter` rules, with chain filter, action/proto/src/dst/in-out/bytes/packets/comment/status columns, and standard loading/error/empty states.
- Above the rules table, a packet-flow diagram visualises the five canonical firewall stops (Ingress → Input → Router → Output → Egress) plus the Forward side-branch, with animated green dots tracing each connector and hover/focus popovers on the chain nodes listing their rules.
- Connected `HandleListFirewallRules` to `routeros.ListFirewallRules` / `GetFirewallRulesByChain`, mapped via `ToFirewallRulesResponse`, returning `[]` instead of `null` when empty.