### PR TITLE
feat(fe): show wifi mode badge on wireless interfaces list

### DIFF
--- a/frontend/src/mocks/types.ts
+++ b/frontend/src/mocks/types.ts
@@ -57,6 +57,7 @@ export interface Interface {
   ssid?: string;
   band?: WirelessBand;
   securityTypes?: string[];
+  mode?: string;
 }
 
 export interface SystemOverview {

--- a/frontend/src/routes/WirelessPage.module.scss
+++ b/frontend/src/routes/WirelessPage.module.scss
@@ -110,3 +110,9 @@
   color: var(--color-text-muted);
   font-size: var(--font-sm);
 }
+
+.modeBadge {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}

--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -11,6 +11,14 @@ interface Props {
   onEdit: (iface: Interface) => void;
 }
 
+const formatMode = (mode: string): string =>
+  mode
+    .split('-')
+    .map((part) =>
+      part.toLowerCase() === 'ap' ? 'AP' : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join(' ');
+
 export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
   const enabled = !iface.disabled;
   return (
@@ -21,6 +29,12 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
       <div>
         <strong>{iface.ssid ?? settings.ssid}</strong>{' '}
         <span className={styles.interfaceName}>({iface.name})</span>
+        {iface.mode ? (
+          <>
+            {' '}
+            <Badge className={styles.modeBadge}>{formatMode(iface.mode)}</Badge>
+          </>
+        ) : null}
         <div>
           {enabled ? (
             iface.running ? (

--- a/frontend/src/routes/wireless/useWireless.ts
+++ b/frontend/src/routes/wireless/useWireless.ts
@@ -45,6 +45,7 @@ const toInterface = (wi: WifiInterfaceResponse): Interface => ({
   ssid: wi.ssid,
   band: toBand(wi.band),
   securityTypes: parseSecurityTypes(wi.securityType),
+  mode: wi.mode,
 });
 
 const toWirelessClient = (c: WifiConnectedClientResponse): WirelessClient => ({


### PR DESCRIPTION
## Summary
Surface the WiFi operating mode (AP, Station, Bridge, etc.) on each row of the wireless interfaces list — previously every interface visually looked like AP regardless of its real role.

Closes #114