### PR TITLE
feat(fe): remove WPA-PSK from wireless edit dialog

### DIFF
--- a/frontend/src/routes/wireless/WirelessFields.tsx
+++ b/frontend/src/routes/wireless/WirelessFields.tsx
@@ -2,7 +2,6 @@ import { Checkbox, FieldRow, FieldStack, Inline, Input, Label, PasswordInput } f
 import type { WirelessSettings } from '../../api';
 
 const SECURITY_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'wpa-psk', label: 'WPA-PSK' },
   { value: 'wpa2-psk', label: 'WPA2-PSK' },
   { value: 'wpa3-psk', label: 'WPA3-PSK' },
 ];

--- a/frontend/tests/e2e/11-wireless-standalone.spec.ts
+++ b/frontend/tests/e2e/11-wireless-standalone.spec.ts
@@ -25,4 +25,23 @@ test.describe('Wireless standalone', () => {
     await page.getByRole('button', { name: /^edit$/i }).click();
     await expect(page.getByLabel('Password', { exact: true })).toHaveValue('newpass123');
   });
+
+  test('edit dialog shows available security protocols', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockWifiBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_wire', name: 'Wireless Router' });
+    await mockWifiBackend({ id: 'rtr_wire' });
+    await page.goto('/router/rtr_wire/wireless');
+
+    await page.getByRole('button', { name: /^edit$/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByLabel('WPA2-PSK', { exact: true })).toBeVisible();
+    await expect(dialog.getByLabel('WPA3-PSK', { exact: true })).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #123

## Summary
- Drop WPA-PSK from the security protocol options offered when editing a wireless interface (deprecated, low security)
- WPA2-PSK and WPA3-PSK remain selectable; backend handling is untouched
- Add e2e coverage asserting the edit dialog exposes WPA2-PSK and WPA3-PSK