### PR TITLE
feat(fe): LAN tab with router port diagram

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ export function App() {
                   <Route path="vpn" element={<VPNPage />} />
                   <Route path="wireless" element={<WirelessPage />} />
                   <Route path="logs" element={<LogsPage />} />
-                  <Route path="dhcp" element={<DHCPPage />} />
+                  <Route path="lan" element={<DHCPPage />} />
                   <Route path="dns" element={<DNSPage />} />
                   <Route path="firewall" element={<FirewallPage />} />
                   <Route path="help" element={<HelpPage />} />

--- a/frontend/src/routes/DHCPPage.module.scss
+++ b/frontend/src/routes/DHCPPage.module.scss
@@ -45,3 +45,23 @@
   padding: 10px var(--space-sm);
   border-bottom: 1px dashed var(--color-border);
 }
+
+.lanPortsRow {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+}
+
+.lanPortsRow > :first-child {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.lanPortsDiagram {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}

--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Cable, Inbox, Pin, Server, Trash2 } from 'lucide-react';
 import {
@@ -20,14 +20,19 @@ import {
   fetchDhcpClients,
   fetchDhcpLeases,
   fetchDhcpServers,
+  fetchInterfaces,
+  fetchSystemOverview,
   makeDhcpLeaseStatic,
   removeDhcpLease,
   type DhcpClient,
   type DhcpLease,
   type DhcpServer,
+  type InterfaceResponse,
 } from '../api';
 import { useSession } from '../state/SessionContext';
 import { useRouter } from '../state/RouterStoreContext';
+import { RouterPortDiagramCard } from './overview-panel/RouterPortDiagramCard';
+import { wanInterfaceNames } from './overview-panel/uplinks';
 
 interface SectionState<T> {
   data: T[];
@@ -58,6 +63,8 @@ export function DHCPPage() {
   const [servers, setServers] = useState<SectionState<DhcpServer>>(initial<DhcpServer>());
   const [leases, setLeases] = useState<SectionState<DhcpLease>>(initial<DhcpLease>());
   const [clients, setClients] = useState<SectionState<DhcpClient>>(initial<DhcpClient>());
+  const [model, setModel] = useState<string | null>(null);
+  const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
   const [busyMac, setBusyMac] = useState<string | null>(null);
   const [leaseToRemove, setLeaseToRemove] = useState<DhcpLease | null>(null);
   const inFlightRef = useRef(false);
@@ -83,12 +90,17 @@ export function DHCPPage() {
 
       inFlightRef.current = true;
       const full = { host, ...creds };
-      const [sResult, lResult, cResult] = await Promise.allSettled([
+      const [sResult, lResult, cResult, oResult, iResult] = await Promise.allSettled([
         fetchDhcpServers(full),
         fetchDhcpLeases(full),
         fetchDhcpClients(full),
+        fetchSystemOverview(id, full),
+        fetchInterfaces(full),
       ]);
       inFlightRef.current = false;
+
+      if (oResult.status === 'fulfilled') setModel(oResult.value.model);
+      if (iResult.status === 'fulfilled') setInterfaces(iResult.value);
 
       setServers(
         sResult.status === 'fulfilled'
@@ -183,6 +195,8 @@ export function DHCPPage() {
       setBusyMac(null);
     }
   }, [id, router?.host, getCredentials, leaseToRemove, reload, toast]);
+
+  const wanNames = useMemo(() => wanInterfaceNames(interfaces), [interfaces]);
 
   const serverColumns: DataTableColumn<DhcpServer>[] = [
     { key: 'name', header: 'Name', render: (r) => r.name || '—' },
@@ -365,22 +379,27 @@ export function DHCPPage() {
 
   return (
     <Stack>
-      <Card data-testid="dhcp-servers">
-        <CardHeader>
-          <CardTitle>Servers</CardTitle>
-          <CardDescription>DHCP server instances bound to router interfaces.</CardDescription>
-        </CardHeader>
-        {servers.error ? <div className={styles.errorBanner}>{servers.error}</div> : null}
-        {servers.loading ? (
-          loadingRows(6)
-        ) : servers.data.length === 0 ? (
-          <div className={styles.empty}>
-            <Server size={22} aria-hidden className={styles.emptyIcon} />
-            <p>No DHCP servers configured.</p>
+      <Card data-testid="lan-ports">
+        <div className={styles.lanPortsRow}>
+          <CardHeader>
+            <CardTitle>LAN ports</CardTitle>
+            <CardDescription>
+              Manage LAN-side ports. WAN ports are managed on the Internet tab.
+            </CardDescription>
+          </CardHeader>
+          <div className={styles.lanPortsDiagram}>
+            {model ? (
+              <RouterPortDiagramCard
+                model={model}
+                interfaces={interfaces}
+                showPowerControls={false}
+                disabledIfaceNames={wanNames}
+              />
+            ) : (
+              <Skeleton width={320} height={56} />
+            )}
           </div>
-        ) : (
-          <DataTable columns={serverColumns} rows={servers.data} rowKey={(r) => r.id} />
-        )}
+        </div>
       </Card>
 
       <Card data-testid="dhcp-leases">
@@ -422,6 +441,24 @@ export function DHCPPage() {
           </div>
         ) : (
           <DataTable columns={clientColumns} rows={clients.data} rowKey={(r) => r.id} />
+        )}
+      </Card>
+
+      <Card data-testid="dhcp-servers">
+        <CardHeader>
+          <CardTitle>Servers</CardTitle>
+          <CardDescription>DHCP server instances bound to router interfaces.</CardDescription>
+        </CardHeader>
+        {servers.error ? <div className={styles.errorBanner}>{servers.error}</div> : null}
+        {servers.loading ? (
+          loadingRows(6)
+        ) : servers.data.length === 0 ? (
+          <div className={styles.empty}>
+            <Server size={22} aria-hidden className={styles.emptyIcon} />
+            <p>No DHCP servers configured.</p>
+          </div>
+        ) : (
+          <DataTable columns={serverColumns} rows={servers.data} rowKey={(r) => r.id} />
         )}
       </Card>
 

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -401,7 +401,7 @@ export function OverviewTab() {
                 </div>
                 Default DHCP Server
               </div>
-              <Button variant="secondary" size="sm" onClick={() => navigate(`/router/${id}/dhcp`)}>
+              <Button variant="secondary" size="sm" onClick={() => navigate(`/router/${id}/lan`)}>
                 View
               </Button>
             </div>

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -26,7 +26,7 @@ const TABS: Array<TabItem & { path: string }> = [
     icon: <Globe size={16} />,
   },
   { id: 'wan', label: 'WAN', path: 'wan', icon: <Cable size={16} /> },
-  { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} />, disabled: true },
+  { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} /> },
   { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
   { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
   { id: 'system', label: 'System', path: 'system', icon: <Cpu size={16} />, disabled: true },

--- a/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
+++ b/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
@@ -9,22 +9,36 @@ import styles from './OverviewPanel.module.scss';
 export interface RouterPortDiagramCardProps {
   model: string;
   interfaces: InterfaceResponse[];
-  onPower: (action: PowerAction) => void;
+  onPower?: (action: PowerAction) => void;
+  showPowerControls?: boolean;
+  disabledIfaceNames?: readonly string[];
 }
 
 export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React.memo(
-  function RouterPortDiagramCard({ model, interfaces, onPower }) {
+  function RouterPortDiagramCard({
+    model,
+    interfaces,
+    onPower,
+    showPowerControls = true,
+    disabledIfaceNames,
+  }) {
     const { descriptor, slots } = useMemo(() => {
       const resolved = resolveModelStrict(model);
-      return { descriptor: resolved, slots: mapPorts(resolved.slots, interfaces) };
-    }, [model, interfaces]);
+      const disabled = disabledIfaceNames
+        ? new Set(disabledIfaceNames.map((n) => n.toLowerCase()))
+        : undefined;
+      const baseSlots = showPowerControls
+        ? resolved.slots
+        : resolved.slots.filter((s) => s.kind !== 'power' && s.kind !== 'reset');
+      return { descriptor: resolved, slots: mapPorts(baseSlots, interfaces, disabled) };
+    }, [model, interfaces, disabledIfaceNames, showPowerControls]);
 
     const Panel = PANEL_REGISTRY[descriptor.key];
 
     const handleSlot = useCallback(
       (slot: ResolvedSlot) => {
         const action = POWER_ACTION[slot.kind];
-        if (action) onPower(action);
+        if (action) onPower?.(action);
       },
       [onPower],
     );

--- a/frontend/src/routes/overview-panel/mapPorts.ts
+++ b/frontend/src/routes/overview-panel/mapPorts.ts
@@ -39,7 +39,11 @@ const deriveStatus = (iface: InterfaceResponse | undefined): PortStatus => {
   return iface.running ? 'up' : 'down';
 };
 
-export function mapPorts(slots: PortSlot[], interfaces: InterfaceResponse[]): ResolvedSlot[] {
+export function mapPorts(
+  slots: PortSlot[],
+  interfaces: InterfaceResponse[],
+  disabledIfaceNames?: ReadonlySet<string>,
+): ResolvedSlot[] {
   return slots.map((slot) => {
     if (!PORT_KINDS.includes(slot.kind)) {
       const action = POWER_ACTION[slot.kind];
@@ -52,7 +56,9 @@ export function mapPorts(slots: PortSlot[], interfaces: InterfaceResponse[]): Re
       };
     }
     const iface = findIface(interfaces, slot.ifaceName);
-    const status = deriveStatus(iface);
+    const forcedDisabled =
+      !!slot.ifaceName && !!disabledIfaceNames?.has(slot.ifaceName.toLowerCase());
+    const status = forcedDisabled ? 'disabled' : deriveStatus(iface);
     const speedLabel = iface?.speed || slot.nominalSpeed;
     const name = slot.ifaceName ?? slot.id;
     const hasTraffic =
@@ -68,7 +74,7 @@ export function mapPorts(slots: PortSlot[], interfaces: InterfaceResponse[]): Re
       ...slot,
       status,
       speedLabel,
-      interactive: true,
+      interactive: !forcedDisabled,
       tooltip,
       rxMbps: status === 'up' ? iface?.rxMbps : undefined,
       txMbps: status === 'up' ? iface?.txMbps : undefined,

--- a/frontend/src/routes/overview-panel/uplinks.ts
+++ b/frontend/src/routes/overview-panel/uplinks.ts
@@ -48,6 +48,10 @@ function classify(iface: InterfaceResponse): UplinkMatch {
   return matchUplink(iface) ?? { kind: 'ether', label: iface.name.toUpperCase() };
 }
 
+export function wanInterfaceNames(interfaces: InterfaceResponse[]): string[] {
+  return interfaces.filter((i) => i.type === 'ether' && matchUplink(i) !== null).map((i) => i.name);
+}
+
 function prefixOf(cidr: string): string {
   const ip = cidr.split('/')[0];
   return `${ip.split('.').slice(0, 3).join('.')}.`;

--- a/frontend/tests/e2e/19-dhcp-page.spec.ts
+++ b/frontend/tests/e2e/19-dhcp-page.spec.ts
@@ -1,16 +1,18 @@
 import { test, expect } from './fixtures';
 
-test.describe('DHCP page', () => {
+test.describe('LAN page (DHCP + port diagram)', () => {
   test('renders servers, leases, and clients loaded from the backend', async ({
     page,
     resetMocks,
     seedRouter,
+    mockOverviewBackend,
     mockDhcpBackend,
   }) => {
     await resetMocks();
-    await seedRouter({ id: 'rtr_dhcp', name: 'DHCP Router', host: '10.10.10.1' });
+    await seedRouter({ id: 'rtr_dhcp', name: 'DHCP Router', host: '10.10.10.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_dhcp', model: 'hAP ax3' });
     await mockDhcpBackend({ id: 'rtr_dhcp' });
-    await page.goto('/router/rtr_dhcp/dhcp');
+    await page.goto('/router/rtr_dhcp/lan');
 
     const servers = page.getByTestId('dhcp-servers');
     await expect(servers).toBeVisible();
@@ -29,5 +31,29 @@ test.describe('DHCP page', () => {
     await expect(clients).toBeVisible();
     await expect(clients).toContainText('ether1');
     await expect(clients).toContainText('10.0.0.42');
+  });
+
+  test('shows the port diagram with WAN ports greyed and LAN port info', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDhcpBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_lan', name: 'LAN Router', host: '10.10.10.2', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_lan', model: 'hAP ax3' });
+    await mockDhcpBackend({ id: 'rtr_lan' });
+    await page.goto('/router/rtr_lan/lan');
+
+    await expect(page.getByTestId('lan-ports')).toBeVisible();
+    await expect(page.getByTestId('port-diagram')).toBeVisible();
+    await expect(page.getByTestId('panel-model')).toHaveText('MikroTik hAP ax3');
+
+    // ether1 has comment "WAN uplink" -> greyed + disabled.
+    await expect(page.getByTestId('port-ether1')).toHaveAttribute('data-status', 'disabled');
+    // ether2 is a LAN port -> live, with info exposed via the hover-card tooltip.
+    await expect(page.getByTestId('port-ether2')).toHaveAttribute('data-status', 'up');
+    await expect(page.getByTestId('port-ether2')).toHaveAttribute('aria-label', /ether2.*up/i);
   });
 });


### PR DESCRIPTION

<img width="994" height="754" alt="Screenshot 2026-05-17 at 13 46 26" src="https://github.com/user-attachments/assets/0452db6a-6440-4cd3-95fe-bc97a9759692" />

## Summary
- Enable the LAN tab; it surfaces the existing DHCP lease/client/server management
- Add the Overview router port diagram to the LAN page: WAN ports greyed out, hover a LAN port for its info, no power controls
- Diagram changes are opt-in props, so the Overview tab is unchanged

Closes #172