### PR TITLE
feat(fe): show L2TP client details modal on name click

### DIFF
--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -51,12 +51,25 @@ export interface L2TPClientDetailsResponse {
   name: string;
   disabled: boolean;
   running: boolean;
+  maxMtu: number;
+  maxMru: number;
+  mrru: string;
   connectTo: string;
   user: string;
   password: string;
   profile: string;
+  keepaliveTimeout: number;
+  usePeerDns: boolean;
   useIPsec: boolean;
   ipsecSecret: string;
+  allowFastPath: boolean;
+  addDefaultRoute: boolean;
+  dialOnDemand: boolean;
+  allow: string;
+  randomSourcePort: boolean;
+  l2tpProtoVersion: string;
+  l2tpv3DigestHash: string;
+  addRoutes: boolean;
   comment: string;
 }
 

--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -71,6 +71,14 @@ export interface L2TPClientDetailsResponse {
   l2tpv3DigestHash: string;
   addRoutes: boolean;
   comment: string;
+  status: string;
+  uptime: string;
+  encoding: string;
+  mtu: number;
+  localAddress: string;
+  remoteAddress: string;
+  localIpv6Address: string;
+  remoteIpv6Address: string;
 }
 
 export interface ServerStatusItem {

--- a/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { Badge, Button, Dialog } from '@nasnet/ui';
+import {
+  ApiError,
+  fetchL2TPClientDetails,
+  isAbortError,
+  type L2TPClientDetailsResponse,
+  type VPNCredentials,
+} from '../../../api';
+
+interface Props {
+  clientName: string | null;
+  creds: VPNCredentials | null;
+  onClose: () => void;
+}
+
+export function L2tpClientDetailsDialog({ clientName, creds, onClose }: Props) {
+  const [details, setDetails] = useState<L2TPClientDetailsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!clientName || !creds) return;
+    const controller = new AbortController();
+    setDetails(null);
+    setError(null);
+    setLoading(true);
+
+    (async () => {
+      try {
+        const data = await fetchL2TPClientDetails(creds, clientName, controller.signal);
+        setDetails(data);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        const message =
+          err instanceof ApiError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : 'Failed to load L2TP client details.';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [clientName, creds]);
+
+  return (
+    <Dialog
+      open={!!clientName}
+      onClose={onClose}
+      title={clientName ? `L2TP client: ${clientName}` : ''}
+      size="lg"
+      footer={
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      {loading ? <p>Loading…</p> : null}
+      {error ? <p style={{ color: 'var(--color-danger)' }}>{error}</p> : null}
+      {details ? (
+        <DList>
+          <Row label="Name" value={details.name} />
+          <Row label="Enabled" value={<BoolBadge value={!details.disabled} />} />
+          <Row label="Running" value={<BoolBadge value={details.running} />} />
+          <Row label="Connect to" value={details.connectTo} />
+          <Row label="User" value={details.user} />
+          <Row label="Password" value={details.password ? <code>{details.password}</code> : '–'} />
+          <Row label="Profile" value={details.profile} />
+          <Row label="Allow" value={details.allow} />
+          <Row label="Max MTU" value={details.maxMtu} />
+          <Row label="Max MRU" value={details.maxMru} />
+          <Row label="MRRU" value={details.mrru} />
+          <Row label="Keepalive timeout" value={`${details.keepaliveTimeout}s`} />
+          <Row label="L2TP version" value={details.l2tpProtoVersion} />
+          <Row label="L2TPv3 digest" value={details.l2tpv3DigestHash} />
+          <Row label="Use peer DNS" value={<BoolBadge value={details.usePeerDns} />} />
+          <Row label="Use IPsec" value={<BoolBadge value={details.useIPsec} />} />
+          <Row
+            label="IPsec secret"
+            value={details.ipsecSecret ? <code>{details.ipsecSecret}</code> : '–'}
+            wide
+          />
+          <Row label="Allow fast path" value={<BoolBadge value={details.allowFastPath} />} />
+          <Row label="Add default route" value={<BoolBadge value={details.addDefaultRoute} />} />
+          <Row label="Add routes" value={<BoolBadge value={details.addRoutes} />} />
+          <Row label="Dial on demand" value={<BoolBadge value={details.dialOnDemand} />} />
+          <Row label="Random source port" value={<BoolBadge value={details.randomSourcePort} />} />
+          {details.comment ? <Row label="Comment" value={details.comment} wide /> : null}
+        </DList>
+      ) : null}
+    </Dialog>
+  );
+}
+
+function DList({ children }: { children: React.ReactNode }) {
+  return (
+    <dl
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '140px minmax(0, 1fr) 140px minmax(0, 1fr)',
+        rowGap: 8,
+        columnGap: 16,
+        margin: 0,
+      }}
+    >
+      {children}
+    </dl>
+  );
+}
+
+function Row({ label, value, wide }: { label: string; value: React.ReactNode; wide?: boolean }) {
+  const empty = value === '' || value === null || value === undefined;
+  return (
+    <>
+      <dt style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>{label}</dt>
+      <dd
+        style={{
+          margin: 0,
+          fontSize: 'var(--font-sm)',
+          wordBreak: 'break-all',
+          gridColumn: wide ? '2 / -1' : undefined,
+        }}
+      >
+        {empty ? '–' : value}
+      </dd>
+    </>
+  );
+}
+
+function BoolBadge({ value }: { value: boolean }) {
+  return <Badge tone={value ? 'success' : 'neutral'}>{value ? 'Yes' : 'No'}</Badge>;
+}

--- a/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
@@ -66,11 +66,19 @@ export function L2tpClientDetailsDialog({ clientName, creds, onClose }: Props) {
           <Row label="Name" value={details.name} />
           <Row label="Enabled" value={<BoolBadge value={!details.disabled} />} />
           <Row label="Running" value={<BoolBadge value={details.running} />} />
+          <Row label="Status" value={details.status} />
+          <Row label="Uptime" value={details.uptime} />
+          <Row label="Encoding" value={details.encoding} />
           <Row label="Connect to" value={details.connectTo} />
+          <Row label="Local address" value={details.localAddress} />
+          <Row label="Remote address" value={details.remoteAddress} />
+          <Row label="Local IPv6 address" value={details.localIpv6Address} />
+          <Row label="Remote IPv6 address" value={details.remoteIpv6Address} />
           <Row label="User" value={details.user} />
           <Row label="Password" value={details.password ? <code>{details.password}</code> : '–'} />
           <Row label="Profile" value={details.profile} />
           <Row label="Allow" value={details.allow} />
+          <Row label="MTU" value={details.mtu} />
           <Row label="Max MTU" value={details.maxMtu} />
           <Row label="Max MRU" value={details.maxMru} />
           <Row label="MRRU" value={details.mrru} />

--- a/frontend/src/routes/vpn/sections/ClientsSection.tsx
+++ b/frontend/src/routes/vpn/sections/ClientsSection.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../api';
 import { AddVpnClientDialog } from '../dialogs/AddVpnClientDialog';
 import { EditL2tpClientDialog } from '../dialogs/EditL2tpClientDialog';
+import { L2tpClientDetailsDialog } from '../dialogs/L2tpClientDetailsDialog';
 import { PaginationControls } from '../PaginationControls';
 import { usePagedFilter } from '../hooks/usePagedFilter';
 import { PAGE_SIZE } from '../utils';
@@ -34,6 +35,7 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
   const paged = usePagedFilter(clients, matches);
   const toast = useToast();
   const [adding, setAdding] = useState(false);
+  const [viewing, setViewing] = useState<VPNClient | null>(null);
   const [editing, setEditing] = useState<VPNClient | null>(null);
   const [pendingDelete, setPendingDelete] = useState<VPNClient | null>(null);
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
@@ -139,6 +141,7 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
             totalRows={clients.length}
             creds={creds}
             onToggled={onChanged}
+            onView={(c) => setViewing(c)}
             onEdit={(c) => setEditing(c)}
             onDelete={(c) => setPendingDelete(c)}
           />
@@ -163,6 +166,11 @@ export function ClientsSection({ creds, clients, onChanged }: Props) {
           onSubmit={onSubmitEdit}
         />
       ) : null}
+      <L2tpClientDetailsDialog
+        clientName={viewing?.name ?? null}
+        creds={creds}
+        onClose={() => setViewing(null)}
+      />
       <ConfirmDialog
         open={!!pendingDelete}
         title="Delete L2TP client"

--- a/frontend/src/routes/vpn/sections/ClientsTable.tsx
+++ b/frontend/src/routes/vpn/sections/ClientsTable.tsx
@@ -10,11 +10,20 @@ interface Props {
   totalRows: number;
   creds: VPNCredentials | null;
   onToggled: () => void;
+  onView: (client: VPNClient) => void;
   onEdit: (client: VPNClient) => void;
   onDelete: (client: VPNClient) => void;
 }
 
-export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDelete }: Props) {
+export function ClientsTable({
+  rows,
+  totalRows,
+  creds,
+  onToggled,
+  onView,
+  onEdit,
+  onDelete,
+}: Props) {
   const toast = useToast();
   const colors = useThemeColors();
   const [pending, setPending] = useState<Set<string>>(() => new Set());
@@ -35,7 +44,31 @@ export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDele
   return (
     <DataTable
       columns={[
-        { key: 'name', header: 'Name', render: (c: VPNClient) => c.name },
+        {
+          key: 'name',
+          header: 'Name',
+          render: (c: VPNClient) => {
+            if (c.protocol !== 'l2tp') return c.name;
+            return (
+              <button
+                type="button"
+                onClick={() => onView(c)}
+                aria-label={`View ${c.name} details`}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  font: 'inherit',
+                  color: 'var(--color-primary)',
+                  textDecoration: 'underline',
+                  cursor: 'pointer',
+                }}
+              >
+                {c.name}
+              </button>
+            );
+          },
+        },
         {
           key: 'status',
           header: 'Status',

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -558,6 +558,124 @@ test.describe('VPN clients tab', () => {
     await expect(page.getByRole('row', { name: /home-l2tp/ })).toBeHidden();
   });
 
+  test('opens details modal when clicking the L2TP client name', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'VPN Router', host: '10.0.0.10' });
+
+    await context.addInitScript((routerId) => {
+      try {
+        const key = 'nasnet-panel.session-credentials.v1';
+        const raw = window.sessionStorage.getItem(key);
+        const map = (raw ? JSON.parse(raw) : {}) as Record<
+          string,
+          { username: string; password: string }
+        >;
+        map[routerId] = { username: 'admin', password: 'test' };
+        window.sessionStorage.setItem(key, JSON.stringify(map));
+      } catch {
+        /* ignore */
+      }
+    }, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([{ ...baseClient, disabled: false }]),
+      });
+    });
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: null,
+        }),
+      });
+    });
+
+    let getCalls = 0;
+    await context.route('**/api/vpn/l2tp-client/home-l2tp', async (route) => {
+      if (route.request().method() === 'GET') {
+        getCalls += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({
+            id: '*9',
+            name: 'home-l2tp',
+            disabled: false,
+            running: true,
+            maxMtu: 1450,
+            maxMru: 1450,
+            mrru: 'disabled',
+            connectTo: '192.0.2.10',
+            user: 'user1',
+            password: 'pass1',
+            profile: 'default-encryption',
+            keepaliveTimeout: 60,
+            usePeerDns: false,
+            useIPsec: true,
+            ipsecSecret: 'admin2',
+            allowFastPath: false,
+            addDefaultRoute: false,
+            dialOnDemand: false,
+            allow: 'pap,chap,mschap1,mschap2',
+            randomSourcePort: false,
+            l2tpProtoVersion: 'l2tpv2',
+            l2tpv3DigestHash: 'md5',
+            addRoutes: false,
+            comment: '',
+            status: 'connected',
+            uptime: '1h2m3s',
+            encoding: 'MPPE128 stateless',
+            mtu: 1400,
+            localAddress: '10.0.0.2',
+            remoteAddress: '10.0.0.1',
+            localIpv6Address: '',
+            remoteIpv6Address: '',
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    const row = page.getByRole('row', { name: /home-l2tp/ });
+    await row.getByRole('button', { name: /view home-l2tp details/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('L2TP client: home-l2tp');
+    await expect.poll(() => getCalls).toBe(1);
+
+    await expect(dialog).toContainText('192.0.2.10');
+    await expect(dialog).toContainText('user1');
+    await expect(dialog).toContainText('default-encryption');
+    await expect(dialog).toContainText('pap,chap,mschap1,mschap2');
+    await expect(dialog).toContainText('l2tpv2');
+    await expect(dialog).toContainText('admin2');
+    await expect(dialog).toContainText('connected');
+    await expect(dialog).toContainText('1h2m3s');
+    await expect(dialog).toContainText('MPPE128 stateless');
+    await expect(dialog).toContainText('10.0.0.2');
+    await expect(dialog).toContainText('10.0.0.1');
+
+    await dialog.getByRole('button', { name: 'Close' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
   test('renders empty-state icon when no clients are configured', async ({
     page,
     context,


### PR DESCRIPTION
<img width="889" height="613" alt="Screenshot 2026-05-05 at 02 46 36" src="https://github.com/user-attachments/assets/5d6773cd-ff40-4c2c-bd1d-15aa85bd01a2" />

## Summary
- Click an L2TP client name in the VPN Clients table to open a details modal
- Modal fetches via existing details endpoint and renders all returned fields
- Name remains plain text for non-L2TP rows