### PR TITLE
feat(fe): split DNS page into view + edit modal (#99)

### DIFF
--- a/frontend/src/routes/DNSEditDialog.module.scss
+++ b/frontend/src/routes/DNSEditDialog.module.scss
@@ -1,0 +1,21 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.sectionLabel {
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.serverInput {
+  flex: 1;
+  min-width: 0;
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+}

--- a/frontend/src/routes/DNSEditDialog.tsx
+++ b/frontend/src/routes/DNSEditDialog.tsx
@@ -1,0 +1,145 @@
+import { useRef, useState } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import { Button, Dialog, Inline, Input, Label, Stack, Switch, useToast } from '@nasnet/ui';
+import styles from './DNSEditDialog.module.scss';
+import { ApiError, updateDnsConfig, type DnsCredentials, type DnsInfoResponse } from '../api';
+
+interface DNSEditDialogProps {
+  open: boolean;
+  initial: DnsInfoResponse;
+  creds: DnsCredentials;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface ServerRow {
+  id: string;
+  value: string;
+}
+
+export function DNSEditDialog({ open, initial, creds, onClose, onSaved }: DNSEditDialogProps) {
+  const toast = useToast();
+  const nextId = useRef(0);
+  const makeRow = (value: string): ServerRow => {
+    nextId.current += 1;
+    return { id: `srv-${nextId.current}`, value };
+  };
+  const [servers, setServers] = useState<ServerRow[]>(() => {
+    const seed = initial.servers.length > 0 ? initial.servers : [''];
+    return seed.map(makeRow);
+  });
+  const [dohEnabled, setDohEnabled] = useState<boolean>(Boolean(initial.dohServer));
+  const [dohUrl, setDohUrl] = useState<string>(initial.dohServer ?? '');
+  const [saving, setSaving] = useState(false);
+
+  const updateServer = (id: string, value: string) => {
+    setServers((prev) => prev.map((row) => (row.id === id ? { ...row, value } : row)));
+  };
+
+  const removeServer = (id: string) => {
+    setServers((prev) => prev.filter((row) => row.id !== id));
+  };
+
+  const addServer = () => {
+    setServers((prev) => [...prev, makeRow('')]);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const cleaned = servers.map((row) => row.value.trim()).filter(Boolean);
+      await updateDnsConfig(creds, {
+        servers: cleaned.join(','),
+        dohServer: dohEnabled ? dohUrl.trim() : '',
+      });
+      toast.notify({ title: 'DNS configuration saved', tone: 'success' });
+      onSaved();
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to update DNS configuration.';
+      toast.notify({ title: 'Failed to save DNS', description: message, tone: 'danger' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Edit DNS configuration"
+      size="md"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={save} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </>
+      }
+    >
+      <Stack $gap="var(--space-md)">
+        <div className={styles.section}>
+          <Label as="span" className={styles.sectionLabel}>
+            DNS servers
+          </Label>
+          <Stack $gap="var(--space-xs)">
+            {servers.map((row, idx) => (
+              <Inline key={row.id} $gap="var(--space-xs)" $align="center">
+                <Input
+                  value={row.value}
+                  onChange={(e) => updateServer(row.id, e.target.value)}
+                  placeholder={idx === 0 ? '1.1.1.1' : '8.8.8.8'}
+                  aria-label={`DNS server ${idx + 1}`}
+                  disabled={saving}
+                  className={styles.serverInput}
+                />
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => removeServer(row.id)}
+                  disabled={saving || servers.length === 1}
+                  aria-label={`Remove DNS server ${idx + 1}`}
+                >
+                  <Minus size={14} aria-hidden />
+                </Button>
+              </Inline>
+            ))}
+          </Stack>
+          <Inline $justify="flex-start">
+            <Button size="sm" variant="secondary" onClick={addServer} disabled={saving}>
+              <Plus size={14} aria-hidden /> Add server
+            </Button>
+          </Inline>
+          <p className={styles.hint}>IPv4 or IPv6 address. Examples: 1.1.1.1, 8.8.8.8.</p>
+        </div>
+
+        <div className={styles.section}>
+          <Switch
+            checked={dohEnabled}
+            onChange={(e) => setDohEnabled(e.target.checked)}
+            label="Enable DNS over HTTPS"
+            disabled={saving}
+          />
+          <Input
+            value={dohUrl}
+            onChange={(e) => setDohUrl(e.target.value)}
+            placeholder="https://cloudflare-dns.com/dns-query"
+            aria-label="DoH server URL"
+            disabled={saving || !dohEnabled}
+          />
+          <p className={styles.hint}>
+            DoH endpoint URL. Example: https://cloudflare-dns.com/dns-query.
+          </p>
+        </div>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -17,30 +17,29 @@
   flex-shrink: 0;
 }
 
-.dynamicRow {
+.infoRow {
   display: grid;
   grid-template-columns: 180px 1fr;
   gap: var(--space-md);
   align-items: start;
-  padding-top: var(--space-sm);
-  border-top: 1px solid var(--color-border);
   font-size: var(--font-sm);
 }
 
-.dynamicLabel {
+.infoLabel {
   color: var(--color-text-muted);
   font-weight: var(--weight-medium);
   padding-top: 4px;
 }
 
-.dynamicValue {
+.infoValue {
   min-width: 0;
   word-break: break-word;
 }
 
-.serverList {
+.serverColumn {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-xs);
 }
 

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,50 +1,32 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Globe, RefreshCw, SearchX } from 'lucide-react';
+import { Check, Globe, Pencil, RefreshCw, SearchX } from 'lucide-react';
 import {
+  Badge,
   Button,
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
-  FieldStack,
   Inline,
-  Input,
-  Label,
   Skeleton,
   Stack,
-  useToast,
 } from '@nasnet/ui';
 import styles from './DNSPage.module.scss';
-import {
-  ApiError,
-  fetchDnsInfo,
-  updateDnsConfig,
-  type DnsCredentials,
-  type DnsInfoResponse,
-} from '../api';
+import { DNSEditDialog } from './DNSEditDialog';
+import { fetchDnsInfo, type DnsCredentials, type DnsInfoResponse } from '../api';
 import { useSession } from '../state/SessionContext';
 import { useRouter } from '../state/RouterStoreContext';
-
-const normalizeServers = (raw: string): string =>
-  raw
-    .split(/[\s,]+/)
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .join(',');
 
 export function DNSPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter(id);
   const { getCredentials } = useSession();
-  const toast = useToast();
 
   const [info, setInfo] = useState<DnsInfoResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [serversInput, setServersInput] = useState<string>('');
-  const [dohInput, setDohInput] = useState<string>('');
-  const [saving, setSaving] = useState<boolean>(false);
+  const [editing, setEditing] = useState(false);
 
   const creds = useMemo<DnsCredentials | null>(() => {
     if (!id) return null;
@@ -65,8 +47,6 @@ export function DNSPage() {
     try {
       const data = await fetchDnsInfo(creds);
       setInfo(data);
-      setServersInput(data.servers.join(', '));
-      setDohInput(data.dohServer ?? '');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load DNS configuration.';
       setError(message);
@@ -79,28 +59,7 @@ export function DNSPage() {
     void reload();
   }, [reload]);
 
-  const save = async () => {
-    if (!creds) return;
-    setSaving(true);
-    try {
-      await updateDnsConfig(creds, {
-        servers: normalizeServers(serversInput),
-        dohServer: dohInput.trim(),
-      });
-      toast.notify({ title: 'DNS configuration saved', tone: 'success' });
-      await reload();
-    } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.message
-          : err instanceof Error
-            ? err.message
-            : 'Failed to update DNS configuration.';
-      toast.notify({ title: 'Failed to save DNS', description: message, tone: 'danger' });
-    } finally {
-      setSaving(false);
-    }
-  };
+  const dohActive = Boolean(info?.dohServer);
 
   return (
     <Stack>
@@ -117,11 +76,16 @@ export function DNSPage() {
             </CardDescription>
           </div>
           <div className={styles.headerActions}>
-            <Button size="sm" variant="secondary" onClick={reload} disabled={loading || saving}>
+            <Button size="sm" variant="secondary" onClick={reload} disabled={loading}>
               <RefreshCw size={14} aria-hidden /> Refresh
             </Button>
-            <Button size="sm" variant="success" onClick={save} disabled={!info || saving}>
-              {saving ? 'Saving…' : 'Save'}
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => setEditing(true)}
+              disabled={!info || loading || !creds}
+            >
+              <Pencil size={14} aria-hidden /> Edit
             </Button>
           </div>
         </CardHeader>
@@ -141,37 +105,47 @@ export function DNSPage() {
             <p>{error}</p>
           </div>
         ) : info ? (
-          <FieldStack>
-            <Label>
-              <span>Static DNS servers</span>
-              <Input
-                value={serversInput}
-                onChange={(e) => setServersInput(e.target.value)}
-                placeholder="8.8.8.8, 1.1.1.1"
-                aria-label="Static DNS servers"
-                disabled={saving}
-              />
-              <div className={styles.fieldHint}>
-                Comma-separated IPv4/IPv6 addresses. Leave empty to clear.
+          <Stack $gap="var(--space-md)">
+            <div className={styles.infoRow}>
+              <span className={styles.infoLabel}>Static DNS servers</span>
+              <div className={styles.infoValue}>
+                {info.servers.length > 0 ? (
+                  <div className={styles.serverColumn}>
+                    {info.servers.map((s) => (
+                      <span key={`static-${s}`} className={styles.serverPill}>
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className={styles.muted}>None configured</span>
+                )}
               </div>
-            </Label>
-            <Label>
-              <span>DoH server URL</span>
-              <Input
-                value={dohInput}
-                onChange={(e) => setDohInput(e.target.value)}
-                placeholder="https://dns.google/dns-query"
-                aria-label="DoH server URL"
-                disabled={saving}
-              />
-              <div className={styles.fieldHint}>Leave empty to disable DNS-over-HTTPS.</div>
-            </Label>
+            </div>
 
-            <div className={styles.dynamicRow}>
-              <span className={styles.dynamicLabel}>Dynamic servers</span>
-              <div className={styles.dynamicValue}>
+            <div className={styles.infoRow}>
+              <span className={styles.infoLabel}>DNS over HTTPS</span>
+              <div className={styles.infoValue}>
+                {dohActive ? (
+                  <Stack $gap="var(--space-xs)">
+                    <Badge tone="success">
+                      <Inline $gap="4px" $align="center">
+                        <Check size={12} aria-hidden /> Active
+                      </Inline>
+                    </Badge>
+                    <span className={styles.serverPill}>{info.dohServer}</span>
+                  </Stack>
+                ) : (
+                  <span className={styles.muted}>Disabled</span>
+                )}
+              </div>
+            </div>
+
+            <div className={styles.infoRow}>
+              <span className={styles.infoLabel}>Dynamic servers</span>
+              <div className={styles.infoValue}>
                 {info.dynamicServers.length > 0 ? (
-                  <div className={styles.serverList}>
+                  <div className={styles.serverColumn}>
                     {info.dynamicServers.map((s) => (
                       <span key={`dynamic-${s}`} className={styles.serverPill}>
                         {s}
@@ -184,9 +158,21 @@ export function DNSPage() {
                 <div className={styles.fieldHint}>Read-only. Supplied by DHCP / PPP peers.</div>
               </div>
             </div>
-          </FieldStack>
+          </Stack>
         ) : null}
       </Card>
+
+      {info && creds ? (
+        <DNSEditDialog
+          open={editing}
+          initial={info}
+          creds={creds}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            void reload();
+          }}
+        />
+      ) : null}
     </Stack>
   );
 }

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -127,14 +127,14 @@ export function DNSPage() {
               <span className={styles.infoLabel}>DNS over HTTPS</span>
               <div className={styles.infoValue}>
                 {dohActive ? (
-                  <Stack $gap="var(--space-xs)">
+                  <div className={styles.serverColumn}>
                     <Badge tone="success">
                       <Inline $gap="4px" $align="center">
                         <Check size={12} aria-hidden /> Active
                       </Inline>
                     </Badge>
                     <span className={styles.serverPill}>{info.dohServer}</span>
-                  </Stack>
+                  </div>
                 ) : (
                   <span className={styles.muted}>Disabled</span>
                 )}


### PR DESCRIPTION
## Summary
- DNS page is now read-only by default: static servers listed one per row, `DoH active` badge only when configured, and `Refresh` + `Edit` in the header.
- New `DNSEditDialog` opens on Edit. Servers are managed as dynamic rows with `+`/`−` buttons, a DoH toggle gates the URL input, and inputs include hint placeholders (`1.1.1.1`, `8.8.8.8`, `https://cloudflare-dns.com/dns-query`).

Closes #99