### PR TITLE
feat(fe): change password modal in header dropdown

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ export {
   fetchVPNClients,
   rebootSystem,
   shutdownSystem,
+  changeUserPassword,
   type SystemCredentials,
   type SystemInfoResponse,
   type ResourceInfoResponse,

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -144,6 +144,20 @@ export async function rebootSystem(creds: SystemCredentials): Promise<void> {
   });
 }
 
+export async function changeUserPassword(
+  creds: SystemCredentials,
+  newPassword: string,
+): Promise<void> {
+  await apiRequest<void>('/api/system/password', {
+    method: 'PUT',
+    headers: {
+      ...authHeaders(creds),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ username: creds.username, newPassword }),
+  });
+}
+
 export async function shutdownSystem(creds: SystemCredentials): Promise<void> {
   await apiRequest<void>('/api/system/shutdown', {
     method: 'POST',

--- a/frontend/src/layout/ChangePasswordDialog.module.scss
+++ b/frontend/src/layout/ChangePasswordDialog.module.scss
@@ -1,0 +1,23 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.error {
+  color: var(--color-danger);
+  font-size: 12px;
+  margin: 0;
+}
+
+.hint {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin: 0;
+}

--- a/frontend/src/layout/ChangePasswordDialog.tsx
+++ b/frontend/src/layout/ChangePasswordDialog.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+import { Button, Dialog, PasswordInput, Stack, useToast } from '@nasnet/ui';
+import { ApiError, changeUserPassword } from '../api';
+import { useRouter } from '../state/RouterStoreContext';
+import { useSession } from '../state/SessionContext';
+import styles from './ChangePasswordDialog.module.scss';
+
+export interface ChangePasswordDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ChangePasswordDialog({ open, onClose }: ChangePasswordDialogProps) {
+  const toast = useToast();
+  const { activeRouterId, getCredentials, setCredentials } = useSession();
+  const router = useRouter(activeRouterId ?? undefined);
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setNewPassword('');
+      setConfirmPassword('');
+      setError(null);
+      setSaving(false);
+    }
+  }, [open]);
+
+  const submit = async () => {
+    setError(null);
+    if (!activeRouterId || !router?.host) {
+      setError('No active router. Open a router first.');
+      return;
+    }
+    const creds = getCredentials(activeRouterId);
+    if (!creds) {
+      setError('Session expired. Please reconnect to the router.');
+      return;
+    }
+    if (newPassword.length < 1) {
+      setError('Enter a new password.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+    if (newPassword === creds.password) {
+      setError('New password must be different from the current one.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await changeUserPassword({ host: router.host, ...creds }, newPassword);
+      setCredentials(activeRouterId, { ...creds, password: newPassword });
+      toast.notify({ title: 'Password changed', tone: 'success' });
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to change password.';
+      setError(message);
+      toast.notify({ title: 'Failed to change password', description: message, tone: 'danger' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? () => undefined : onClose}
+      title="Change password"
+      description={
+        router?.name
+          ? `Update the password for "${router.name}".`
+          : 'Update the router login password.'
+      }
+      size="sm"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={submit} disabled={saving}>
+            {saving ? 'Saving…' : 'Change password'}
+          </Button>
+        </>
+      }
+    >
+      <Stack $gap="var(--space-md)">
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="change-password-new">
+            New password
+          </label>
+          <PasswordInput
+            id="change-password-new"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="change-password-confirm">
+            Confirm new password
+          </label>
+          <PasswordInput
+            id="change-password-confirm"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+        {error ? (
+          <p className={styles.error} role="alert">
+            {error}
+          </p>
+        ) : (
+          <p className={styles.hint}>
+            You will stay signed in — the new password is saved for this session.
+          </p>
+        )}
+      </Stack>
+    </Dialog>
+  );
+}

--- a/frontend/src/layout/HeaderActions.tsx
+++ b/frontend/src/layout/HeaderActions.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Bell, ChevronDown, LogOut, Moon, Sun } from 'lucide-react';
+import { Bell, ChevronDown, KeyRound, LogOut, Moon, Sun } from 'lucide-react';
 import { useAppTheme } from '../state/ThemeContext';
+import { ChangePasswordDialog } from './ChangePasswordDialog';
 import styles from './HeaderActions.module.scss';
 
 export interface HeaderActionsProps {
@@ -16,6 +17,7 @@ export function HeaderActions({ routerName }: HeaderActionsProps) {
   const location = useLocation();
   const hideSessionActions = location.pathname === '/' || location.pathname === '/routers/new';
   const [open, setOpen] = useState(false);
+  const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -118,6 +120,18 @@ export function HeaderActions({ routerName }: HeaderActionsProps) {
             type="button"
             role="menuitem"
             className={styles.menuItem}
+            onClick={() => {
+              setOpen(false);
+              setPasswordDialogOpen(true);
+            }}
+          >
+            <KeyRound size={16} aria-hidden />
+            <span>Change password</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={styles.menuItem}
             onClick={goAndClose('/')}
           >
             <LogOut size={16} aria-hidden />
@@ -125,6 +139,10 @@ export function HeaderActions({ routerName }: HeaderActionsProps) {
           </button>
         </div>
       ) : null}
+      <ChangePasswordDialog
+        open={passwordDialogOpen}
+        onClose={() => setPasswordDialogOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a **Change password** item to the header user dropdown.
- Opens a modal with new + confirm password fields, validates locally, and calls `PUT /api/system/password`.
- Refreshes the stored session credential on success so the user stays signed in.
