### PR TITLE
feat(fe): show hostname and status on router list cards

### DIFF
--- a/frontend/src/mocks/types.ts
+++ b/frontend/src/mocks/types.ts
@@ -5,6 +5,7 @@ export interface Router {
   id: string;
   name: string;
   host: string;
+  hostname?: string;
   port: number;
   platform: RouterPlatform;
   model?: string;

--- a/frontend/src/routes/RouterCard.tsx
+++ b/frontend/src/routes/RouterCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Activity, Router as RouterIcon, Trash2 } from 'lucide-react';
+import { Globe, Router as RouterIcon, Trash2 } from 'lucide-react';
 import { Badge, Card, CardDescription, CardTitle, Inline, Skeleton, StatusDot } from '@nasnet/ui';
 import type { Router } from '../api';
 import styles from './RouterListPage.module.scss';
@@ -34,10 +34,16 @@ export function RouterCard({ router, isProbed, onOpen, onRemove }: Props) {
             </div>
           </div>
           <Inline>
-            <Badge tone="neutral">
-              <Activity size={12} aria-hidden />
-              {router.model ?? router.platform}
-            </Badge>
+            {router.hostname || isProbed ? (
+              <Badge tone="neutral" className={styles.hostnameBadge}>
+                <Globe size={12} aria-hidden />
+                {router.hostname ?? '—'}
+              </Badge>
+            ) : (
+              <Skeleton width={140} height={20} radius={999} />
+            )}
+          </Inline>
+          <div className={styles.cardBottomRow}>
             {isProbed ? (
               <Badge tone={toneFor(router.status)}>
                 <StatusDot $status={router.status} aria-hidden /> {router.status}
@@ -45,9 +51,6 @@ export function RouterCard({ router, isProbed, onOpen, onRemove }: Props) {
             ) : (
               <Skeleton width={78} height={20} radius={999} />
             )}
-          </Inline>
-          <div className={styles.cardBottomRow}>
-            <span>RouterOS {router.version ?? '—'}</span>
             <span>
               {router.lastSeen
                 ? `seen ${new Date(router.lastSeen).toLocaleDateString()}`

--- a/frontend/src/routes/RouterListPage.module.scss
+++ b/frontend/src/routes/RouterListPage.module.scss
@@ -96,6 +96,10 @@
   color: var(--color-text-muted);
 }
 
+.hostnameBadge {
+  text-transform: lowercase;
+}
+
 .motionGrid {
   display: grid;
   width: 100%;

--- a/frontend/src/routes/add-router/useAddRouter.ts
+++ b/frontend/src/routes/add-router/useAddRouter.ts
@@ -86,7 +86,7 @@ export function useAddRouter(
         username: state.username,
         password: state.password,
       });
-      await finishAndNavigate(router);
+      await finishAndNavigate({ ...router, hostname: verification.hostname });
     } catch (err) {
       dispatch({ type: 'error', message: (err as Error).message ?? 'Connection failed' });
     } finally {

--- a/frontend/src/routes/useRouterStatusPolling.ts
+++ b/frontend/src/routes/useRouterStatusPolling.ts
@@ -44,8 +44,18 @@ export function useRouterStatusPolling(
         if (!current) return;
         const nextStatus: Router['status'] = result.isOnline ? 'online' : 'offline';
         const nextLastSeen = result.isOnline ? new Date().toISOString() : current.lastSeen;
-        if (current.status !== nextStatus || current.lastSeen !== nextLastSeen) {
-          upsertRef.current({ ...current, status: nextStatus, lastSeen: nextLastSeen });
+        const nextHostname = result.hostname ?? current.hostname;
+        if (
+          current.status !== nextStatus ||
+          current.lastSeen !== nextLastSeen ||
+          current.hostname !== nextHostname
+        ) {
+          upsertRef.current({
+            ...current,
+            status: nextStatus,
+            lastSeen: nextLastSeen,
+            hostname: nextHostname,
+          });
         }
         markProbed(id);
       } catch {

--- a/frontend/src/state/RouterStoreContext.tsx
+++ b/frontend/src/state/RouterStoreContext.tsx
@@ -56,7 +56,12 @@ function reducer(state: State, action: Action): State {
       const merged = action.remote.map((incoming) => {
         const existing = existingById.get(incoming.id);
         if (!existing) return incoming;
-        return { ...incoming, status: existing.status, lastSeen: existing.lastSeen };
+        return {
+          ...incoming,
+          status: existing.status,
+          lastSeen: existing.lastSeen,
+          hostname: incoming.hostname ?? existing.hostname,
+        };
       });
       return { ...state, routers: merged };
     }
@@ -107,7 +112,18 @@ export const RouterStoreProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
   useEffect(() => {
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      const toStore = {
+        ...state,
+        routers: state.routers.map((r) => ({
+          id: r.id,
+          name: r.name,
+          host: r.host,
+          hostname: r.hostname,
+          status: r.status,
+          lastSeen: r.lastSeen,
+        })),
+      };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
     } catch {
       /* ignore quota errors */
     }


### PR DESCRIPTION
## Summary
- Replace the model badge on each router card with the device hostname (populated from the verify probe); show a skeleton until first probe.
- Move the online/offline status badge into the bottom row, replacing the static `RouterOS {version}` label.
- Persist `hostname` via the polling tick and when adding a new router, and trim the localStorage payload to only the fields the UI actually reads (`id`, `name`, `host`, `hostname`, `status`, `lastSeen`).