### PR TITLE
feat(fe): add reboot and shutdown actions to router overview

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -23,6 +23,8 @@ export {
   fetchInterfaceTraffic,
   fetchInterfaces,
   fetchVPNClients,
+  rebootSystem,
+  shutdownSystem,
   type SystemCredentials,
   type SystemInfoResponse,
   type ResourceInfoResponse,

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -143,6 +143,20 @@ export async function fetchVPNClients(
   return clients ?? [];
 }
 
+export async function rebootSystem(creds: SystemCredentials): Promise<void> {
+  await apiRequest<void>('/api/system/reboot', {
+    method: 'POST',
+    headers: authHeaders(creds),
+  });
+}
+
+export async function shutdownSystem(creds: SystemCredentials): Promise<void> {
+  await apiRequest<void>('/api/system/shutdown', {
+    method: 'POST',
+    headers: authHeaders(creds),
+  });
+}
+
 export async function fetchInterfaceTraffic(
   creds: SystemCredentials,
   interfaceName: string,

--- a/frontend/src/routes/OverviewTab.module.scss
+++ b/frontend/src/routes/OverviewTab.module.scss
@@ -80,6 +80,18 @@
   font-weight: var(--weight-semibold);
 }
 
+.rebootBtn:not(:disabled):hover {
+  background: var(--color-warning);
+  border-color: var(--color-warning);
+  color: #000;
+}
+
+.shutdownBtn:not(:disabled):hover {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+  color: #fff;
+}
+
 .resourceCard {
   display: flex;
   flex-direction: column;

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Activity, Network as NetworkIcon, Shield, Timer, Users as UsersIcon } from 'lucide-react';
+import {
+  Activity,
+  Network as NetworkIcon,
+  Power,
+  RotateCw,
+  Shield,
+  Timer,
+  Users as UsersIcon,
+} from 'lucide-react';
 import {
   Badge,
   Button,
@@ -8,13 +16,16 @@ import {
   CardHeader,
   CardTitle,
   CircularProgress,
+  ConfirmDialog,
   SectionGrid,
   SectionHeading,
   Select,
   Skeleton,
   Stack,
   StatusDot,
+  Tooltip,
   TrafficChart,
+  useToast,
 } from '@nasnet/ui';
 import {
   fetchDHCPLeases,
@@ -23,6 +34,8 @@ import {
   fetchInterfaces,
   fetchSystemOverview,
   fetchVPNClients,
+  rebootSystem,
+  shutdownSystem,
   type DHCPLeaseResponse,
   type InterfaceResponse,
   type SystemOverview,
@@ -83,7 +96,37 @@ export function OverviewTab() {
   const [dhcpLeaseList, setDhcpLeaseList] = useState<DHCPLeaseResponse[]>([]);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
   const [selectedIface, setSelectedIface] = useState<string>(DEFAULT_TRAFFIC_INTERFACE);
+  const [powerAction, setPowerAction] = useState<'reboot' | 'shutdown' | null>(null);
+  const [powerBusy, setPowerBusy] = useState<'reboot' | 'shutdown' | null>(null);
   const colors = useThemeColors();
+  const toast = useToast();
+
+  const runPowerAction = async (action: 'reboot' | 'shutdown') => {
+    setPowerAction(null);
+    if (!id) return;
+    const creds = getCredentials(id);
+    const host = router?.host;
+    if (!creds || !host) return;
+    setPowerBusy(action);
+    try {
+      if (action === 'reboot') {
+        await rebootSystem({ host, ...creds });
+        toast.notify({ title: 'Reboot initiated', tone: 'warning' });
+      } else {
+        await shutdownSystem({ host, ...creds });
+        toast.notify({ title: 'Shutdown initiated', tone: 'warning' });
+      }
+      navigate('/');
+    } catch (err) {
+      toast.notify({
+        title: `Failed to ${action} router`,
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+    } finally {
+      setPowerBusy(null);
+    }
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -204,6 +247,37 @@ export function OverviewTab() {
             <Activity size={14} aria-hidden />{' '}
             <span className={styles.statValue}>{overview.vpnTunnels}</span> <span>VPN</span>
           </span>
+          <span className={styles.bannerDivider} aria-hidden />
+          <div style={{ display: 'inline-flex', gap: 'var(--space-sm)' }}>
+            <Tooltip label="Reboot router">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setPowerAction('reboot')}
+                loading={powerBusy === 'reboot'}
+                disabled={powerBusy !== null}
+                aria-label="Reboot router"
+                className={styles.rebootBtn}
+                data-testid="overview-reboot"
+              >
+                <RotateCw size={14} aria-hidden />
+              </Button>
+            </Tooltip>
+            <Tooltip label="Shutdown router">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setPowerAction('shutdown')}
+                loading={powerBusy === 'shutdown'}
+                disabled={powerBusy !== null}
+                aria-label="Shutdown router"
+                className={styles.shutdownBtn}
+                data-testid="overview-shutdown"
+              >
+                <Power size={14} aria-hidden />
+              </Button>
+            </Tooltip>
+          </div>
         </div>
       </Card>
 
@@ -471,6 +545,24 @@ export function OverviewTab() {
           </Card>
         </SectionGrid>
       </div>
+
+      <ConfirmDialog
+        open={powerAction !== null}
+        title={powerAction === 'shutdown' ? 'Shutdown router?' : 'Reboot router?'}
+        description={
+          powerAction === 'shutdown'
+            ? 'The router will power off. You will need physical access to turn it back on.'
+            : 'The router will restart. Connectivity drops briefly.'
+        }
+        destructive
+        confirmLabel={powerAction === 'shutdown' ? 'Shutdown' : 'Reboot'}
+        onConfirm={() => {
+          if (powerAction) {
+            void runPowerAction(powerAction);
+          }
+        }}
+        onCancel={() => setPowerAction(null)}
+      />
     </Stack>
   );
 }

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -25,6 +25,8 @@ export { Dialog, ConfirmDialog } from './patterns/Dialog';
 export type { DialogProps, ConfirmDialogProps } from './patterns/Dialog';
 export { ToastProvider, useToast } from './patterns/Toast';
 export type { ToastTone } from './patterns/Toast';
+export { Tooltip } from './patterns/Tooltip';
+export type { TooltipProps } from './patterns/Tooltip';
 export { DataTable } from './patterns/DataTable';
 export type { DataTableColumn, DataTableProps } from './patterns/DataTable';
 export { FileDrop } from './patterns/FileDrop';

--- a/frontend/src/ui/patterns/Tooltip.module.scss
+++ b/frontend/src/ui/patterns/Tooltip.module.scss
@@ -1,0 +1,39 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.bubble {
+  position: absolute;
+  left: 50%;
+  pointer-events: none;
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-text);
+  color: var(--color-surface);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast);
+  z-index: 100;
+}
+
+.wrapper[data-placement='top'] .bubble {
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%) translateY(4px);
+}
+
+.wrapper[data-placement='bottom'] .bubble {
+  top: calc(100% + 6px);
+  transform: translateX(-50%) translateY(-4px);
+}
+
+.wrapper:hover .bubble,
+.wrapper:focus-within .bubble {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/frontend/src/ui/patterns/Tooltip.tsx
+++ b/frontend/src/ui/patterns/Tooltip.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './Tooltip.module.scss';
+
+export interface TooltipProps {
+  label: string;
+  children: React.ReactElement;
+  placement?: 'top' | 'bottom';
+  className?: string;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({
+  label,
+  children,
+  placement = 'top',
+  className,
+}) => (
+  <span
+    className={[styles.wrapper, className].filter(Boolean).join(' ')}
+    data-placement={placement}
+  >
+    {children}
+    <span className={styles.bubble} role="tooltip">
+      {label}
+    </span>
+  </span>
+);

--- a/frontend/tests/e2e/20-overview-power-actions.spec.ts
+++ b/frontend/tests/e2e/20-overview-power-actions.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from './fixtures';
+
+test.describe('Overview tab — power actions', () => {
+  test('reboot confirms, posts to backend, toasts, returns to router list', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_pwr', name: 'Power Router', host: '10.0.0.50' });
+    await mockOverviewBackend({ id: 'rtr_pwr' });
+
+    let rebootCalled = false;
+    await context.route('**/api/system/reboot', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      rebootCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 200, message: 'System reboot initiated' }),
+      });
+    });
+
+    await page.goto('/router/rtr_pwr');
+    await expect(page.getByTestId('overview-uptime')).not.toBeEmpty();
+
+    await page.getByTestId('overview-reboot').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: /reboot router\?/i })).toBeVisible();
+    await dialog.getByRole('button', { name: /^reboot$/i }).click();
+
+    await expect(page.getByText(/reboot initiated/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
+    expect(rebootCalled).toBe(true);
+  });
+
+  test('shutdown confirms, posts to backend, toasts, returns to router list', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_pwr', name: 'Power Router', host: '10.0.0.50' });
+    await mockOverviewBackend({ id: 'rtr_pwr' });
+
+    let shutdownCalled = false;
+    await context.route('**/api/system/shutdown', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      shutdownCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 200, message: 'System shutdown initiated' }),
+      });
+    });
+
+    await page.goto('/router/rtr_pwr');
+    await expect(page.getByTestId('overview-uptime')).not.toBeEmpty();
+
+    await page.getByTestId('overview-shutdown').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: /shutdown router\?/i })).toBeVisible();
+    await dialog.getByRole('button', { name: /^shutdown$/i }).click();
+
+    await expect(page.getByText(/shutdown initiated/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
+    expect(shutdownCalled).toBe(true);
+  });
+
+  test('cancel keeps the user on the dashboard and does not call backend', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_pwr', name: 'Power Router', host: '10.0.0.50' });
+    await mockOverviewBackend({ id: 'rtr_pwr' });
+
+    let called = false;
+    await context.route('**/api/system/reboot', async (route) => {
+      called = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 200, message: 'ok' }),
+      });
+    });
+
+    await page.goto('/router/rtr_pwr');
+    await expect(page.getByTestId('overview-uptime')).not.toBeEmpty();
+
+    await page.getByTestId('overview-reboot').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/router\/rtr_pwr/);
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New icon-only Reboot (warning-on-hover) and Shutdown (danger-on-hover) buttons in the overview banner, next to the uptime/devices/VPN stats.
- Each action opens a confirm dialog, shows a toast on success or failure, and returns the user to the router list after a successful call — session credentials are preserved so the router can be reopened once it's back up.
- Added a lightweight CSS-only `Tooltip` pattern in `@nasnet/ui` to surface the button labels on hover.
- Playwright coverage for the confirm-reboot, confirm-shutdown, and cancel paths.