### PR TITLE
fix(fe): default scan subnet to MikroTik factory IP range

### DIFF
--- a/frontend/src/routes/add-router/ScanStep.tsx
+++ b/frontend/src/routes/add-router/ScanStep.tsx
@@ -35,7 +35,7 @@ const SCAN_COLUMNS = [
 ];
 
 export function ScanStep({ onSelect }: Props) {
-  const [subnet, setSubnet] = useState('192.168.1.0/24');
+  const [subnet, setSubnet] = useState('192.168.88.0/24');
   const [scanning, setScanning] = useState(false);
   const [percent, setPercent] = useState(0);
   const [displayPercent, setDisplayPercent] = useSmoothedPercent(percent);

--- a/frontend/src/routes/add-router/ScanToolbar.tsx
+++ b/frontend/src/routes/add-router/ScanToolbar.tsx
@@ -17,7 +17,7 @@ export function ScanToolbar({ subnet, scanning, onSubnetChange, onStart }: Props
         <Input
           value={subnet}
           onChange={(e) => onSubnetChange(e.target.value)}
-          placeholder="192.168.1.0/24"
+          placeholder="192.168.88.0/24"
           aria-label="Subnet"
         />
       </Label>

--- a/frontend/tests/e2e/02-add-router-scan.spec.ts
+++ b/frontend/tests/e2e/02-add-router-scan.spec.ts
@@ -21,7 +21,7 @@ test.describe('Add router — scan network', () => {
     await expect(page.getByRole('heading', { name: /add router/i })).toBeVisible();
 
     const subnet = page.getByLabel(/subnet/i);
-    await expect(subnet).toHaveValue('192.168.1.0/24');
+    await expect(subnet).toHaveValue('192.168.88.0/24');
 
     await page.getByRole('button', { name: /start scan/i }).click();
 


### PR DESCRIPTION
## Summary

The "Add router, Scan network" form now pre-fills `192.168.88.0/24` (MikroTik's factory-default LAN) instead of the generic `192.168.1.0/24`, so a freshly unboxed router is found on the first scan with no retyping.

Resolves #100.