### PR TITLE
feat(fe): wire wireless edit dialog to single-call settings endpoint

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -36,6 +36,7 @@ export {
   fetchWifiInterface,
   fetchWifiClients,
   updateWifiInterface,
+  updateWifiSettings,
   removeWifiClient,
   fetchWifiPassphrase,
   updateWifiPassphrase,
@@ -43,6 +44,7 @@ export {
   type WifiInterfaceResponse,
   type WifiConnectedClientResponse,
   type WifiPassphraseResponse,
+  type UpdateWifiSettingsRequest,
 } from './wifi';
 export {
   fetchLogs,

--- a/frontend/src/api/wifi.ts
+++ b/frontend/src/api/wifi.ts
@@ -112,6 +112,26 @@ export async function updateWifiInterface(
   });
 }
 
+export interface UpdateWifiSettingsRequest {
+  ssid?: string;
+  password?: string;
+  securityTypes?: string;
+}
+
+export async function updateWifiSettings(
+  creds: WifiCredentials,
+  name: string,
+  settings: UpdateWifiSettingsRequest,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiRequest(`/api/wifi/settings/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    headers: authHeaders(creds),
+    body: JSON.stringify(settings),
+    signal,
+  });
+}
+
 export async function removeWifiClient(
   creds: WifiCredentials,
   mac: string,

--- a/frontend/src/mocks/types.ts
+++ b/frontend/src/mocks/types.ts
@@ -51,6 +51,7 @@ export interface Interface {
   type: 'ether' | 'wireless' | 'bridge' | 'vlan';
   mac: string;
   running: boolean;
+  disabled?: boolean;
   comment?: string;
   ssid?: string;
   band?: WirelessBand;
@@ -121,13 +122,12 @@ export interface LogEntry {
   message: string;
 }
 
-export type WirelessSecurity = 'WPA2-PSK' | 'WPA3-PSK' | 'open';
 export type WirelessBand = '2.4ghz' | '5ghz';
 
 export interface WirelessSettings {
   ssid: string;
   password: string;
-  security: WirelessSecurity;
+  securityTypes: string[];
   band: WirelessBand;
   countryCode: string;
   hidden: boolean;

--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -12,6 +12,7 @@ interface Props {
 }
 
 export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
+  const enabled = !iface.disabled;
   return (
     <div className={styles.interfaceRow}>
       <div className={cx(styles.iconTone, toneClass('primary'))}>
@@ -21,12 +22,10 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
         <strong>{iface.ssid ?? settings.ssid}</strong>{' '}
         <span className={styles.interfaceName}>({iface.name})</span>
         <div>
-          <Badge tone={iface.running ? 'success' : 'neutral'}>
-            {iface.running ? 'enabled' : 'disabled'}
-          </Badge>{' '}
+          {enabled && !iface.running ? <Badge tone="warning">down</Badge> : null}{' '}
           {(iface.securityTypes && iface.securityTypes.length > 0
             ? iface.securityTypes
-            : [settings.security]
+            : settings.securityTypes
           ).map((s) => (
             <Badge key={s} tone="neutral">
               {s}
@@ -39,7 +38,7 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
       <Inline $gap="12px">
         <Switch
           aria-label={`Enable ${iface.name}`}
-          checked={iface.running}
+          checked={enabled}
           onChange={(e) => onToggle(e.target.checked)}
         />
         <Button size="sm" variant="secondary" onClick={() => onEdit(iface)}>

--- a/frontend/src/routes/wireless/WirelessFields.tsx
+++ b/frontend/src/routes/wireless/WirelessFields.tsx
@@ -1,16 +1,10 @@
-import { FieldRow, FieldStack, Input, Label, PasswordInput, Select, Switch } from '@nasnet/ui';
+import { Checkbox, FieldRow, FieldStack, Inline, Input, Label, PasswordInput } from '@nasnet/ui';
 import type { WirelessSettings } from '../../api';
-import styles from '../WirelessPage.module.scss';
 
-const SECURITY_OPTIONS = [
-  { value: 'WPA2-PSK', label: 'WPA2-PSK' },
-  { value: 'WPA3-PSK', label: 'WPA3-PSK' },
-  { value: 'open', label: 'Open' },
-];
-
-const BAND_OPTIONS = [
-  { value: '2.4ghz', label: '2.4 GHz' },
-  { value: '5ghz', label: '5 GHz' },
+const SECURITY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'wpa-psk', label: 'WPA-PSK' },
+  { value: 'wpa2-psk', label: 'WPA2-PSK' },
+  { value: 'wpa3-psk', label: 'WPA3-PSK' },
 ];
 
 interface Props {
@@ -19,6 +13,13 @@ interface Props {
 }
 
 export function WirelessFields({ draft, onPatch }: Props) {
+  const toggleType = (value: string, on: boolean) => {
+    const next = on
+      ? Array.from(new Set([...draft.securityTypes, value]))
+      : draft.securityTypes.filter((t) => t !== value);
+    onPatch('securityTypes', next);
+  };
+
   return (
     <FieldStack>
       <FieldRow>
@@ -39,42 +40,19 @@ export function WirelessFields({ draft, onPatch }: Props) {
           />
         </Label>
       </FieldRow>
-      <FieldRow>
-        <Label>
-          <span>Security</span>
-          <Select
-            aria-label="Security"
-            value={draft.security}
-            onChange={(v) => onPatch('security', v as WirelessSettings['security'])}
-            options={SECURITY_OPTIONS}
-          />
-        </Label>
-        <Label>
-          <span>Band</span>
-          <Select
-            aria-label="Band"
-            value={draft.band}
-            onChange={(v) => onPatch('band', v as WirelessSettings['band'])}
-            options={BAND_OPTIONS}
-          />
-        </Label>
-        <Label>
-          <span>Country code</span>
-          <Input
-            value={draft.countryCode}
-            onChange={(e) => onPatch('countryCode', e.target.value)}
-            aria-label="Country code"
-          />
-        </Label>
-        <Label as="div" className={styles.hiddenToggle}>
-          <span>Hide network</span>
-          <Switch
-            aria-label="Hide network from broadcast"
-            checked={draft.hidden}
-            onChange={(e) => onPatch('hidden', e.target.checked)}
-          />
-        </Label>
-      </FieldRow>
+      <Label as="div">
+        <span>Security</span>
+        <Inline $gap="16px">
+          {SECURITY_OPTIONS.map((opt) => (
+            <Checkbox
+              key={opt.value}
+              label={opt.label}
+              checked={draft.securityTypes.includes(opt.value)}
+              onChange={(e) => toggleType(opt.value, e.target.checked)}
+            />
+          ))}
+        </Inline>
+      </Label>
     </FieldStack>
   );
 }

--- a/frontend/src/routes/wireless/useWireless.ts
+++ b/frontend/src/routes/wireless/useWireless.ts
@@ -5,14 +5,14 @@ import {
   fetchWifiInterfaces,
   fetchWifiPassphrase,
   updateWifiInterface,
-  updateWifiPassphrase,
+  updateWifiSettings,
   type Interface,
+  type UpdateWifiSettingsRequest,
   type WifiConnectedClientResponse,
   type WifiCredentials,
   type WifiInterfaceResponse,
   type WirelessBand,
   type WirelessClient,
-  type WirelessSecurity,
   type WirelessSettings,
 } from '../../api';
 import { useRouter } from '../../state/RouterStoreContext';
@@ -20,13 +20,6 @@ import { useSession } from '../../state/SessionContext';
 
 const toBand = (value: string | undefined): WirelessBand =>
   value && value.toLowerCase().startsWith('5') ? '5ghz' : '2.4ghz';
-
-const toSecurity = (value: string | undefined): WirelessSecurity => {
-  const v = (value ?? '').toLowerCase();
-  if (v.includes('wpa3')) return 'WPA3-PSK';
-  if (v === 'none' || v === 'open' || v === '') return 'open';
-  return 'WPA2-PSK';
-};
 
 const parseNumber = (value: string | undefined): number => {
   if (!value) return 0;
@@ -46,7 +39,8 @@ const toInterface = (wi: WifiInterfaceResponse): Interface => ({
   name: wi.name || wi.interface,
   type: 'wireless',
   mac: wi.macAddress,
-  running: wi.running && !wi.disabled,
+  running: wi.running,
+  disabled: wi.disabled,
   comment: wi.comment,
   ssid: wi.ssid,
   band: toBand(wi.band),
@@ -72,7 +66,7 @@ const toSettings = (
   return {
     ssid: primary.ssid,
     password: passphrase,
-    security: toSecurity(primary.securityType),
+    securityTypes: parseSecurityTypes(primary.securityType),
     band: toBand(primary.band),
     countryCode: '',
     hidden: false,
@@ -171,7 +165,7 @@ export function useWireless(id: string | undefined) {
       setEditingSettings({
         ssid: iface.ssid ?? '',
         password: passphrase,
-        security: toSecurity(iface.securityTypes?.join(',')),
+        securityTypes: iface.securityTypes ?? [],
         band: iface.band ?? '2.4ghz',
         countryCode: settings?.countryCode ?? '',
         hidden: false,
@@ -187,17 +181,33 @@ export function useWireless(id: string | undefined) {
 
   const save = async (next: WirelessSettings) => {
     if (!creds || !editingIface) return;
-    if (next.password && next.password !== editingSettings?.password) {
-      await updateWifiPassphrase(creds, editingIface.name, next.password);
+    const patch: UpdateWifiSettingsRequest = {};
+    if (next.ssid !== editingSettings?.ssid) patch.ssid = next.ssid;
+    if (next.password !== editingSettings?.password) patch.password = next.password;
+    const nextTypes = [...next.securityTypes].sort().join(',');
+    const prevTypes = [...(editingSettings?.securityTypes ?? [])].sort().join(',');
+    if (nextTypes !== prevTypes) patch.securityTypes = next.securityTypes.join(',');
+    if (Object.keys(patch).length === 0) {
+      closeEdit();
+      return;
     }
-    toast.notify({ title: 'Wireless settings saved', tone: 'success' });
-    closeEdit();
+    try {
+      await updateWifiSettings(creds, editingIface.name, patch);
+      toast.notify({ title: 'Wireless settings saved', tone: 'success' });
+      closeEdit();
+      void reload();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save wireless settings';
+      toast.notify({ title: 'Save failed', description: message, tone: 'danger' });
+    }
   };
 
   const toggleInterface = async (ifaceName: string, running: boolean) => {
     if (!creds) return;
     await updateWifiInterface(creds, ifaceName, running);
-    setInterfaces((prev) => prev.map((i) => (i.name === ifaceName ? { ...i, running } : i)));
+    setInterfaces((prev) =>
+      prev.map((i) => (i.name === ifaceName ? { ...i, disabled: !running } : i)),
+    );
     toast.notify({
       title: `${ifaceName} ${running ? 'enabled' : 'disabled'}`,
       tone: 'success',

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -341,6 +341,24 @@ export const test = base.extend<TestFixtures>({
           body: envelope({ interfaceName, passphrase }),
         });
       });
+
+      await context.route('**/api/wifi/settings/*', async (route) => {
+        if (route.request().method() === 'PUT') {
+          const body = route.request().postDataJSON() as {
+            ssid?: string;
+            password?: string;
+            securityTypes?: string;
+          } | null;
+          if (body?.password) passphrase = body.password;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: envelope({ ok: true }),
+          });
+          return;
+        }
+        await route.fallback();
+      });
     });
   },
   mockLogsBackend: async ({ context }, use) => {


### PR DESCRIPTION
## Summary
- Wires the wireless interface edit dialog to PR #81's `PUT /api/wifi/settings/{name}`, sending only changed `ssid`/`password`/`securityTypes` and reloading after success.
- Splits admin state (`disabled`) from operational state (`running`) so the per-interface Switch reflects the admin flag and toggling actually flips it; an amber `down` badge surfaces admin-enabled-but-not-running.
- Replaces the security single-select with three multi-select checkboxes (`WPA-PSK`, `WPA2-PSK`, `WPA3-PSK`) joined into the comma-separated `securityTypes` payload (empty = open network).
- Drops the Band, Country code, and Hide network fields from the dialog — none are accepted by the new endpoint.
- Removes the literal "enabled"/"disabled" badges from the row; the Switch is the canonical admin-state indicator.