### PR TITLE
feat(fe): make pages responsive on narrow viewports

### DIFF
--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -10,11 +10,46 @@
   gap: var(--space-md);
 }
 
+.cardHeader > :first-child {
+  min-width: 0;
+}
+
 .headerActions {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   flex-shrink: 0;
+}
+
+@media (max-width: 960px) {
+  .card {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .infoRow,
+  .skeletonGrid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-xs);
+  }
+
+  .infoLabel {
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .cardHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .headerActions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
 }
 
 .infoRow {
@@ -44,12 +79,18 @@
 }
 
 .serverPill {
+  display: inline-block;
+  max-width: 100%;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--font-xs);
   background: var(--color-surface-alt);
   padding: 4px 10px;
   border-radius: var(--radius-sm);
   color: var(--color-text);
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  word-break: normal;
 }
 
 .muted {

--- a/frontend/src/routes/FirewallPage.module.scss
+++ b/frontend/src/routes/FirewallPage.module.scss
@@ -232,6 +232,10 @@
   gap: var(--space-md);
 }
 
+.cardHeader > :first-child {
+  min-width: 0;
+}
+
 .headerActions {
   display: flex;
   align-items: flex-end;
@@ -241,6 +245,24 @@
 
 .chainField {
   min-width: 160px;
+}
+
+@media (max-width: 768px) {
+  .cardHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .headerActions {
+    flex-shrink: 1;
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .chainField {
+    min-width: 0;
+    flex: 1 1 100%;
+  }
 }
 
 .chainLabel {

--- a/frontend/src/routes/LogsPage.module.scss
+++ b/frontend/src/routes/LogsPage.module.scss
@@ -1,6 +1,10 @@
+.streamScroll {
+  overflow-x: auto;
+}
+
 .logRow {
   display: grid;
-  grid-template-columns: 180px 90px 130px 1fr;
+  grid-template-columns: 180px 90px 130px minmax(280px, 1fr);
   gap: var(--space-md);
   padding: 8px var(--space-sm);
   font: inherit;
@@ -13,6 +17,7 @@
   border-radius: var(--radius-sm);
   align-items: center;
   width: 100%;
+  min-width: 720px;
   cursor: pointer;
   transition: background var(--transition-fast);
 
@@ -82,11 +87,27 @@
   gap: var(--space-md);
 }
 
+.cardHeader > :first-child {
+  min-width: 0;
+}
+
 .headerActions {
   display: flex;
   align-items: center;
   gap: var(--space-md);
   flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .cardHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .headerActions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
 }
 
 .pagination {

--- a/frontend/src/routes/LogsPage.tsx
+++ b/frontend/src/routes/LogsPage.tsx
@@ -199,7 +199,7 @@ export function LogsPage() {
 
       <Card data-testid="log-stream">
         {isSearching ? (
-          <div data-testid="log-skeleton">
+          <div data-testid="log-skeleton" className={styles.streamScroll}>
             {['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((k) => (
               <div key={`skeleton-${k}`} className={styles.logRow}>
                 <Skeleton width={160} height={14} />
@@ -221,33 +221,35 @@ export function LogsPage() {
           </div>
         ) : (
           <div>
-            <AnimatePresence mode="wait" initial={false}>
-              <motion.div
-                key={currentPage}
-                initial={{ opacity: 0, y: 4 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.18 }}
-              >
-                {pagedLogs.map((log) => (
-                  <button
-                    type="button"
-                    key={log.id}
-                    data-testid="log-row"
-                    className={styles.logRow}
-                    onClick={() => setSelected(log)}
-                    aria-label={`Open details for log ${log.id}`}
-                  >
-                    <span className={styles.timestamp}>{log.time}</span>
-                    <Badge className={styles.logLevel} tone={toneForLevel(log.level)}>
-                      {log.level}
-                    </Badge>
-                    <span className={styles.topic}>{log.topic}</span>
-                    <span className={styles.message}>{log.message}</span>
-                  </button>
-                ))}
-              </motion.div>
-            </AnimatePresence>
+            <div className={styles.streamScroll}>
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={currentPage}
+                  initial={{ opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.18 }}
+                >
+                  {pagedLogs.map((log) => (
+                    <button
+                      type="button"
+                      key={log.id}
+                      data-testid="log-row"
+                      className={styles.logRow}
+                      onClick={() => setSelected(log)}
+                      aria-label={`Open details for log ${log.id}`}
+                    >
+                      <span className={styles.timestamp}>{log.time}</span>
+                      <Badge className={styles.logLevel} tone={toneForLevel(log.level)}>
+                        {log.level}
+                      </Badge>
+                      <span className={styles.topic}>{log.topic}</span>
+                      <span className={styles.message}>{log.message}</span>
+                    </button>
+                  ))}
+                </motion.div>
+              </AnimatePresence>
+            </div>
             {visibleLogs.length > pageSize ? (
               <div className={styles.pagination}>
                 <span className={styles.paginationInfo}>

--- a/frontend/src/routes/VPNPage.module.scss
+++ b/frontend/src/routes/VPNPage.module.scss
@@ -78,6 +78,23 @@
   min-width: 160px;
 }
 
+@media (max-width: 640px) {
+  .sectionHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .headerActions {
+    justify-content: flex-start;
+  }
+
+  .headerSearch {
+    width: 100%;
+    min-width: 0;
+    flex: 1 1 100%;
+  }
+}
+
 .pagination {
   display: flex;
   align-items: center;
@@ -106,4 +123,57 @@
   font-variant-numeric: tabular-nums;
   min-width: 100px;
   text-align: center;
+}
+
+.detailsList {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 140px minmax(0, 1fr);
+  row-gap: 8px;
+  column-gap: 16px;
+  margin: 0;
+}
+
+.detailsLabel {
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+}
+
+.detailsValue {
+  margin: 0;
+  font-size: var(--font-sm);
+  word-break: break-all;
+}
+
+.detailsValueWide {
+  grid-column: 2 / -1;
+}
+
+@media (max-width: 640px) {
+  .detailsList {
+    grid-template-columns: 110px minmax(0, 1fr);
+    column-gap: 12px;
+  }
+
+  .detailsValueWide {
+    grid-column: 2 / -1;
+  }
+}
+
+@media (max-width: 420px) {
+  .detailsList {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 4px;
+  }
+
+  .detailsLabel {
+    margin-top: 8px;
+  }
+
+  .detailsLabel:first-of-type {
+    margin-top: 0;
+  }
+
+  .detailsValueWide {
+    grid-column: 1 / -1;
+  }
 }

--- a/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/L2tpClientDetailsDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Badge, Button, Dialog } from '@nasnet/ui';
+import styles from '../../VPNPage.module.scss';
 import {
   ApiError,
   fetchL2TPClientDetails,
@@ -105,34 +106,15 @@ export function L2tpClientDetailsDialog({ clientName, creds, onClose }: Props) {
 }
 
 function DList({ children }: { children: React.ReactNode }) {
-  return (
-    <dl
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '140px minmax(0, 1fr) 140px minmax(0, 1fr)',
-        rowGap: 8,
-        columnGap: 16,
-        margin: 0,
-      }}
-    >
-      {children}
-    </dl>
-  );
+  return <dl className={styles.detailsList}>{children}</dl>;
 }
 
 function Row({ label, value, wide }: { label: string; value: React.ReactNode; wide?: boolean }) {
   const empty = value === '' || value === null || value === undefined;
   return (
     <>
-      <dt style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>{label}</dt>
-      <dd
-        style={{
-          margin: 0,
-          fontSize: 'var(--font-sm)',
-          wordBreak: 'break-all',
-          gridColumn: wide ? '2 / -1' : undefined,
-        }}
-      >
+      <dt className={styles.detailsLabel}>{label}</dt>
+      <dd className={`${styles.detailsValue}${wide ? ` ${styles.detailsValueWide}` : ''}`}>
         {empty ? '–' : value}
       </dd>
     </>

--- a/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Badge, Button, Dialog } from '@nasnet/ui';
+import styles from '../../VPNPage.module.scss';
 import {
   ApiError,
   fetchL2tpServerDetails,
@@ -232,34 +233,15 @@ function DetailsBody({ server, details }: { server: VPNServer; details: Details 
 }
 
 function DList({ children }: { children: React.ReactNode }) {
-  return (
-    <dl
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '140px minmax(0, 1fr) 140px minmax(0, 1fr)',
-        rowGap: 8,
-        columnGap: 16,
-        margin: 0,
-      }}
-    >
-      {children}
-    </dl>
-  );
+  return <dl className={styles.detailsList}>{children}</dl>;
 }
 
 function Row({ label, value, wide }: { label: string; value: React.ReactNode; wide?: boolean }) {
   const empty = value === '' || value === null || value === undefined;
   return (
     <>
-      <dt style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>{label}</dt>
-      <dd
-        style={{
-          margin: 0,
-          fontSize: 'var(--font-sm)',
-          wordBreak: 'break-all',
-          gridColumn: wide ? '2 / -1' : undefined,
-        }}
-      >
+      <dt className={styles.detailsLabel}>{label}</dt>
+      <dd className={`${styles.detailsValue}${wide ? ` ${styles.detailsValueWide}` : ''}`}>
         {empty ? '–' : value}
       </dd>
     </>


### PR DESCRIPTION
Closes #141

## Summary
- VPN, DNS, Firewall, Logs page headers stack vertically on narrow viewports instead of crushing the title block
- VPN/DNS detail grids collapse to fewer columns; DNS pills stay single-line and scroll horizontally for long URLs
- Logs row gains horizontal scroll so wide rows stop overflowing the viewport