### PR TITLE
fix(fe): show router identity as Platform in overview

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -215,6 +215,7 @@ export async function fetchSystemOverview(
 
   return {
     routerId,
+    identity: info.identity || 'unknown',
     model: info.boardName || 'unknown',
     version: info.version || 'unknown',
     buildTime: info.buildTime || '',

--- a/frontend/src/mocks/types.ts
+++ b/frontend/src/mocks/types.ts
@@ -59,6 +59,7 @@ export interface Interface {
 
 export interface SystemOverview {
   routerId: string;
+  identity: string;
   model: string;
   version: string;
   buildTime: string;

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -450,7 +450,7 @@ export function OverviewTab() {
             </CardHeader>
             <div className={styles.infoRow}>
               <span className={styles.infoKey}>Platform</span>
-              <span className={styles.infoVal}>MikroTik</span>
+              <span className={styles.infoVal}>{overview.identity || '—'}</span>
             </div>
             <div className={styles.infoRow}>
               <span className={styles.infoKey}>Board</span>


### PR DESCRIPTION
## Summary
- Replaces the hardcoded "MikroTik" Platform label in the Overview tab's Hardware Details with the router's identity.
- Threads `identity` through `SystemOverview` and `fetchSystemOverview`.