### PR TITLE
feat(fe): embed Chatwoot widget on help page, add knowledge base link

### DIFF
--- a/frontend/src/routes/HelpPage.module.scss
+++ b/frontend/src/routes/HelpPage.module.scss
@@ -2,6 +2,14 @@
   width: 100%;
 }
 
+.chatFrame {
+  width: 100%;
+  height: 600px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
 .chat {
   display: flex;
   flex-direction: column;
@@ -258,12 +266,12 @@
   }
 }
 
-.telegram .linkIcon {
-  background: #229ed9;
+.knowledgeBase .linkIcon {
+  background: #0ea5e9;
 }
 
-.youtube .linkIcon {
-  background: #ff0000;
+.telegram .linkIcon {
+  background: #229ed9;
 }
 
 .github .linkIcon {

--- a/frontend/src/routes/HelpPage.tsx
+++ b/frontend/src/routes/HelpPage.tsx
@@ -1,8 +1,10 @@
 import { MessagesSquare } from 'lucide-react';
 import { Card, CardDescription, CardHeader, CardTitle, Inline, Stack } from '@nasnet/ui';
 import styles from './HelpPage.module.scss';
-import { ChatPanel } from './help/ChatPanel';
 import { SupportLinks } from './help/SupportLinks';
+
+const CHATWOOT_WIDGET_URL =
+  'https://app.chatwoot.com/widget?website_token=6bf25JZcWyhrbtLMgiv4oNuy';
 
 export function HelpPage() {
   return (
@@ -18,12 +20,17 @@ export function HelpPage() {
               </Inline>
             </CardTitle>
             <CardDescription>
-              Ask our AI assistant about setup, VPN, or Wi-Fi. A support agent can join the same
-              conversation when needed.
+              Ask our AI assistant anything, and a support agent can join the conversation when
+              needed.
             </CardDescription>
           </div>
         </CardHeader>
-        <ChatPanel />
+        <iframe
+          className={styles.chatFrame}
+          src={CHATWOOT_WIDGET_URL}
+          title="AI Assistant chat"
+          allow="microphone; camera; clipboard-write"
+        />
       </Card>
     </Stack>
   );

--- a/frontend/src/routes/help/SupportLinks.tsx
+++ b/frontend/src/routes/help/SupportLinks.tsx
@@ -1,10 +1,26 @@
-import { Bug, ExternalLink, Send, Youtube } from 'lucide-react';
-import { GITHUB_ISSUES_URL, TELEGRAM_SUPPORT_URL, YOUTUBE_CHANNEL_URL } from './links';
+import { BookOpen, Bug, ExternalLink, Send } from 'lucide-react';
+import { GITHUB_ISSUES_URL, KNOWLEDGE_BASE_URL, TELEGRAM_SUPPORT_URL } from './links';
 import styles from '../HelpPage.module.scss';
 
 export function SupportLinks() {
   return (
     <div className={styles.links}>
+      <a
+        className={`${styles.linkCard} ${styles.knowledgeBase}`}
+        href={KNOWLEDGE_BASE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className={styles.linkIcon} aria-hidden>
+          <BookOpen size={18} />
+        </span>
+        <span className={styles.linkBody}>
+          <span className={styles.linkTitle}>Knowledge base</span>
+          <span className={styles.linkDesc}>Browse guides and documentation</span>
+        </span>
+        <ExternalLink size={14} aria-hidden className={styles.linkExternal} />
+      </a>
+
       <a
         className={`${styles.linkCard} ${styles.telegram}`}
         href={TELEGRAM_SUPPORT_URL}
@@ -17,22 +33,6 @@ export function SupportLinks() {
         <span className={styles.linkBody}>
           <span className={styles.linkTitle}>Telegram support</span>
           <span className={styles.linkDesc}>Chat with the team on Telegram</span>
-        </span>
-        <ExternalLink size={14} aria-hidden className={styles.linkExternal} />
-      </a>
-
-      <a
-        className={`${styles.linkCard} ${styles.youtube}`}
-        href={YOUTUBE_CHANNEL_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <span className={styles.linkIcon} aria-hidden>
-          <Youtube size={18} />
-        </span>
-        <span className={styles.linkBody}>
-          <span className={styles.linkTitle}>YouTube channel</span>
-          <span className={styles.linkDesc}>Watch setup guides and tutorials</span>
         </span>
         <ExternalLink size={14} aria-hidden className={styles.linkExternal} />
       </a>

--- a/frontend/src/routes/help/links.ts
+++ b/frontend/src/routes/help/links.ts
@@ -2,4 +2,4 @@ export const GITHUB_ISSUES_URL = 'https://github.com/nasnet-community/nasnet-pan
 
 export const TELEGRAM_SUPPORT_URL = 'https://t.me/joinNASNETGroup';
 
-export const YOUTUBE_CHANNEL_URL = 'https://www.youtube.com/@JoinNASNET';
+export const KNOWLEDGE_BASE_URL = 'https://docs.s4i.co/hc/nasnet/fa';

--- a/frontend/tests/e2e/25-help-page.spec.ts
+++ b/frontend/tests/e2e/25-help-page.spec.ts
@@ -1,44 +1,9 @@
 import { test, expect } from './fixtures';
-import type { Page } from '@playwright/test';
 
 const ROUTER = { id: 'rtr_help', name: 'Help Router', host: '10.0.0.5' };
 
 const GITHUB_ISSUES_URL = 'https://github.com/nasnet-community/nasnet-panel/issues/new';
-
-async function mockChatwoot(page: Page) {
-  const messages: Array<{ id: number; content: string; message_type: number }> = [];
-  let nextId = 1;
-
-  await page.route('**/public/api/v1/inboxes/**', async (route) => {
-    const req = route.request();
-    const url = req.url();
-    const method = req.method();
-    const json = (body: unknown, status = 200) =>
-      route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
-
-    if (method === 'POST' && /\/contacts$/.test(url.split('?')[0])) {
-      return json({ source_id: 'contact-xyz', pubsub_token: 'pub-tok' });
-    }
-    if (method === 'POST' && /\/conversations$/.test(url.split('?')[0])) {
-      return json({ id: 4242 });
-    }
-    if (method === 'POST' && /\/messages$/.test(url.split('?')[0])) {
-      const sent = (req.postDataJSON() as { content?: string } | null)?.content ?? '';
-      const userMsg = { id: nextId++, content: sent, message_type: 0 };
-      messages.push(userMsg);
-      messages.push({
-        id: nextId++,
-        content: 'Thanks, an agent will help shortly.',
-        message_type: 1,
-      });
-      return json(userMsg);
-    }
-    if (method === 'GET' && /\/messages$/.test(url.split('?')[0])) {
-      return json(messages);
-    }
-    return json({}, 200);
-  });
-}
+const KNOWLEDGE_BASE_URL = 'https://docs.s4i.co/hc/nasnet/fa';
 
 test.describe('Help page', () => {
   test('Help tab is enabled and navigates to the help page', async ({
@@ -48,7 +13,6 @@ test.describe('Help page', () => {
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
-    await mockChatwoot(page);
     await page.goto(`/router/${ROUTER.id}`);
 
     const helpTab = page.getByRole('tab', { name: 'Help' });
@@ -56,37 +20,22 @@ test.describe('Help page', () => {
     await helpTab.click();
 
     await expect(page).toHaveURL(new RegExp(`/router/${ROUTER.id}/help$`));
-    await expect(page.getByTestId('help-chat')).toBeVisible();
+    await expect(page.getByTitle('AI Assistant chat')).toBeVisible();
   });
 
-  test('AI chat sends a message and shows the agent reply', async ({
+  test('support buttons link to knowledge base, Telegram and GitHub in a new tab', async ({
     page,
     resetMocks,
     seedRouter,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
-    await mockChatwoot(page);
     await page.goto(`/router/${ROUTER.id}/help`);
 
-    const input = page.getByRole('textbox', { name: 'Message' });
-    await input.fill('How do I reset my password?');
-    await page.getByRole('button', { name: 'Send message' }).click();
-
-    const chat = page.getByTestId('help-chat');
-    await expect(chat).toContainText('How do I reset my password?');
-    await expect(chat).toContainText('Thanks, an agent will help shortly.');
-  });
-
-  test('support buttons link to Telegram and GitHub in a new tab', async ({
-    page,
-    resetMocks,
-    seedRouter,
-  }) => {
-    await resetMocks();
-    await seedRouter(ROUTER);
-    await mockChatwoot(page);
-    await page.goto(`/router/${ROUTER.id}/help`);
+    const knowledgeBase = page.getByRole('link', { name: /knowledge base/i });
+    await expect(knowledgeBase).toHaveAttribute('target', '_blank');
+    await expect(knowledgeBase).toHaveAttribute('rel', /noopener/);
+    await expect(knowledgeBase).toHaveAttribute('href', KNOWLEDGE_BASE_URL);
 
     const telegram = page.getByRole('link', { name: /telegram/i });
     await expect(telegram).toHaveAttribute('target', '_blank');


### PR DESCRIPTION

<img width="1246" height="818" alt="Screenshot 2026-05-23 at 03 23 02" src="https://github.com/user-attachments/assets/c99281ea-18f5-4d31-bb76-f916a763ea58" />


## Summary
- Replace inline AI chat with embedded Chatwoot widget iframe
- Add Knowledge Base link card, remove YouTube link
- Update help page e2e tests for new layout