### PR TITLE
feat(fe): wire updates page to backend and refresh UI

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -78,6 +78,14 @@ export {
 } from './dhcp';
 export { fetchFirewallRules, type FirewallCredentials, type FirewallRule } from './firewall';
 export {
+  fetchUpdateInfo,
+  checkForUpdates,
+  installUpdate,
+  type UpdateInfoResponse,
+  type UpdateCheckResponse,
+  type UpdateInstallResponse,
+} from './updates';
+export {
   listVPNClients,
   updateVPNClient,
   addL2TPClient,

--- a/frontend/src/api/updates.ts
+++ b/frontend/src/api/updates.ts
@@ -1,0 +1,65 @@
+import { apiRequest } from './http';
+import type { SystemCredentials } from './system';
+
+export interface UpdateInfoResponse {
+  version: string;
+  buildTime: string;
+  channel: string;
+  updatePolicy: string;
+  currentTime: string;
+  installTime: string;
+  scheduledTime: string;
+}
+
+export interface UpdateCheckResponse {
+  channel: string;
+  installedVersion: string;
+  latestVersion: string;
+  status: string;
+  updateAvailable: boolean;
+}
+
+export interface UpdateInstallResponse {
+  success: boolean;
+  message: string;
+  installedVersion: string;
+  latestVersion: string;
+}
+
+function authHeaders({ host, username, password }: SystemCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function fetchUpdateInfo(
+  creds: SystemCredentials,
+  signal?: AbortSignal,
+): Promise<UpdateInfoResponse> {
+  return apiRequest<UpdateInfoResponse>('/api/system/updates', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}
+
+export async function checkForUpdates(
+  creds: SystemCredentials,
+  signal?: AbortSignal,
+): Promise<UpdateCheckResponse> {
+  return apiRequest<UpdateCheckResponse>('/api/system/check-for-updates', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}
+
+export async function installUpdate(creds: SystemCredentials): Promise<UpdateInstallResponse> {
+  return apiRequest<UpdateInstallResponse>('/api/system/install-update', {
+    method: 'POST',
+    headers: authHeaders(creds),
+  });
+}

--- a/frontend/src/layout/AppHeader.tsx
+++ b/frontend/src/layout/AppHeader.tsx
@@ -1,13 +1,15 @@
 import { Link } from 'react-router-dom';
 import { HeaderActions } from './HeaderActions';
 import { useSession } from '../state/SessionContext';
-import { useRouter } from '../state/RouterStoreContext';
+import { useRouter, useRouterStore } from '../state/RouterStoreContext';
 import styles from './AppHeader.module.scss';
 
 export function AppHeader() {
   const { activeRouterId } = useSession();
-  const router = useRouter(activeRouterId ?? undefined);
-  const logoTarget = activeRouterId ? `/router/${activeRouterId}` : '/';
+  const { lastConnectedRouterId, selectedRouterId } = useRouterStore();
+  const targetId = activeRouterId ?? lastConnectedRouterId ?? selectedRouterId ?? null;
+  const router = useRouter(targetId ?? undefined);
+  const logoTarget = targetId ? `/router/${targetId}` : '/';
   return (
     <header className={styles.headerRoot}>
       <div className={styles.wrap}>

--- a/frontend/src/routes/UpdatesPage.module.scss
+++ b/frontend/src/routes/UpdatesPage.module.scss
@@ -105,35 +105,96 @@
   flex-wrap: wrap;
 }
 
-.versionGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: var(--space-md);
-  padding: var(--space-md);
-  background: var(--color-surface-alt);
-  border-radius: var(--radius-md);
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
 }
 
-.versionCell {
+.metaPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+
+  span {
+    color: var(--color-text);
+  }
+}
+
+.versionTrack {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-md);
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.versionStop {
+  flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 6px;
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.versionStopMatched {
+  border-color: rgba(62, 194, 141, 0.35);
+  background: rgba(62, 194, 141, 0.05);
+}
+
+.versionStopHighlight {
+  border-color: rgba(224, 168, 46, 0.45);
+  background: rgba(224, 168, 46, 0.08);
+  box-shadow: 0 0 0 4px rgba(224, 168, 46, 0.08);
+}
+
+.versionStopLabel {
+  display: inline-flex;
+  align-items: center;
   gap: 4px;
-  min-width: 0;
-}
-
-.versionLabel {
   font-size: var(--font-xs);
-  color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: var(--weight-medium);
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  font-weight: var(--weight-semibold);
 }
 
-.versionValue {
+.versionStopValue {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: var(--font-sm);
+  font-size: var(--font-md, 1rem);
+  font-weight: var(--weight-semibold);
   color: var(--color-text);
-  word-break: break-all;
+  letter-spacing: 0.02em;
+}
+
+.versionArrow {
+  align-self: center;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+
+  @media (max-width: 480px) {
+    transform: rotate(90deg);
+  }
+}
+
+.versionArrowActive {
+  color: var(--color-warning);
 }
 
 .changelog {

--- a/frontend/src/routes/UpdatesPage.tsx
+++ b/frontend/src/routes/UpdatesPage.tsx
@@ -40,6 +40,7 @@ import { useSession } from '../state/SessionContext';
 import { RouterTabBar } from '../layout/RouterTabBar';
 import styles from './UpdatesPage.module.scss';
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __APP_VERSION__: string;
 
 function VersionTrackSkeleton() {

--- a/frontend/src/routes/UpdatesPage.tsx
+++ b/frontend/src/routes/UpdatesPage.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AppWindow,
+  ArrowRight,
+  CalendarClock,
+  Check,
   CheckCircle2,
   Download,
-  HardDriveDownload,
+  GitBranch,
   Loader2,
-  RefreshCw,
   Router as RouterIcon,
+  Sparkles,
+  Tag,
 } from 'lucide-react';
 import {
   Badge,
@@ -18,14 +22,60 @@ import {
   PageSubtitle,
   PageTitle,
   Progress,
-  Select,
+  Skeleton,
   Stack,
   useToast,
 } from '@nasnet/ui';
-import { api, type AppUpdateInfo, type FirmwareUpdateInfo, type Router } from '../api';
+import {
+  api,
+  checkForUpdates,
+  fetchUpdateInfo,
+  installUpdate,
+  type AppUpdateInfo,
+  type UpdateCheckResponse,
+  type UpdateInfoResponse,
+} from '../api';
 import { useRouterStore } from '../state/RouterStoreContext';
+import { useSession } from '../state/SessionContext';
 import { RouterTabBar } from '../layout/RouterTabBar';
 import styles from './UpdatesPage.module.scss';
+
+declare const __APP_VERSION__: string;
+
+function VersionTrackSkeleton() {
+  return (
+    <div className={styles.versionTrack} aria-busy>
+      <div className={styles.versionStop}>
+        <Skeleton width={64} height={10} />
+        <Skeleton width={96} height={18} style={{ marginTop: 8 }} />
+      </div>
+      <ArrowRight size={20} aria-hidden className={styles.versionArrow} />
+      <div className={styles.versionStop}>
+        <Skeleton width={64} height={10} />
+        <Skeleton width={96} height={18} style={{ marginTop: 8 }} />
+      </div>
+    </div>
+  );
+}
+
+function MetaRowSkeleton() {
+  return (
+    <div className={styles.metaRow} aria-busy>
+      <Skeleton width={120} height={26} radius={999} />
+      <Skeleton width={90} height={26} radius={999} />
+    </div>
+  );
+}
+
+function RouterOSIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 41.83 44.62" width={size} height={size} fill="currentColor" aria-hidden>
+      <path d="M11.71,21.59c-.09-.1-.19-.19-.31-.26l-2.95-1.63c-.11-.06-.22-.07-.32-.05-.27-.02-.53.18-.53.48v7.99c0,.72.39,1.39,1.03,1.74l2.7,1.48c.33.18.73-.06.73-.43v-8.58c0-.29-.13-.55-.34-.74Z" />
+      <path d="M33.21,14.78l-10.19-5.58-1.31-.72c-.52-.29-1.16-.29-1.69,0l-2.9,1.6c-.1.05-.16.13-.21.22-.17.23-.12.57.15.72l8.62,4.72c.3.22.29.68-.05.87l-3.81,2.11c-.52.29-1.16.29-1.69,0l-8.48-4.69c-.52-.29-1.16-.29-1.69,0l-1.4.77c-.28.16-.51.39-.66.65-.2.31-.32.68-.32,1.06v.52l6.44,3.53,3.73,2.06s.06.05.09.07c.09.06.17.12.25.19.24.23.4.52.5.83.04.14.06.29.06.44v10.66c0,.26.12.49.31.66.07.08.15.14.24.2l.76.42c.59.33,1.31.33,1.91,0l.76-.42c.17-.09.31-.24.39-.41.1-.14.15-.31.15-.49v-10.55c0-.63.34-1.22.9-1.53l4.95-2.73c.32-.18.7.03.75.38v10.57c0,.38.4.62.73.43l2.7-1.48c.64-.35,1.03-1.02,1.03-1.74v-11.61c0-.72-.4-1.39-1.03-1.74Z" />
+      <path d="M39.33,9.57L23.3.62c-1.48-.83-3.28-.83-4.76,0L2.5,9.57c-1.54.86-2.5,2.49-2.5,4.26v17.08c0,1.78.97,3.42,2.53,4.28l16.04,8.82c1.46.81,3.24.81,4.7,0l16.04-8.82c1.56-.86,2.53-2.5,2.53-4.28V13.83c0-1.77-.96-3.4-2.5-4.26ZM36.95,32.33l-15.01,8.26c-.64.35-1.41.35-2.05,0l-15.01-8.26c-.68-.37-1.1-1.09-1.1-1.86V14.27c0-.77.42-1.48,1.09-1.86l15.01-8.38c.64-.36,1.43-.36,2.07,0l15.01,8.38c.67.38,1.09,1.09,1.09,1.86v16.2c0,.78-.42,1.49-1.1,1.86Z" />
+    </svg>
+  );
+}
 
 export function UpdatesPage() {
   const [appInfo, setAppInfo] = useState<AppUpdateInfo | null>(null);
@@ -49,52 +99,12 @@ export function UpdatesPage() {
           </div>
         </PageHeader>
 
-        <SummaryStrip appInfo={appInfo} />
-
         <div className={styles.cardGrid}>
           <AppUpdateCard info={appInfo} reload={reloadApp} />
           <FirmwareUpdateCard />
         </div>
       </PageShell>
     </>
-  );
-}
-
-function SummaryStrip({ appInfo }: { appInfo: AppUpdateInfo | null }) {
-  const appUpToDate = appInfo ? !appInfo.updateAvailable : null;
-
-  return (
-    <div className={styles.summaryGrid}>
-      <Card className={styles.summaryCard}>
-        <span
-          className={`${styles.summaryIcon} ${
-            appUpToDate === null
-              ? styles.summaryIconInfo
-              : appUpToDate
-                ? styles.summaryIconSuccess
-                : styles.summaryIconWarning
-          }`}
-        >
-          <AppWindow size={20} aria-hidden />
-        </span>
-        <div className={styles.summaryBody}>
-          <span className={styles.summaryLabel}>App</span>
-          <span className={styles.summaryValue}>
-            {appInfo === null ? 'Checking…' : appUpToDate ? 'Up to date' : 'Update available'}
-          </span>
-        </div>
-      </Card>
-
-      <Card className={styles.summaryCard}>
-        <span className={`${styles.summaryIcon} ${styles.summaryIconInfo}`}>
-          <HardDriveDownload size={20} aria-hidden />
-        </span>
-        <div className={styles.summaryBody}>
-          <span className={styles.summaryLabel}>RouterOS firmware</span>
-          <span className={styles.summaryValue}>Per-router check</span>
-        </div>
-      </Card>
-    </div>
   );
 }
 
@@ -132,15 +142,15 @@ function AppUpdateCard({
               <h3 style={{ margin: 0 }}>App update</h3>
             </div>
           </div>
-          <p className={styles.emptyNote}>
-            <Loader2 size={14} aria-hidden /> Checking for updates…
-          </p>
+          <VersionTrackSkeleton />
         </Stack>
       </Card>
     );
   }
 
   const installing = progress !== null && !complete;
+  const currentVersion = __APP_VERSION__;
+  const updateAvailable = info.latestVersion !== currentVersion;
 
   return (
     <Card>
@@ -154,28 +164,60 @@ function AppUpdateCard({
               <h3 style={{ margin: 0 }}>App update</h3>
             </div>
             <p style={{ margin: 0, color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>
-              {info.updateAvailable
+              {updateAvailable
                 ? 'A newer version of Nasnet Panel is available.'
                 : 'You are running the latest version.'}
             </p>
           </div>
           <span className={styles.badgeRow}>
-            <Badge tone={info.updateAvailable ? 'warning' : 'success'}>
-              {info.updateAvailable ? 'update available' : 'up to date'}
+            <Badge tone={updateAvailable ? 'warning' : 'success'}>
+              {updateAvailable ? null : (
+                <Check
+                  size={12}
+                  strokeWidth={2.5}
+                  aria-hidden
+                  style={{ marginRight: 4, verticalAlign: '-2px' }}
+                />
+              )}
+              {updateAvailable ? 'update available' : 'up to date'}
             </Badge>
           </span>
         </div>
 
-        <div className={styles.versionGrid}>
-          <div className={styles.versionCell}>
-            <span className={styles.versionLabel}>Current</span>
-            <span className={styles.versionValue} data-testid="app-current-version">
-              {info.currentVersion}
+        <div className={styles.metaRow}>
+          <div className={styles.metaPill}>
+            <Tag size={14} aria-hidden />
+            <span>v{currentVersion}</span>
+          </div>
+          <div className={styles.metaPill}>
+            <GitBranch size={14} aria-hidden />
+            <span>stable</span>
+          </div>
+        </div>
+
+        <div className={styles.versionTrack}>
+          <div className={styles.versionStop}>
+            <span className={styles.versionStopLabel}>
+              <Tag size={12} aria-hidden /> Current
+            </span>
+            <span className={styles.versionStopValue} data-testid="app-current-version">
+              {currentVersion}
             </span>
           </div>
-          <div className={styles.versionCell}>
-            <span className={styles.versionLabel}>Latest</span>
-            <span className={styles.versionValue} data-testid="app-latest-version">
+          <ArrowRight
+            size={20}
+            aria-hidden
+            className={`${styles.versionArrow} ${updateAvailable ? styles.versionArrowActive : ''}`}
+          />
+          <div
+            className={`${styles.versionStop} ${
+              updateAvailable ? styles.versionStopHighlight : styles.versionStopMatched
+            }`}
+          >
+            <span className={styles.versionStopLabel}>
+              <Sparkles size={12} aria-hidden /> Latest
+            </span>
+            <span className={styles.versionStopValue} data-testid="app-latest-version">
               {info.latestVersion}
             </span>
           </div>
@@ -193,10 +235,7 @@ function AppUpdateCard({
         ) : null}
 
         <div className={styles.actions}>
-          <Button variant="ghost" size="sm" onClick={reload} disabled={installing}>
-            <RefreshCw size={14} aria-hidden /> Check again
-          </Button>
-          <Button onClick={install} disabled={!info.updateAvailable || installing}>
+          <Button variant="success" onClick={install} disabled={!updateAvailable || installing}>
             {installing ? (
               <>
                 <Loader2 size={14} aria-hidden /> Installing…
@@ -214,59 +253,118 @@ function AppUpdateCard({
 }
 
 function FirmwareUpdateCard() {
-  const { routers } = useRouterStore();
-  const sorted = useMemo(
-    () => [...routers].sort((a, b) => a.name.localeCompare(b.name)),
-    [routers],
+  const { routers, lastConnectedRouterId, selectedRouterId } = useRouterStore();
+  const { activeRouterId, getCredentials } = useSession();
+  const targetId = activeRouterId ?? lastConnectedRouterId ?? selectedRouterId ?? null;
+  const targetRouter = useMemo(
+    () => (targetId ? routers.find((r) => r.id === targetId) : undefined),
+    [routers, targetId],
   );
-  const [selectedId, setSelectedId] = useState<string>(sorted[0]?.id ?? '');
-  const [info, setInfo] = useState<FirmwareUpdateInfo | null>(null);
+  const creds = targetId ? getCredentials(targetId) : undefined;
+  const host = targetRouter?.host;
+  const ready = Boolean(targetId && creds && host);
+
+  const [check, setCheck] = useState<UpdateCheckResponse | null>(null);
+  const [meta, setMeta] = useState<UpdateInfoResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
-  const [progress, setProgress] = useState<number | null>(null);
+  const [installing, setInstalling] = useState(false);
   const [complete, setComplete] = useState(false);
   const toast = useToast();
 
   const reload = useCallback(async () => {
-    if (!selectedId) {
-      setInfo(null);
+    if (!creds || !host) {
+      setCheck(null);
+      setMeta(null);
       return;
     }
-    const data = await api.updates.checkFirmware(selectedId);
-    setInfo(data);
-  }, [selectedId]);
+    setLoading(true);
+    setError(null);
+    try {
+      const [c, m] = await Promise.all([
+        checkForUpdates({ host, ...creds }),
+        fetchUpdateInfo({ host, ...creds }).catch(() => null),
+      ]);
+      setCheck(c);
+      setMeta(m);
+      setComplete(false);
+    } catch (err) {
+      setCheck(null);
+      setMeta(null);
+      setError(err instanceof Error ? err.message : 'Failed to check for updates');
+    } finally {
+      setLoading(false);
+    }
+  }, [host, creds]);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      if (!selectedId) {
-        setInfo(null);
+      if (!creds || !host) {
+        setCheck(null);
+        setMeta(null);
         return;
       }
-      const data = await api.updates.checkFirmware(selectedId);
-      if (!cancelled) setInfo(data);
+      setLoading(true);
+      setError(null);
+      try {
+        const [c, m] = await Promise.all([
+          checkForUpdates({ host, ...creds }),
+          fetchUpdateInfo({ host, ...creds }).catch(() => null),
+        ]);
+        if (cancelled) return;
+        setCheck(c);
+        setMeta(m);
+        setComplete(false);
+      } catch (err) {
+        if (cancelled) return;
+        setCheck(null);
+        setMeta(null);
+        setError(err instanceof Error ? err.message : 'Failed to check for updates');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, [selectedId]);
-
-  useEffect(() => {
-    if (!selectedId && sorted.length > 0) setSelectedId(sorted[0].id);
-  }, [selectedId, sorted]);
+  }, [host, creds]);
 
   const install = async () => {
     setConfirming(false);
-    setProgress(0);
+    if (!creds || !host) return;
+    setInstalling(true);
     setComplete(false);
-    for await (const pct of api.updates.installFirmware(selectedId)) {
-      setProgress(pct);
+    try {
+      const result = await installUpdate({ host, ...creds });
+      setComplete(true);
+      if (result.success) {
+        toast.notify({
+          title: 'Firmware update started',
+          description: result.message || 'Router will reboot to apply the update.',
+          tone: 'success',
+        });
+      } else {
+        toast.notify({
+          title: 'Firmware update failed',
+          description: result.message,
+          tone: 'danger',
+        });
+      }
+      await reload();
+    } catch (err) {
+      toast.notify({
+        title: 'Firmware update failed',
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+    } finally {
+      setInstalling(false);
     }
-    setComplete(true);
-    toast.notify({ title: 'Firmware update complete', tone: 'success' });
   };
 
-  const installing = progress !== null && !complete;
-  const selectedRouter = sorted.find((r: Router) => r.id === selectedId);
+  const channel = meta?.channel || check?.channel;
 
   return (
     <Card>
@@ -275,90 +373,116 @@ function FirmwareUpdateCard() {
           <div className={styles.cardHeaderLeft}>
             <div className={styles.cardHeaderTitleRow}>
               <span className={styles.cardHeaderIcon}>
-                <HardDriveDownload size={18} aria-hidden />
+                <RouterOSIcon size={18} />
               </span>
               <h3 style={{ margin: 0 }}>RouterOS firmware</h3>
             </div>
             <p style={{ margin: 0, color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>
-              Pick a router, then install the latest RouterOS release.
+              {targetRouter
+                ? `Install the latest RouterOS release on ${targetRouter.name}.`
+                : 'Connect to a router to check firmware.'}
             </p>
           </div>
-          {info ? (
+          {check ? (
             <span className={styles.badgeRow}>
-              <Badge tone={info.updateAvailable ? 'warning' : 'success'}>
-                {info.updateAvailable ? 'update available' : 'up to date'}
+              <Badge tone={check.updateAvailable ? 'warning' : 'success'}>
+                {check.updateAvailable ? null : (
+                  <Check
+                    size={12}
+                    strokeWidth={2.5}
+                    aria-hidden
+                    style={{ marginRight: 4, verticalAlign: '-2px' }}
+                  />
+                )}
+                {check.updateAvailable ? 'update available' : 'up to date'}
               </Badge>
             </span>
           ) : null}
         </div>
 
-        {sorted.length === 0 ? (
-          <p className={styles.emptyNote}>No routers added yet. Add a router to check firmware.</p>
+        {!ready ? (
+          <p className={styles.emptyNote}>
+            Connect to a router first to check for firmware updates.
+          </p>
         ) : (
           <>
-            <Select
-              aria-label="Router"
-              value={selectedId}
-              onChange={(v) => setSelectedId(v)}
-              placeholder="Select a router…"
-              options={sorted.map((r: Router) => ({
-                value: r.id,
-                label: `${r.name}${r.host ? ` · ${r.host}` : ''}`,
-              }))}
-            />
+            {loading && !check ? (
+              <>
+                <MetaRowSkeleton />
+                <VersionTrackSkeleton />
+              </>
+            ) : null}
 
-            {info ? (
-              <div className={styles.versionGrid}>
-                <div className={styles.versionCell}>
-                  <span className={styles.versionLabel}>Router</span>
-                  <span className={styles.versionValue}>
-                    <RouterIcon size={12} aria-hidden /> {selectedRouter?.name ?? '—'}
-                  </span>
+            {error ? <p className={styles.emptyNote}>{error}</p> : null}
+
+            {check ? (
+              <>
+                <div className={styles.metaRow}>
+                  <div className={styles.metaPill}>
+                    <RouterIcon size={14} aria-hidden />
+                    <span>{targetRouter?.name ?? '—'}</span>
+                  </div>
+                  <div className={styles.metaPill}>
+                    <RouterIcon size={14} aria-hidden />
+                    <span>{channel || '—'}</span>
+                  </div>
+                  {meta?.scheduledTime ? (
+                    <div className={styles.metaPill}>
+                      <CalendarClock size={14} aria-hidden />
+                      <span>{meta.scheduledTime}</span>
+                    </div>
+                  ) : null}
                 </div>
-                <div className={styles.versionCell}>
-                  <span className={styles.versionLabel}>Channel</span>
-                  <span className={styles.versionValue}>{info.currentChannel}</span>
+
+                <div className={styles.versionTrack}>
+                  <div className={styles.versionStop}>
+                    <span className={styles.versionStopLabel}>
+                      <Tag size={12} aria-hidden /> Current
+                    </span>
+                    <span className={styles.versionStopValue}>{check.installedVersion || '—'}</span>
+                  </div>
+                  <ArrowRight
+                    size={20}
+                    aria-hidden
+                    className={`${styles.versionArrow} ${
+                      check.updateAvailable ? styles.versionArrowActive : ''
+                    }`}
+                  />
+                  <div
+                    className={`${styles.versionStop} ${
+                      check.updateAvailable
+                        ? styles.versionStopHighlight
+                        : styles.versionStopMatched
+                    }`}
+                  >
+                    <span className={styles.versionStopLabel}>
+                      <Sparkles size={12} aria-hidden /> Latest
+                    </span>
+                    <span className={styles.versionStopValue}>{check.latestVersion || '—'}</span>
+                  </div>
                 </div>
-                <div className={styles.versionCell}>
-                  <span className={styles.versionLabel}>Current</span>
-                  <span className={styles.versionValue}>{info.currentVersion}</span>
-                </div>
-                <div className={styles.versionCell}>
-                  <span className={styles.versionLabel}>Latest</span>
-                  <span className={styles.versionValue}>{info.latestVersion}</span>
-                </div>
+              </>
+            ) : null}
+
+            {check?.updateAvailable ? (
+              <div className={styles.actions}>
+                <Button variant="success" onClick={() => setConfirming(true)} disabled={installing}>
+                  {installing ? (
+                    <>
+                      <Loader2 size={14} aria-hidden /> Installing…
+                    </>
+                  ) : complete ? (
+                    <>
+                      <CheckCircle2 size={14} aria-hidden /> Done
+                    </>
+                  ) : (
+                    <>
+                      <Download size={14} aria-hidden /> Install firmware
+                    </>
+                  )}
+                </Button>
               </div>
             ) : null}
-
-            {progress !== null ? (
-              <Progress value={progress} label={complete ? 'Done' : 'Installing firmware'} />
-            ) : null}
-
-            <div className={styles.actions}>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={reload}
-                disabled={installing || !selectedId}
-              >
-                <RefreshCw size={14} aria-hidden /> Check again
-              </Button>
-              <Button onClick={() => setConfirming(true)} disabled={!info || installing}>
-                {installing ? (
-                  <>
-                    <Loader2 size={14} aria-hidden /> Installing…
-                  </>
-                ) : complete ? (
-                  <>
-                    <CheckCircle2 size={14} aria-hidden /> Done
-                  </>
-                ) : (
-                  <>
-                    <Download size={14} aria-hidden /> Install firmware
-                  </>
-                )}
-              </Button>
-            </div>
           </>
         )}
       </Stack>

--- a/frontend/tests/e2e/13-updates-app-and-firmware.spec.ts
+++ b/frontend/tests/e2e/13-updates-app-and-firmware.spec.ts
@@ -14,13 +14,87 @@ test.describe('Updates page', () => {
     await expect(page.getByText(/update complete/i)).toBeVisible();
   });
 
-  test('firmware update flow requires confirmation', async ({ page, resetMocks, seedRouter }) => {
+  test('firmware update flow requires confirmation', async ({
+    context,
+    page,
+    resetMocks,
+    seedRouter,
+  }) => {
     await resetMocks();
-    await seedRouter({ id: 'rtr_upd', name: 'Update Router' });
+    await seedRouter({ id: 'rtr_upd', name: 'Update Router', host: '192.168.88.1' });
+
+    await context.addInitScript((routerId: string) => {
+      try {
+        const credKey = 'nasnet-panel.session-credentials.v1';
+        window.sessionStorage.setItem(
+          credKey,
+          JSON.stringify({ [routerId]: { username: 'admin', password: 'test' } }),
+        );
+        const storeKey = 'nasnet-panel.router-store.v1';
+        window.localStorage.setItem(
+          storeKey,
+          JSON.stringify({
+            routers: [{ id: routerId, name: 'Update Router', host: '192.168.88.1' }],
+            selectedRouterId: null,
+            lastConnectedRouterId: routerId,
+          }),
+        );
+      } catch {
+        /* ignore */
+      }
+    }, 'rtr_upd');
+
+    const envelope = <T>(data: T) => JSON.stringify({ status: 200, message: 'OK', data });
+
+    await context.route('**/api/system/check-for-updates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          channel: 'stable',
+          installedVersion: '7.14',
+          latestVersion: '7.15',
+          status: 'New version is available',
+          updateAvailable: true,
+        }),
+      });
+    });
+
+    await context.route('**/api/system/updates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          version: '7.14',
+          buildTime: 'Jan/10/2026 15:30:00',
+          channel: 'stable',
+          updatePolicy: 'manual',
+          currentTime: 'Jan/10/2026 16:00:00',
+          installTime: '',
+          scheduledTime: '',
+        }),
+      });
+    });
+
+    await context.route('**/api/system/install-update', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          success: true,
+          message: 'Update started',
+          installedVersion: '7.14',
+          latestVersion: '7.15',
+        }),
+      });
+    });
+
     await page.goto('/updates');
+
     await page.getByRole('button', { name: /install firmware/i }).click();
     await expect(page.getByRole('dialog')).toBeVisible();
     await page.getByRole('button', { name: /^confirm$/i }).click();
-    await expect(page.getByText(/firmware update complete/i)).toBeVisible();
+    await expect(page.getByText(/firmware update started/i)).toBeVisible();
   });
 });

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -6,6 +6,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 module.exports = (_env, argv) => {
   const isProduction = argv.mode === 'production';
   const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+  const appVersion = require('../package.json').version;
 
   return {
     mode: isProduction ? 'production' : 'development',
@@ -70,6 +71,7 @@ module.exports = (_env, argv) => {
     plugins: [
       new webpack.DefinePlugin({
         __BACKEND_URL__: JSON.stringify(backendUrl),
+        __APP_VERSION__: JSON.stringify(appVersion),
       }),
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, 'public', 'index.html'),


### PR DESCRIPTION
## Summary
- Wire firmware update card to real RouterOS update endpoints; scope to the logged-in router.
- Pull app current version from package.json via webpack define.
- Skeleton loaders, GitHub-style pills, Current to Latest track, green install buttons.