### PR TITLE
fix(fe): rename wifi interface "down" badge to "idle"

### DIFF
--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -22,7 +22,7 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
         <strong>{iface.ssid ?? settings.ssid}</strong>{' '}
         <span className={styles.interfaceName}>({iface.name})</span>
         <div>
-          {enabled && !iface.running ? <Badge tone="warning">down</Badge> : null}{' '}
+          {enabled && !iface.running ? <Badge tone="warning">idle</Badge> : null}{' '}
           {(iface.securityTypes && iface.securityTypes.length > 0
             ? iface.securityTypes
             : settings.securityTypes

--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -22,7 +22,13 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
         <strong>{iface.ssid ?? settings.ssid}</strong>{' '}
         <span className={styles.interfaceName}>({iface.name})</span>
         <div>
-          {enabled && !iface.running ? <Badge tone="warning">idle</Badge> : null}{' '}
+          {enabled ? (
+            iface.running ? (
+              <Badge tone="success">active</Badge>
+            ) : (
+              <Badge tone="primary">idle</Badge>
+            )
+          ) : null}{' '}
           {(iface.securityTypes && iface.securityTypes.length > 0
             ? iface.securityTypes
             : settings.securityTypes


### PR DESCRIPTION
## Summary

Renames the wifi interface badge from "down" to "idle" so an enabled radio with no clients reads as quiet rather than broken.

Closes #101