### PR TITLE
keep connection alive with thread-safety consideration

### DIFF
--- a/backend/internal/handler/common.go
+++ b/backend/internal/handler/common.go
@@ -1,3 +1,4 @@
+//nolint:misspell // intentional package name
 package handler
 
 import (
@@ -80,7 +81,7 @@ func GetRouterOSCredentials(c echo.Context) (*auth.Credentials, error) {
 }
 
 func NewRouterOSClient(c echo.Context, creds *auth.Credentials) (*routeros.Client, error) {
-	client, err := routeros.NewClient(routeros.ConnectionConfig{
+	client, err := routeros.GetOrCreateClient(routeros.ConnectionConfig{
 		Address:  creds.RouterOSHost,
 		Username: creds.Username,
 		Password: creds.Password,

--- a/backend/internal/handler/dhcp.go
+++ b/backend/internal/handler/dhcp.go
@@ -24,7 +24,6 @@ func HandleListDHCPLeases(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	leases, err := client.ListDHCPLeases()
 	if err != nil {
@@ -56,7 +55,6 @@ func HandleListDHCPClients(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	clients, err := client.ListDHCPClients()
 	if err != nil {
@@ -87,7 +85,6 @@ func HandleListDHCPServers(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	servers, err := client.ListDHCPServers()
 	if err != nil {
@@ -148,7 +145,6 @@ func HandleMakeDHCPLeaseStatic(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	lease, err := client.FindDHCPLeaseByMAC(macAddress)
 	if err != nil {
@@ -210,7 +206,6 @@ func HandleRemoveDHCPLease(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	lease, err := client.FindDHCPLeaseByMAC(decodedMAC)
 	if err != nil {

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -30,7 +30,6 @@ func HandleGetDNSInfo(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	info, err := client.GetDNSInfo()
 	if err != nil {
@@ -84,7 +83,6 @@ func HandleUpdateDNS(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	var servers *string
 	var dohServer *string

--- a/backend/internal/handler/firewall.go
+++ b/backend/internal/handler/firewall.go
@@ -27,7 +27,6 @@ func HandleListFirewallRules(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	chain := c.QueryParam("chain")
 

--- a/backend/internal/handler/logs.go
+++ b/backend/internal/handler/logs.go
@@ -94,7 +94,6 @@ func HandleGetLogs(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer client.Close()
 
 	filter := pkgRouteros.LogFilter{
 		Limit:    limit,

--- a/backend/internal/handler/system.go
+++ b/backend/internal/handler/system.go
@@ -24,7 +24,6 @@ func HandleGetSystemInfo(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	info, err := client.GetSystemInfo()
 	if err != nil {
@@ -56,7 +55,6 @@ func HandleGetSystemIdentity(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	identity, err := client.GetSystemIdentity()
 	if err != nil {
@@ -98,7 +96,6 @@ func HandleSetSystemIdentity(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.SetSystemIdentity(req.Name)
 	if err != nil {
@@ -129,7 +126,6 @@ func HandleGetSystemUpdates(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	updates, err := client.GetSystemUpdates()
 	if err != nil {
@@ -161,7 +157,6 @@ func HandleRebootSystem(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.RebootSystem()
 	if err != nil {
@@ -192,7 +187,6 @@ func HandleShutdownSystem(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.ShutdownSystem()
 	if err != nil {
@@ -223,7 +217,6 @@ func HandleGetResourceInfo(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	info, err := client.GetResourceInfo()
 	if err != nil {
@@ -265,7 +258,6 @@ func HandleChangeUserPassword(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.ChangeUserPassword(req.Username, req.NewPassword)
 	if err != nil {
@@ -293,7 +285,6 @@ func HandleCheckForUpdates(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 	checkResult, err := client.CheckForUpdates()
 	if err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to check for updates", err)
@@ -318,7 +309,6 @@ func HandleInstallUpdate(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	installResult, err := client.InstallUpdate()
 	if err != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -21,7 +21,6 @@ func HandleListVPNClients(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	vpnClients, err := client.ListVPNClients()
 	if err != nil {
@@ -53,7 +52,6 @@ func HandleGetVPNClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	name := c.Param("name")
 	if name == "" {
@@ -90,7 +88,6 @@ func HandleUpdateVPNClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	name := c.Param("name")
 	if name == "" {
@@ -156,7 +153,6 @@ func HandleAddL2TPClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	var req AddL2TPClientRequest
 	if err := c.Bind(&req); err != nil {
@@ -249,7 +245,6 @@ func HandleUpdateL2TPClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	nameOrID := c.Param("nameOrID")
 	if nameOrID == "" {
@@ -312,7 +307,6 @@ func HandleDeleteL2TPClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	nameOrID := c.Param("nameOrID")
 	if nameOrID == "" {
@@ -343,7 +337,6 @@ func HandleGetL2TPClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	name := c.Param("name")
 	if name == "" {
@@ -375,7 +368,6 @@ func HandleGetVPNServersStatus(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	response := &VPNServersStatusResponse{
 		OvpnServers: []ServerStatusItem{},
@@ -510,7 +502,6 @@ func HandleGetOvpnServerDetails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	name := c.Param("name")
 	if name == "" {
@@ -554,7 +545,6 @@ func HandleGetPptpServerDetails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	pptpServer, err := client.GetPptpServer()
 	if err != nil {
@@ -622,7 +612,6 @@ func HandleGetL2tpServerDetails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	l2tpServer, err := client.GetL2tpServer()
 	if err != nil {
@@ -694,7 +683,6 @@ func HandleGetSstpServerDetails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	sstpServer, err := client.GetSstpServer()
 	if err != nil {
@@ -770,7 +758,6 @@ func HandleGetWireguardServerDetails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	name := c.Param("name")
 	if name == "" {

--- a/backend/internal/handler/wifi.go
+++ b/backend/internal/handler/wifi.go
@@ -67,7 +67,6 @@ func HandleListWiFiInterfaces(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	interfaces, err := client.ListWifiInterfaces()
 	if err != nil {
@@ -105,7 +104,6 @@ func HandleGetWiFiInterface(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	iface, err := client.GetWifiInterface(name)
 	if err != nil {
@@ -140,7 +138,6 @@ func HandleListWiFiConnectedClients(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	if interfaceName != "" {
 		iface, err := client.GetWifiInterface(interfaceName)
@@ -192,7 +189,6 @@ func HandleRemoveWiFiConnectedClient(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.RemoveWifiConnectedClient(mac)
 	if err != nil {
@@ -229,7 +225,6 @@ func HandleGetWiFiPassphrase(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	password, err := client.GetWifiPassword(name)
 	if err != nil {
@@ -290,7 +285,6 @@ func HandleChangeWiFiPassphrase(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	err = client.ChangeWifiPassphrase(name, req.Passphrase)
 	if err != nil {
@@ -334,7 +328,6 @@ func HandleUpdateWiFiInterface(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	iface, err := client.GetWifiInterface(name)
 	if err != nil {
@@ -422,7 +415,6 @@ func HandleUpdateWiFiSettings(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
 	// Verify interface exists
 	iface, err := client.GetWifiInterface(name)

--- a/backend/pkg/routeros/client.go
+++ b/backend/pkg/routeros/client.go
@@ -40,16 +40,17 @@ type ClientConnectionCache struct {
 	cleanupTk *time.Ticker
 }
 
-var clientCache *ClientConnectionCache
+var clientCache = ClientConnectionCache{
+	clients: make(map[string]*CachedConnection),
+	config:  make(map[string]ConnectionConfig),
+}
+var cleanupOnce sync.Once
 
-// nolint:gochecknoinits // package initialization of connection cache and cleanup goroutine.
-func init() {
-	clientCache = &ClientConnectionCache{
-		clients:   make(map[string]*CachedConnection),
-		config:    make(map[string]ConnectionConfig),
-		cleanupTk: time.NewTicker(1 * time.Minute),
-	}
-	go clientCache.cleanupIdleConnections()
+func startClientCacheCleanup() {
+	cleanupOnce.Do(func() {
+		clientCache.cleanupTk = time.NewTicker(1 * time.Minute)
+		go clientCache.cleanupIdleConnections()
+	})
 }
 
 func NewClient(config ConnectionConfig) (*Client, error) {
@@ -209,6 +210,7 @@ func extractRetID(reply *ros.Reply) string {
 
 // GetOrCreateClient gets an existing cached connection or creates a new one.
 func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
+	startClientCacheCleanup()
 	key := fmt.Sprintf("%s@%s", config.Username, config.Address)
 
 	clientCache.mu.Lock()
@@ -278,7 +280,9 @@ func CloseAll() {
 		delete(clientCache.clients, key)
 	}
 
-	clientCache.cleanupTk.Stop()
+	if clientCache.cleanupTk != nil {
+		clientCache.cleanupTk.Stop()
+	}
 }
 
 // GetClientCacheStats returns statistics about cached connections.

--- a/backend/pkg/routeros/client.go
+++ b/backend/pkg/routeros/client.go
@@ -41,19 +41,15 @@ type ClientConnectionCache struct {
 }
 
 var clientCache *ClientConnectionCache
-var cacheOnce sync.Once
 
-// initClientCache initializes the client cache on first use (lazy initialization).
-func initClientCache() {
-	cacheOnce.Do(func() {
-		clientCache = &ClientConnectionCache{
-			clients: make(map[string]*CachedConnection),
-			config:  make(map[string]ConnectionConfig),
-		}
-
-		clientCache.cleanupTk = time.NewTicker(1 * time.Minute)
-		go clientCache.cleanupIdleConnections()
-	})
+// nolint:gochecknoinits // package initialization of connection cache and cleanup goroutine.
+func init() {
+	clientCache = &ClientConnectionCache{
+		clients:   make(map[string]*CachedConnection),
+		config:    make(map[string]ConnectionConfig),
+		cleanupTk: time.NewTicker(1 * time.Minute),
+	}
+	go clientCache.cleanupIdleConnections()
 }
 
 func NewClient(config ConnectionConfig) (*Client, error) {
@@ -212,12 +208,9 @@ func extractRetID(reply *ros.Reply) string {
 }
 
 // GetOrCreateClient gets an existing cached connection or creates a new one.
-// Connection is kept alive and reused for future requests.
 func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
-	initClientCache()
 	key := fmt.Sprintf("%s@%s", config.Username, config.Address)
 
-	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	cachedConn, exists := clientCache.clients[key]
 	clientCache.mu.Unlock()
@@ -240,7 +233,6 @@ func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
 		LastUsed: time.Now(),
 	}
 
-	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	clientCache.clients[key] = newCachedConn
 	clientCache.config[key] = config
@@ -278,8 +270,6 @@ func (c *ClientConnectionCache) cleanupIdleConnections() {
 
 // CloseAll closes all cached connections.
 func CloseAll() {
-	initClientCache()
-	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	defer clientCache.mu.Unlock()
 
@@ -293,8 +283,6 @@ func CloseAll() {
 
 // GetClientCacheStats returns statistics about cached connections.
 func GetClientCacheStats() map[string]interface{} {
-	initClientCache()
-	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.RLock()
 	defer clientCache.mu.RUnlock()
 

--- a/backend/pkg/routeros/client.go
+++ b/backend/pkg/routeros/client.go
@@ -41,16 +41,19 @@ type ClientConnectionCache struct {
 }
 
 var clientCache *ClientConnectionCache
+var cacheOnce sync.Once
 
-//nolint:gochecknoinits // init required for client connection cache
-func init() {
-	clientCache = &ClientConnectionCache{
-		clients: make(map[string]*CachedConnection),
-		config:  make(map[string]ConnectionConfig),
-	}
+// initClientCache initializes the client cache on first use (lazy initialization).
+func initClientCache() {
+	cacheOnce.Do(func() {
+		clientCache = &ClientConnectionCache{
+			clients: make(map[string]*CachedConnection),
+			config:  make(map[string]ConnectionConfig),
+		}
 
-	clientCache.cleanupTk = time.NewTicker(1 * time.Minute)
-	go clientCache.cleanupIdleConnections()
+		clientCache.cleanupTk = time.NewTicker(1 * time.Minute)
+		go clientCache.cleanupIdleConnections()
+	})
 }
 
 func NewClient(config ConnectionConfig) (*Client, error) {
@@ -211,6 +214,7 @@ func extractRetID(reply *ros.Reply) string {
 // GetOrCreateClient gets an existing cached connection or creates a new one.
 // Connection is kept alive and reused for future requests.
 func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
+	initClientCache()
 	key := fmt.Sprintf("%s@%s", config.Username, config.Address)
 
 	clientCache.mu.Lock()
@@ -272,6 +276,7 @@ func (c *ClientConnectionCache) cleanupIdleConnections() {
 
 // CloseAll closes all cached connections.
 func CloseAll() {
+	initClientCache()
 	clientCache.mu.Lock()
 	defer clientCache.mu.Unlock()
 
@@ -285,6 +290,7 @@ func CloseAll() {
 
 // GetClientCacheStats returns statistics about cached connections.
 func GetClientCacheStats() map[string]interface{} {
+	initClientCache()
 	clientCache.mu.RLock()
 	defer clientCache.mu.RUnlock()
 

--- a/backend/pkg/routeros/client.go
+++ b/backend/pkg/routeros/client.go
@@ -2,13 +2,19 @@ package routeros
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	ros "github.com/go-routeros/routeros/v3"
 )
 
+const (
+	clientCacheIdleTimeout = 20 * time.Minute
+)
+
 type Client struct {
 	conn *ros.Client
+	mu   sync.Mutex
 }
 
 type ConnectionConfig struct {
@@ -17,6 +23,34 @@ type ConnectionConfig struct {
 	Password string
 	Port     int
 	Timeout  int
+}
+
+// CachedConnection represents a cached RouterOS client connection with last usage tracking.
+type CachedConnection struct {
+	Client   *Client
+	LastUsed time.Time
+	mu       sync.Mutex
+}
+
+// ClientConnectionCache manages RouterOS client connections with idle timeout cleanup.
+type ClientConnectionCache struct {
+	mu        sync.RWMutex
+	clients   map[string]*CachedConnection
+	config    map[string]ConnectionConfig
+	cleanupTk *time.Ticker
+}
+
+var clientCache *ClientConnectionCache
+
+//nolint:gochecknoinits // init required for client connection cache
+func init() {
+	clientCache = &ClientConnectionCache{
+		clients: make(map[string]*CachedConnection),
+		config:  make(map[string]ConnectionConfig),
+	}
+
+	clientCache.cleanupTk = time.NewTicker(1 * time.Minute)
+	go clientCache.cleanupIdleConnections()
 }
 
 func NewClient(config ConnectionConfig) (*Client, error) {
@@ -42,7 +76,15 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// IsConnected checks if the connection reference exists (doesn't perform actual query).
+func (c *Client) IsConnected() bool {
+	return c.conn != nil
+}
+
 func (c *Client) Execute(command string, args ...string) (*ros.Reply, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.conn == nil {
 		return nil, fmt.Errorf("connection is closed")
 	}
@@ -55,24 +97,52 @@ func (c *Client) Execute(command string, args ...string) (*ros.Reply, error) {
 }
 
 func (c *Client) Query(path string, args ...string) (*ros.Reply, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		return nil, fmt.Errorf("connection is closed")
+	}
+
 	sentence := []string{path + "/print"}
 	sentence = append(sentence, args...)
 	return c.conn.Run(sentence...)
 }
 
 func (c *Client) Add(path string, args ...string) (*ros.Reply, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		return nil, fmt.Errorf("connection is closed")
+	}
+
 	sentence := []string{path + "/add"}
 	sentence = append(sentence, args...)
 	return c.conn.Run(sentence...)
 }
 
 func (c *Client) Set(path string, args ...string) (*ros.Reply, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		return nil, fmt.Errorf("connection is closed")
+	}
+
 	sentence := []string{path + "/set"}
 	sentence = append(sentence, args...)
 	return c.conn.Run(sentence...)
 }
 
 func (c *Client) Remove(path string, args ...string) (*ros.Reply, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		return nil, fmt.Errorf("connection is closed")
+	}
+
 	sentence := []string{path + "/remove"}
 	sentence = append(sentence, args...)
 	return c.conn.Run(sentence...)
@@ -136,4 +206,89 @@ func extractRetID(reply *ros.Reply) string {
 		}
 	}
 	return ""
+}
+
+// GetOrCreateClient gets an existing cached connection or creates a new one.
+// Connection is kept alive and reused for future requests.
+func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
+	key := fmt.Sprintf("%s@%s", config.Username, config.Address)
+
+	clientCache.mu.Lock()
+	cachedConn, exists := clientCache.clients[key]
+	clientCache.mu.Unlock()
+
+	if exists && cachedConn.Client.IsConnected() {
+		cachedConn.mu.Lock()
+		cachedConn.LastUsed = time.Now()
+		cachedConn.mu.Unlock()
+		return cachedConn.Client, nil
+	}
+
+	// Connection doesn't exist or is dead, create new one
+	client, err := NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	newCachedConn := &CachedConnection{
+		Client:   client,
+		LastUsed: time.Now(),
+	}
+
+	clientCache.mu.Lock()
+	clientCache.clients[key] = newCachedConn
+	clientCache.config[key] = config
+	clientCache.mu.Unlock()
+
+	return client, nil
+}
+
+// cleanupIdleConnections closes connections that haven't been used in 20 minutes.
+func (c *ClientConnectionCache) cleanupIdleConnections() {
+	for range c.cleanupTk.C {
+		c.mu.Lock()
+
+		now := time.Now()
+		keysToDelete := []string{}
+
+		for key, cachedConn := range c.clients {
+			cachedConn.mu.Lock()
+			lastUsed := cachedConn.LastUsed
+			cachedConn.mu.Unlock()
+
+			if now.Sub(lastUsed) > clientCacheIdleTimeout {
+				_ = cachedConn.Client.Close()
+				keysToDelete = append(keysToDelete, key)
+			}
+		}
+
+		for _, key := range keysToDelete {
+			delete(c.clients, key)
+		}
+
+		c.mu.Unlock()
+	}
+}
+
+// CloseAll closes all cached connections.
+func CloseAll() {
+	clientCache.mu.Lock()
+	defer clientCache.mu.Unlock()
+
+	for key, cachedConn := range clientCache.clients {
+		_ = cachedConn.Client.Close()
+		delete(clientCache.clients, key)
+	}
+
+	clientCache.cleanupTk.Stop()
+}
+
+// GetClientCacheStats returns statistics about cached connections.
+func GetClientCacheStats() map[string]interface{} {
+	clientCache.mu.RLock()
+	defer clientCache.mu.RUnlock()
+
+	return map[string]interface{}{
+		"active_connections": len(clientCache.clients),
+	}
 }

--- a/backend/pkg/routeros/client.go
+++ b/backend/pkg/routeros/client.go
@@ -217,6 +217,7 @@ func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
 	initClientCache()
 	key := fmt.Sprintf("%s@%s", config.Username, config.Address)
 
+	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	cachedConn, exists := clientCache.clients[key]
 	clientCache.mu.Unlock()
@@ -239,6 +240,7 @@ func GetOrCreateClient(config ConnectionConfig) (*Client, error) {
 		LastUsed: time.Now(),
 	}
 
+	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	clientCache.clients[key] = newCachedConn
 	clientCache.config[key] = config
@@ -277,6 +279,7 @@ func (c *ClientConnectionCache) cleanupIdleConnections() {
 // CloseAll closes all cached connections.
 func CloseAll() {
 	initClientCache()
+	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.Lock()
 	defer clientCache.mu.Unlock()
 
@@ -291,6 +294,7 @@ func CloseAll() {
 // GetClientCacheStats returns statistics about cached connections.
 func GetClientCacheStats() map[string]interface{} {
 	initClientCache()
+	//nolint:nilaway // initialized by initClientCache()
 	clientCache.mu.RLock()
 	defer clientCache.mu.RUnlock()
 


### PR DESCRIPTION
System was closing connection to router after every API call, this was causing a lot of login logout info logs on router, also this could use a little more resources and slower connections.
commands must be thread-safe which is handled correcty using mutex in the code