### PR TITLE
feat(fe): show active router name as a badge in the header

### DIFF
--- a/frontend/src/layout/AppHeader.module.scss
+++ b/frontend/src/layout/AppHeader.module.scss
@@ -58,4 +58,11 @@
   margin-left: auto;
   display: flex;
   align-items: center;
+  gap: var(--space-md);
+}
+
+.separator {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border);
 }

--- a/frontend/src/layout/AppHeader.tsx
+++ b/frontend/src/layout/AppHeader.tsx
@@ -1,10 +1,13 @@
 import { Link } from 'react-router-dom';
+import { Badge } from '@nasnet/ui';
 import { HeaderActions } from './HeaderActions';
 import { useSession } from '../state/SessionContext';
+import { useRouter } from '../state/RouterStoreContext';
 import styles from './AppHeader.module.scss';
 
 export function AppHeader() {
   const { activeRouterId } = useSession();
+  const router = useRouter(activeRouterId ?? undefined);
   const logoTarget = activeRouterId ? `/router/${activeRouterId}` : '/';
   return (
     <header className={styles.headerRoot}>
@@ -19,6 +22,12 @@ export function AppHeader() {
           </div>
         </Link>
         <div className={styles.actionsRight}>
+          {router?.name ? (
+            <>
+              <Badge tone="primary">{router.name}</Badge>
+              <span className={styles.separator} aria-hidden />
+            </>
+          ) : null}
           <HeaderActions />
         </div>
       </div>

--- a/frontend/src/ui/primitives/Badge.module.scss
+++ b/frontend/src/ui/primitives/Badge.module.scss
@@ -8,6 +8,7 @@
   font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  white-space: nowrap;
 }
 
 .neutral {


### PR DESCRIPTION
## Summary
- Render the active router name as a primary-tone `Badge` in the top-right of `AppHeader`, before the icon actions, with a vertical separator between them.
- Pull the name from the router store via `activeRouterId` so it only appears when a router is selected.
- Add `white-space: nowrap` to `.badge` so multi-word names like "NASNET 15" stay on one line.