### PR TITLE
feat(fe): add UI for adding L2TP VPN clients

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -80,6 +80,7 @@ export { fetchFirewallRules, type FirewallCredentials, type FirewallRule } from 
 export {
   listVPNClients,
   updateVPNClient,
+  addL2TPClient,
   fetchVPNServersStatus,
   fetchOvpnServerDetails,
   fetchPptpServerDetails,
@@ -89,6 +90,7 @@ export {
   type VPNCredentials,
   type VPNClientResponse,
   type UpdateVPNClientRequest,
+  type AddL2TPClientRequest,
   type VPNServersStatusResponse,
   type ServerStatusItem,
   type SingleServerStatus,

--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -29,6 +29,15 @@ export interface UpdateVPNClientRequest {
   comment?: string;
 }
 
+export interface AddL2TPClientRequest {
+  name: string;
+  connectTo: string;
+  user: string;
+  password: string;
+  disabled?: boolean;
+  ipsecSecret?: string;
+}
+
 export interface ServerStatusItem {
   name: string;
   enabled: boolean;
@@ -155,6 +164,19 @@ export async function updateVPNClient(
 ): Promise<VPNClientResponse> {
   return apiRequest<VPNClientResponse>(`/api/vpn/clients/${encodeURIComponent(name)}`, {
     method: 'PUT',
+    headers: authHeaders(creds),
+    body: JSON.stringify(body),
+    signal,
+  });
+}
+
+export async function addL2TPClient(
+  creds: VPNCredentials,
+  body: AddL2TPClientRequest,
+  signal?: AbortSignal,
+): Promise<VPNClientResponse> {
+  return apiRequest<VPNClientResponse>('/api/vpn/l2tp-client', {
+    method: 'POST',
     headers: authHeaders(creds),
     body: JSON.stringify(body),
     signal,

--- a/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
@@ -155,7 +155,13 @@ export function AddVpnClientDialog({ onCancel, onSubmitL2TP }: Props) {
         </FieldRow>
 
         {type === 'l2tp' ? (
-          <L2tpFields draft={draft} set={set} errors={errors} touched={touched} markTouched={markTouched} />
+          <L2tpFields
+            draft={draft}
+            set={set}
+            errors={errors}
+            touched={touched}
+            markTouched={markTouched}
+          />
         ) : null}
 
         {type === 'openvpn' ? <OpenVpnFields draft={draft} set={set} /> : null}
@@ -206,9 +212,7 @@ function L2tpFields({ draft, set, errors, touched, markTouched }: L2tpFieldsProp
             aria-label="Connect to"
             aria-invalid={touched.connectTo && !!errors.connectTo}
           />
-          {touched.connectTo && errors.connectTo ? (
-            <FormError>{errors.connectTo}</FormError>
-          ) : null}
+          {touched.connectTo && errors.connectTo ? <FormError>{errors.connectTo}</FormError> : null}
         </Label>
         <Label>
           <span>User</span>

--- a/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
@@ -1,0 +1,348 @@
+import { useMemo, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  FieldRow,
+  FieldStack,
+  FormError,
+  Input,
+  Label,
+  PasswordInput,
+  Select,
+} from '@nasnet/ui';
+import type { AddL2TPClientRequest } from '../../../api';
+import { validateHostOrIp, validateIdentifier } from '../../../utils/validators';
+
+export type AddVpnType = 'l2tp' | 'openvpn' | 'wireguard';
+
+const TYPE_OPTIONS: Array<{ value: AddVpnType; label: string; supported: boolean }> = [
+  { value: 'l2tp', label: 'L2TP', supported: true },
+  { value: 'openvpn', label: 'OpenVPN', supported: false },
+  { value: 'wireguard', label: 'WireGuard', supported: false },
+];
+
+interface Draft {
+  name: string;
+  connectTo: string;
+  user: string;
+  password: string;
+  ipsecSecret: string;
+  disabled: boolean;
+  // PPTP/SSTP/OpenVPN reuse the auth fields above; SSTP/OpenVPN add port.
+  port: string;
+  // WireGuard-specific.
+  publicKey: string;
+  endpoint: string;
+  endpointPort: string;
+  allowedAddress: string;
+}
+
+const EMPTY_DRAFT: Draft = {
+  name: '',
+  connectTo: '',
+  user: '',
+  password: '',
+  ipsecSecret: '',
+  disabled: false,
+  port: '',
+  publicKey: '',
+  endpoint: '',
+  endpointPort: '',
+  allowedAddress: '',
+};
+
+interface Props {
+  onCancel: () => void;
+  onSubmitL2TP: (req: AddL2TPClientRequest) => Promise<void>;
+}
+
+export function AddVpnClientDialog({ onCancel, onSubmitL2TP }: Props) {
+  const [type, setType] = useState<AddVpnType>('l2tp');
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  const set = <K extends keyof Draft>(key: K, value: Draft[K]) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  const markTouched = (key: string) => setTouched((t) => (t[key] ? t : { ...t, [key]: true }));
+
+  const supported = TYPE_OPTIONS.find((t) => t.value === type)?.supported ?? false;
+
+  const errors = useMemo(
+    () => ({
+      name: validateIdentifier(draft.name),
+      connectTo: validateHostOrIp(draft.connectTo),
+      user: draft.user.trim() === '' ? 'User is required.' : null,
+      password: draft.password === '' ? 'Password is required.' : null,
+    }),
+    [draft.name, draft.connectTo, draft.user, draft.password],
+  );
+
+  const hasErrors = Object.values(errors).some(Boolean);
+  const canSubmit = supported && !submitting && !hasErrors;
+
+  const handleSubmit = async () => {
+    setTouched({ name: true, connectTo: true, user: true, password: true });
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      if (type === 'l2tp') {
+        await onSubmitL2TP({
+          name: draft.name.trim(),
+          connectTo: draft.connectTo.trim(),
+          user: draft.user.trim(),
+          password: draft.password,
+          disabled: draft.disabled,
+          ipsecSecret: draft.ipsecSecret.trim() || undefined,
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add VPN client.');
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={submitting ? () => undefined : onCancel}
+      title="New VPN client"
+      size="md"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? 'Adding…' : 'Add client'}
+          </Button>
+        </>
+      }
+    >
+      <FieldStack>
+        <FieldRow>
+          <Label>
+            <span>VPN type</span>
+            <Select
+              aria-label="VPN type"
+              value={type}
+              onChange={(v) => setType(v as AddVpnType)}
+              options={TYPE_OPTIONS.map((o) => ({
+                value: o.value,
+                label: o.label,
+                disabled: !o.supported,
+              }))}
+            />
+          </Label>
+          <Label>
+            <span>Name</span>
+            <Input
+              value={draft.name}
+              onChange={(e) => set('name', e.target.value)}
+              onBlur={() => markTouched('name')}
+              placeholder="my-l2tp-client"
+              aria-label="Name"
+              aria-invalid={touched.name && !!errors.name}
+            />
+            {touched.name && errors.name ? <FormError>{errors.name}</FormError> : null}
+          </Label>
+        </FieldRow>
+
+        {type === 'l2tp' ? (
+          <L2tpFields draft={draft} set={set} errors={errors} touched={touched} markTouched={markTouched} />
+        ) : null}
+
+        {type === 'openvpn' ? <OpenVpnFields draft={draft} set={set} /> : null}
+
+        {type === 'wireguard' ? <WireguardFields draft={draft} set={set} /> : null}
+
+        <Label as="div">
+          <Checkbox
+            label="Disabled on creation"
+            checked={draft.disabled}
+            onChange={(e) => set('disabled', e.target.checked)}
+          />
+        </Label>
+
+        {error ? <FormError role="alert">{error}</FormError> : null}
+      </FieldStack>
+    </Dialog>
+  );
+}
+
+type SetFn = <K extends keyof Draft>(key: K, value: Draft[K]) => void;
+
+interface FieldErrors {
+  connectTo: string | null;
+  user: string | null;
+  password: string | null;
+}
+
+interface L2tpFieldsProps {
+  draft: Draft;
+  set: SetFn;
+  errors: FieldErrors;
+  touched: Record<string, boolean>;
+  markTouched: (key: string) => void;
+}
+
+function L2tpFields({ draft, set, errors, touched, markTouched }: L2tpFieldsProps) {
+  return (
+    <>
+      <FieldRow>
+        <Label>
+          <span>Connect to</span>
+          <Input
+            value={draft.connectTo}
+            onChange={(e) => set('connectTo', e.target.value)}
+            onBlur={() => markTouched('connectTo')}
+            placeholder="192.168.1.1"
+            aria-label="Connect to"
+            aria-invalid={touched.connectTo && !!errors.connectTo}
+          />
+          {touched.connectTo && errors.connectTo ? (
+            <FormError>{errors.connectTo}</FormError>
+          ) : null}
+        </Label>
+        <Label>
+          <span>User</span>
+          <Input
+            value={draft.user}
+            onChange={(e) => set('user', e.target.value)}
+            onBlur={() => markTouched('user')}
+            placeholder="username"
+            aria-label="User"
+            autoComplete="off"
+            aria-invalid={touched.user && !!errors.user}
+          />
+          {touched.user && errors.user ? <FormError>{errors.user}</FormError> : null}
+        </Label>
+      </FieldRow>
+      <FieldRow>
+        <Label>
+          <span>Password</span>
+          <PasswordInput
+            value={draft.password}
+            onChange={(e) => set('password', e.target.value)}
+            onBlur={() => markTouched('password')}
+            aria-label="Password"
+            autoComplete="new-password"
+            aria-invalid={touched.password && !!errors.password}
+          />
+          {touched.password && errors.password ? <FormError>{errors.password}</FormError> : null}
+        </Label>
+        <Label>
+          <span>IPsec secret (optional)</span>
+          <PasswordInput
+            value={draft.ipsecSecret}
+            onChange={(e) => set('ipsecSecret', e.target.value)}
+            aria-label="IPsec secret"
+            autoComplete="off"
+          />
+        </Label>
+      </FieldRow>
+    </>
+  );
+}
+
+function OpenVpnFields({ draft, set }: { draft: Draft; set: SetFn }) {
+  return (
+    <>
+      <FieldRow>
+        <Label>
+          <span>Connect to</span>
+          <Input
+            value={draft.connectTo}
+            onChange={(e) => set('connectTo', e.target.value)}
+            placeholder="vpn.example.com"
+            aria-label="Connect to"
+          />
+        </Label>
+        <Label>
+          <span>Port</span>
+          <Input
+            value={draft.port}
+            onChange={(e) => set('port', e.target.value)}
+            placeholder="1194"
+            inputMode="numeric"
+            aria-label="Port"
+          />
+        </Label>
+      </FieldRow>
+      <FieldRow>
+        <Label>
+          <span>User</span>
+          <Input
+            value={draft.user}
+            onChange={(e) => set('user', e.target.value)}
+            aria-label="User"
+            autoComplete="off"
+          />
+        </Label>
+        <Label>
+          <span>Password</span>
+          <PasswordInput
+            value={draft.password}
+            onChange={(e) => set('password', e.target.value)}
+            aria-label="Password"
+            autoComplete="new-password"
+          />
+        </Label>
+      </FieldRow>
+    </>
+  );
+}
+
+function WireguardFields({ draft, set }: { draft: Draft; set: SetFn }) {
+  return (
+    <>
+      <FieldRow>
+        <Label>
+          <span>Peer public key</span>
+          <Input
+            value={draft.publicKey}
+            onChange={(e) => set('publicKey', e.target.value)}
+            placeholder="xxxxxxx="
+            aria-label="Peer public key"
+          />
+        </Label>
+        <Label>
+          <span>Allowed address</span>
+          <Input
+            value={draft.allowedAddress}
+            onChange={(e) => set('allowedAddress', e.target.value)}
+            placeholder="0.0.0.0/0"
+            aria-label="Allowed address"
+          />
+        </Label>
+      </FieldRow>
+      <FieldRow>
+        <Label>
+          <span>Endpoint host</span>
+          <Input
+            value={draft.endpoint}
+            onChange={(e) => set('endpoint', e.target.value)}
+            placeholder="vpn.example.com"
+            aria-label="Endpoint host"
+          />
+        </Label>
+        <Label>
+          <span>Endpoint port</span>
+          <Input
+            value={draft.endpointPort}
+            onChange={(e) => set('endpointPort', e.target.value)}
+            placeholder="51820"
+            inputMode="numeric"
+            aria-label="Endpoint port"
+          />
+        </Label>
+      </FieldRow>
+    </>
+  );
+}

--- a/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
   Button,
-  Checkbox,
   Dialog,
   FieldRow,
   FieldStack,
@@ -10,6 +9,7 @@ import {
   Label,
   PasswordInput,
   Select,
+  Switch,
 } from '@nasnet/ui';
 import type { AddL2TPClientRequest } from '../../../api';
 import { validateHostOrIp, validateIdentifier } from '../../../utils/validators';
@@ -27,6 +27,7 @@ interface Draft {
   connectTo: string;
   user: string;
   password: string;
+  useIpsec: boolean;
   ipsecSecret: string;
   disabled: boolean;
   // PPTP/SSTP/OpenVPN reuse the auth fields above; SSTP/OpenVPN add port.
@@ -43,6 +44,7 @@ const EMPTY_DRAFT: Draft = {
   connectTo: '',
   user: '',
   password: '',
+  useIpsec: false,
   ipsecSecret: '',
   disabled: false,
   port: '',
@@ -97,7 +99,7 @@ export function AddVpnClientDialog({ onCancel, onSubmitL2TP }: Props) {
           user: draft.user.trim(),
           password: draft.password,
           disabled: draft.disabled,
-          ipsecSecret: draft.ipsecSecret.trim() || undefined,
+          ipsecSecret: draft.useIpsec ? draft.ipsecSecret.trim() || undefined : undefined,
         });
       }
     } catch (err) {
@@ -168,13 +170,27 @@ export function AddVpnClientDialog({ onCancel, onSubmitL2TP }: Props) {
 
         {type === 'wireguard' ? <WireguardFields draft={draft} set={set} /> : null}
 
-        <Label as="div">
-          <Checkbox
-            label="Disabled on creation"
-            checked={draft.disabled}
-            onChange={(e) => set('disabled', e.target.checked)}
-          />
-        </Label>
+        <FieldRow>
+          <Label as="div">
+            <Switch
+              label="Enabled on creation"
+              checked={!draft.disabled}
+              onChange={(e) => set('disabled', !e.target.checked)}
+            />
+          </Label>
+          {type === 'l2tp' ? (
+            <Label as="div">
+              <Switch
+                label="Use IPsec"
+                checked={draft.useIpsec}
+                onChange={(e) => {
+                  const on = e.target.checked;
+                  setDraft((d) => ({ ...d, useIpsec: on, ipsecSecret: on ? d.ipsecSecret : '' }));
+                }}
+              />
+            </Label>
+          ) : null}
+        </FieldRow>
 
         {error ? <FormError role="alert">{error}</FormError> : null}
       </FieldStack>
@@ -242,12 +258,14 @@ function L2tpFields({ draft, set, errors, touched, markTouched }: L2tpFieldsProp
           {touched.password && errors.password ? <FormError>{errors.password}</FormError> : null}
         </Label>
         <Label>
-          <span>IPsec secret (optional)</span>
+          <span>IPsec secret</span>
           <PasswordInput
             value={draft.ipsecSecret}
             onChange={(e) => set('ipsecSecret', e.target.value)}
+            placeholder="Pre-shared key"
             aria-label="IPsec secret"
             autoComplete="off"
+            disabled={!draft.useIpsec}
           />
         </Label>
       </FieldRow>

--- a/frontend/src/routes/vpn/sections/ClientsSection.tsx
+++ b/frontend/src/routes/vpn/sections/ClientsSection.tsx
@@ -1,9 +1,15 @@
-import { Card, Stack } from '@nasnet/ui';
-import type { VPNClient, VPNCredentials } from '../../../api';
-// import { useState } from 'react';
+import { useState } from 'react';
+import { Card, Stack, useToast } from '@nasnet/ui';
+import {
+  ApiError,
+  addL2TPClient,
+  type AddL2TPClientRequest,
+  type VPNClient,
+  type VPNCredentials,
+} from '../../../api';
 // import { ConfirmDialog } from '@nasnet/ui';
-// import { ClientFormDialog } from '../dialogs/ClientFormDialog';
 // import { useClientActions } from '../hooks/useClientActions';
+import { AddVpnClientDialog } from '../dialogs/AddVpnClientDialog';
 import { PaginationControls } from '../PaginationControls';
 import { usePagedFilter } from '../hooks/usePagedFilter';
 import { PAGE_SIZE } from '../utils';
@@ -24,21 +30,32 @@ interface Props {
 
 export function ClientsSection({ creds, clients, onChanged }: Props) {
   const paged = usePagedFilter(clients, matches);
-  // Add/Edit/Delete are hidden until the backend exposes create/delete endpoints.
-  // const [editing, setEditing] = useState<Partial<VPNClient> | null>(null);
+  const toast = useToast();
+  const [adding, setAdding] = useState(false);
+  // Edit/Delete still hidden until the backend exposes those endpoints.
   // const [deletingId, setDeletingId] = useState<string | null>(null);
-  // const actions = useClientActions(routerId, onChanged);
 
-  // const onSave = async (draft: Partial<VPNClient>) => {
-  //   await actions.save(draft);
-  //   setEditing(null);
-  // };
-
-  // const onConfirmDelete = async () => {
-  //   if (!deletingId) return;
-  //   await actions.remove(deletingId);
-  //   setDeletingId(null);
-  // };
+  const onSubmitL2TP = async (req: AddL2TPClientRequest) => {
+    if (!creds) {
+      toast.notify({ title: 'Not connected to router', tone: 'danger' });
+      return;
+    }
+    try {
+      await addL2TPClient(creds, req);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to add L2TP client.';
+      toast.notify({ title: 'Failed to add VPN client', description: message, tone: 'danger' });
+      throw err;
+    }
+    setAdding(false);
+    toast.notify({ title: `L2TP client "${req.name}" added`, tone: 'success' });
+    onChanged();
+  };
 
   return (
     <Stack>
@@ -53,10 +70,11 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
             ariaLabel: 'Search clients',
             onChange: paged.setSearch,
           }}
-          // action={{
-          //   label: 'Add client',
-          //   onClick: () => setEditing({ protocol: 'wireguard', enabled: true }),
-          // }}
+          action={{
+            label: 'Add client',
+            disabled: !creds,
+            onClick: () => setAdding(true),
+          }}
         />
         <div style={{ marginTop: 16 }}>
           <ClientsTable
@@ -64,8 +82,6 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
             totalRows={clients.length}
             creds={creds}
             onToggled={onChanged}
-            // onEdit={setEditing}
-            // onDelete={setDeletingId}
           />
           <PaginationControls
             page={paged.page}
@@ -77,10 +93,10 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
           />
         </div>
       </Card>
-      {/* {editing ? (
-        <ClientFormDialog value={editing} onCancel={() => setEditing(null)} onSave={onSave} />
+      {adding ? (
+        <AddVpnClientDialog onCancel={() => setAdding(false)} onSubmitL2TP={onSubmitL2TP} />
       ) : null}
-      <ConfirmDialog
+      {/* <ConfirmDialog
         open={!!deletingId}
         title="Delete VPN client"
         destructive

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -34,3 +34,34 @@ export const isWifiPassword = (value: string): boolean => value.length >= 8 && v
 
 export const isRequired = (value: string | undefined | null): boolean =>
   typeof value === 'string' && value.trim().length > 0;
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]+$/;
+const HOSTNAME_RE =
+  /^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/;
+
+export const isIdentifier = (value: string): boolean => {
+  const v = value.trim();
+  return v.length > 0 && v.length <= 64 && IDENTIFIER_RE.test(v);
+};
+
+export const isHostname = (value: string): boolean => HOSTNAME_RE.test(value.trim());
+
+export const isHostOrIp = (value: string): boolean => {
+  const v = value.trim();
+  return isIPv4(v) || isHostname(v);
+};
+
+export function validateIdentifier(value: string): string | null {
+  const v = value.trim();
+  if (!isRequired(v)) return 'Name is required.';
+  if (v.length > 64) return 'Name must be 64 characters or fewer.';
+  if (!IDENTIFIER_RE.test(v)) return 'Use letters, digits, hyphens or underscores only.';
+  return null;
+}
+
+export function validateHostOrIp(value: string): string | null {
+  const v = value.trim();
+  if (!isRequired(v)) return 'Host is required.';
+  if (isIPv4(v) || isHostname(v)) return null;
+  return 'Enter a valid IP address or hostname.';
+}

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -256,7 +256,12 @@ test.describe('VPN clients tab', () => {
     await dialog.getByLabel('Connect to').fill('vpn.example.com');
     await dialog.getByLabel('User').fill('alice');
     await dialog.getByLabel('Password', { exact: true }).fill('s3cret');
-    await dialog.getByLabel('IPsec secret').fill('topsecret');
+
+    const ipsecSecret = dialog.getByLabel('IPsec secret');
+    await expect(ipsecSecret).toBeDisabled();
+    await dialog.getByRole('switch', { name: 'Use IPsec' }).check();
+    await expect(ipsecSecret).toBeEnabled();
+    await ipsecSecret.fill('topsecret');
     await dialog.getByRole('button', { name: 'Add client' }).click();
 
     await expect.poll(() => lastPostBody?.name).toBe('home-l2tp');

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -96,6 +96,183 @@ test.describe('VPN clients tab', () => {
     await expect.poll(() => lastPutBody?.disabled).toBe(false);
   });
 
+  test('validates name and host inputs in add dialog and limits selectable types', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'VPN Router', host: '10.0.0.10' });
+
+    await context.addInitScript((routerId) => {
+      try {
+        const key = 'nasnet-panel.session-credentials.v1';
+        const raw = window.sessionStorage.getItem(key);
+        const map = (raw ? JSON.parse(raw) : {}) as Record<
+          string,
+          { username: string; password: string }
+        >;
+        map[routerId] = { username: 'admin', password: 'test' };
+        window.sessionStorage.setItem(key, JSON.stringify(map));
+      } catch {
+        /* ignore */
+      }
+    }, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([]),
+      });
+    });
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: null,
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Add client' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('combobox', { name: 'VPN type' }).click();
+    await expect(page.getByRole('option', { name: 'L2TP' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'OpenVPN' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    await expect(page.getByRole('option', { name: 'WireGuard' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    await page.getByRole('option', { name: 'L2TP' }).click();
+
+    const submit = dialog.getByRole('button', { name: 'Add client' });
+    await expect(submit).toBeDisabled();
+
+    const name = dialog.getByLabel('Name');
+    await name.fill('bad name');
+    await name.blur();
+    await expect(
+      dialog.getByText('Use letters, digits, hyphens or underscores only.'),
+    ).toBeVisible();
+    await name.fill('home-l2tp');
+
+    const connect = dialog.getByLabel('Connect to');
+    await connect.fill('not a host');
+    await connect.blur();
+    await expect(dialog.getByText('Enter a valid IP address or hostname.')).toBeVisible();
+    await connect.fill('192.168.1.1');
+
+    await dialog.getByLabel('User').fill('alice');
+    await dialog.getByLabel('Password', { exact: true }).fill('s3cret');
+
+    await expect(submit).toBeEnabled();
+  });
+
+  test('submits L2TP client via POST and refreshes the list', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'VPN Router', host: '10.0.0.10' });
+
+    await context.addInitScript((routerId) => {
+      try {
+        const key = 'nasnet-panel.session-credentials.v1';
+        const raw = window.sessionStorage.getItem(key);
+        const map = (raw ? JSON.parse(raw) : {}) as Record<
+          string,
+          { username: string; password: string }
+        >;
+        map[routerId] = { username: 'admin', password: 'test' };
+        window.sessionStorage.setItem(key, JSON.stringify(map));
+      } catch {
+        /* ignore */
+      }
+    }, ROUTER_ID);
+
+    let listCalls = 0;
+    await context.route('**/api/vpn/clients', async (route) => {
+      listCalls += 1;
+      const body = listCalls === 1 ? [] : [{ ...baseClient, disabled: false }];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(body),
+      });
+    });
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: null,
+        }),
+      });
+    });
+
+    let lastPostBody: {
+      name?: string;
+      connectTo?: string;
+      user?: string;
+      password?: string;
+      ipsecSecret?: string;
+      disabled?: boolean;
+    } | null = null;
+    await context.route('**/api/vpn/l2tp-client', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      lastPostBody = route.request().postDataJSON() as typeof lastPostBody;
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: envelope({ ...baseClient, disabled: false }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Add client' }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Name').fill('home-l2tp');
+    await dialog.getByLabel('Connect to').fill('vpn.example.com');
+    await dialog.getByLabel('User').fill('alice');
+    await dialog.getByLabel('Password', { exact: true }).fill('s3cret');
+    await dialog.getByLabel('IPsec secret').fill('topsecret');
+    await dialog.getByRole('button', { name: 'Add client' }).click();
+
+    await expect.poll(() => lastPostBody?.name).toBe('home-l2tp');
+    expect(lastPostBody).toMatchObject({
+      name: 'home-l2tp',
+      connectTo: 'vpn.example.com',
+      user: 'alice',
+      password: 's3cret',
+      ipsecSecret: 'topsecret',
+      disabled: false,
+    });
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByRole('row', { name: /home-l2tp/ })).toBeVisible();
+  });
+
   test('renders empty-state icon when no clients are configured', async ({
     page,
     context,


### PR DESCRIPTION
## Summary

- Add client dialog on VPN page with type selector (L2TP, OpenVPN, WireGuard); only L2TP submits today
- IPsec pre-shared key gated behind a Use IPsec switch; omitted when off so backend leaves IPsec disabled
- Create-state is a switch labelled Enabled on creation, paired beside Use IPsec
- Shared identifier and host/IP validators in utils for reuse
- Playwright e2e covers the add flow