### PR TITLE
chore: collapse renovate minor updates into one PR per dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,9 @@
   "dependencyDashboardApproval": true,
   "minimumReleaseAge": "7 days",
   "separateMajorMinor": true,
-  "separateMinorPatch": true,
+  "separateMinorPatch": false,
   "separateMultipleMajor": true,
-  "separateMultipleMinor": true,
+  "separateMultipleMinor": false,
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Closes #33

## Summary

- Set `separateMinorPatch` and `separateMultipleMinor` to false in `renovate.json`.
- Renovate was opening a branch per intermediate minor version (e.g. docker/dockerfile 1.14 produced 9 dashboard checkboxes for 1.15 through 1.23).
- With this change Renovate consolidates to a single update per dependency, targeting the latest version.