### PR TITLE
feat(docs,ci): MikroTik install guide and snapshot container tars

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -94,3 +94,48 @@ jobs:
               "${IMAGE}:dev-arm64" \
               "${IMAGE}:dev-armv7"
           done
+
+  package:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Log in to ${{ env.REGISTRY }}
+        run: skopeo login "${{ env.REGISTRY }}" -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Package per-arch RouterOS container tars
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for SUFFIX in amd64 arm64 armv7; do
+            REF="${IMAGE}:dev-${SUFFIX}"
+            OUT="nasnet-panel-dev-${SUFFIX}.tar"
+            echo "-> ${REF} => dist/${OUT}"
+            skopeo copy "docker://${REF}" "docker-archive:dist/${OUT}:nasnet-panel:dev-${SUFFIX}"
+            ( cd dist && sha256sum "${OUT}" > "${OUT}.sha256" )
+          done
+
+      - name: Publish to rolling snapshot release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: snapshot
+          name: Dev snapshot
+          prerelease: true
+          body: |
+            Rolling development snapshot, rebuilt on every push to `dev`.
+            Commit ${{ github.sha }}.
+
+            RouterOS container image tars consumed by `scripts/install.sh`:
+            - `nasnet-panel-dev-amd64.tar` (RouterOS x86_64)
+            - `nasnet-panel-dev-arm64.tar` (RouterOS arm64)
+            - `nasnet-panel-dev-armv7.tar` (RouterOS arm)
+          files: |
+            dist/*.tar
+            dist/*.tar.sha256

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Supported platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`. Image is buil
 - RouterOS v7.x with the `container` package installed and enabled.
 - Container `device-mode` enabled (requires physical confirmation on first activation: reset button or cold reboot).
 - External storage (the script defaults to `disk1/`).
-- ≥ 128 MB free RAM on the router.
+- ≥ 30 MB free RAM on the router.
 - Local tools: `bash`, `curl`, `ssh`, `scp`, `sha256sum` (or `shasum`).
 
 **Run it**
@@ -197,8 +197,8 @@ When it finishes, the panel is reachable at `http://<router-ip>:8080` (or whatev
 | `--dry-run`          | Print every action the script would take, change nothing.          |
 | `--uninstall`        | Remove the container, networking, NAT rules, and uploaded tarball. |
 | `--config <file>`    | Env-style file with `ROUTER_IP=`, `ROUTER_USER=`, `ROUTER_PASS=`.  |
-| `--version <tag>`    | Release tag to install. Defaults to the latest release.            |
-| `--image-tar <path>` | Use a local tarball instead of downloading a release asset.        |
+| `--version <tag>`    | Release tag to install (default `snapshot`).                       |
+| `--image-tar <path>` | Use a local tar instead of downloading a release asset.            |
 | `--lan-port <port>`  | LAN-facing port for the dst-nat rule (default `8080`).             |
 | `--no-rollback`      | Do not undo partial state on failure (useful for debugging).       |
 | `-v`, `--verbose`    | Verbose output.                                                    |
@@ -208,12 +208,16 @@ When it finishes, the panel is reachable at `http://<router-ip>:8080` (or whatev
 
 1. Probes Winbox (8291) and SSH (22) on the router; collects credentials.
 2. Checks RouterOS version, architecture (`arm` / `arm64` / `x86_64`), free RAM, `container` package, and `device-mode container`.
-3. Downloads `nasnet-panel-<version>-<arch>.tar` and `.sha256` from the latest GitHub release (or the tag passed to `--version`) and verifies the checksum.
+3. Downloads the prebuilt container tar for the detected arch (`amd64` / `arm64` / `armv7`) from the rolling `snapshot` release (or the tag passed to `--version`) and verifies its checksum.
 4. Configures container networking: `veth1` at `192.168.50.2/24`, `containers` bridge at `192.168.50.1/24`, `srcnat` masquerade for `192.168.50.0/24`, and `dstnat` from `--lan-port` to the veth.
 5. SCPs the tarball to `disk1/`, adds the container with `start-on-boot=yes`, and starts it.
 6. Polls `http://<router>:<lan-port>/health` for up to 120 s; dumps container logs on failure.
 
 To remove everything: `bash scripts/install.sh --uninstall --config router.env`.
+
+**Prefer to install by hand?**
+
+See [`scripts/INSTALL.md`](scripts/INSTALL.md) for the full installation guide. It walks through both the automated script and a manual route via Winbox or the RouterOS terminal, reproducing every networking, firewall, and container command the installer runs.
 
 ### 3. From source (development)
 

--- a/scripts/INSTALL.md
+++ b/scripts/INSTALL.md
@@ -1,0 +1,264 @@
+# Installing Nasnet Panel on MikroTik
+
+This guide explains how to install Nasnet Panel on a MikroTik RouterOS device. There are two routes: the automated `install.sh` script (recommended) and a manual installation via Winbox or the RouterOS terminal. Both deploy the panel as a RouterOS container and produce an identical result.
+
+## Before you begin
+
+You will need the following, regardless of which route you choose.
+
+- A MikroTik router running RouterOS v7.x.
+- The `container` package installed and enabled. Install it from **System > Packages** in WebFig or Winbox, or download the matching architecture from mikrotik.com. After enabling, reboot the router.
+- Container `device-mode` enabled. The first time this is switched on, RouterOS demands physical confirmation: press the reset/mode button briefly, or perform a cold power-cycle (unplug, plug back in) for boards without a button.
+- External storage available. The container, its tarball, and root directory live under `disk1/` by default.
+- At least 30 MB of free RAM on the router.
+- A supported CPU architecture: `arm`, `arm64`, or `x86_64`.
+
+The router must also be reachable on the RouterOS API port (8291) and SSH port (22) from the machine running the script.
+
+## Route 1: The automated script
+
+The `install.sh` script performs the entire deployment end-to-end: it probes the router, verifies prerequisites, enables device-mode if required, downloads the prebuilt container image tar for the router's architecture, uploads it, configures the networking and firewall rules, creates and starts the container, then polls the panel's health endpoint until it responds.
+
+By default it installs the latest snapshot, published as ready-to-use RouterOS tars on the rolling `snapshot` release. The build pipeline packages these (with `skopeo`) so nothing needs converting locally. Pass `--version <tag>` to install a tagged release instead, or `--image-tar <path>` to use a local tar and skip the download entirely.
+
+### Local prerequisites
+
+The machine running the script (not the router) needs `bash`, `curl`, `ssh`, `scp`, and either `sha256sum` or `shasum`. How you get these depends on your operating system.
+
+**Linux**
+
+These tools are present on virtually every distribution out of the box. If `scp` is missing, install the OpenSSH client (`openssh-clients` on Fedora/RHEL, `openssh-client` on Debian/Ubuntu).
+
+**macOS**
+
+`bash`, `curl`, `ssh`, and `scp` ship with macOS. There is no `sha256sum`, but `shasum` is present and the script uses it automatically. Run the script from Terminal.
+
+**Windows**
+
+The script will not run under Command Prompt or PowerShell directly, as it is a bash script. Use one of the following:
+
+- **WSL (recommended).** Install Windows Subsystem for Linux (`wsl --install` in an elevated PowerShell), open your Linux shell, and run the script as you would on Linux.
+- **Git Bash.** Installed with [Git for Windows](https://git-scm.com/download/win). It provides `bash`, `curl`, `ssh`, and `scp`. Run the script from a Git Bash window.
+
+If you would rather not set up a Unix shell on Windows at all, use the manual route in [Route 2](#route-2-manual-installation-via-winbox-or-terminal) instead. Winbox is a native Windows application, so the manual installation needs no extra tooling.
+
+### Running it interactively
+
+The simplest invocation prompts you for the router's address and credentials:
+
+```bash
+bash install.sh
+```
+
+You will be asked for the router IP, then the user (defaults to `admin`) and password. The script probes the API and SSH ports before continuing, and will prompt for alternative ports if the defaults are not open.
+
+### Running it non-interactively
+
+Supply the credentials through an env-style config file:
+
+```bash
+cat > router.env <<'EOF'
+ROUTER_IP=192.168.88.1
+ROUTER_USER=admin
+ROUTER_PASS=secret
+EOF
+
+bash install.sh --config router.env
+```
+
+Alternatively, pass the password through the `SSHPASS` environment variable rather than writing it to disk:
+
+```bash
+SSHPASS=secret bash install.sh --config router.env
+```
+
+### Useful flags
+
+| Flag                 | Purpose                                                                 |
+| -------------------- | ----------------------------------------------------------------------- |
+| `--dry-run`          | Print every action the script would take, change nothing.               |
+| `--uninstall`        | Stop and remove the container, networking, NAT rules, and uploaded tar. |
+| `--config <file>`    | Read `ROUTER_IP`, `ROUTER_USER`, and `ROUTER_PASS` from an env file.    |
+| `--version <tag>`    | Release tag to install (default: `snapshot`).                           |
+| `--image-tar <path>` | Use a local tar instead of downloading a release asset.                 |
+| `--lan-port <port>`  | LAN port for the panel (default: 8080).                                 |
+| `--no-rollback`      | Leave partial state in place on failure rather than undoing it.         |
+| `-v`, `--verbose`    | Verbose output.                                                         |
+| `-h`, `--help`       | Show usage.                                                             |
+
+### When it finishes
+
+The panel is reachable at `http://<router-ip>:8080/`, or on whichever port you passed to `--lan-port`. If anything fails partway through, the script rolls back the changes it made, unless you passed `--no-rollback`.
+
+To remove everything later:
+
+```bash
+bash install.sh --uninstall --config router.env
+```
+
+## Route 2: Manual installation via Winbox or terminal
+
+Use this route if you would rather not run the script, or if your workstation cannot reach the router directly. Every step below mirrors exactly what the script does. Commands are written for the RouterOS terminal (the **New Terminal** window in Winbox); the equivalent menus are noted where helpful.
+
+### Step 1: Confirm the prerequisites
+
+In the terminal, check the package is present and enabled:
+
+```
+/system/package/print where name=container
+```
+
+If it is disabled, enable it and reboot:
+
+```
+/system/package/enable container
+/system/reboot
+```
+
+Check the architecture and free memory:
+
+```
+/system/resource/print
+```
+
+The architecture must be `arm`, `arm64`, or `x86_64`, and free memory must be at least 30 MB.
+
+### Step 2: Enable container device-mode
+
+```
+/system/device-mode/print
+```
+
+If `container` is `no`, enable it. RouterOS will wait for physical confirmation:
+
+```
+/system/device-mode/update container=yes
+```
+
+Within roughly two minutes, press the router's reset/mode button briefly, or cold power-cycle the router. Re-run the print command to confirm `container: yes`.
+
+### Step 3: Download and upload the image
+
+The build pipeline publishes ready-to-use RouterOS container tars on the rolling `snapshot` release, so there is nothing to package by hand. Download the one that matches your board's architecture. Note that RouterOS and the asset names use different labels:
+
+| RouterOS architecture | Asset to download            |
+| --------------------- | ---------------------------- |
+| `x86_64`              | `nasnet-panel-dev-amd64.tar` |
+| `arm64`               | `nasnet-panel-dev-arm64.tar` |
+| `arm`                 | `nasnet-panel-dev-armv7.tar` |
+
+You checked the architecture with `/system/resource/print` in Step 1. Each tar has a matching `.sha256` file; verify the download before uploading.
+
+In Winbox, open **Files** and drag the tar into the `disk1` directory, so it lands at `disk1/nasnet-panel-dev-<suffix>.tar`. Note that path; you reference it when creating the container in Step 5.
+
+### Step 4: Configure the networking
+
+These commands create a virtual ethernet interface for the container, a bridge, an address, and the firewall rules that expose the panel on the LAN. Run them in order.
+
+```
+/interface/veth/add name=veth1 address=192.168.50.2/24 gateway=192.168.50.1
+
+/interface/bridge/add name=containers
+
+/ip/address/add address=192.168.50.1/24 interface=containers
+
+/interface/bridge/port/add bridge=containers interface=veth1
+
+/ip/firewall/nat/add chain=srcnat action=masquerade src-address=192.168.50.0/24 comment="nasnet-panel-installer-srcnat"
+
+/ip/firewall/nat/add chain=dstnat action=dst-nat protocol=tcp dst-port=8080 to-addresses=192.168.50.2 to-ports=80 comment="nasnet-panel-installer-dstnat"
+
+/ip/firewall/filter/add chain=forward action=accept protocol=tcp dst-address=192.168.50.2 dst-port=80 comment="nasnet-panel-installer-forward"
+```
+
+The dstnat rule maps LAN port 8080 to the container. If you want the panel on a different port, change `dst-port=8080` accordingly. Move both new firewall rules to the top of their respective chains so they take effect ahead of any blocking rules:
+
+```
+/ip/firewall/nat/move [find comment="nasnet-panel-installer-dstnat"] destination=0
+/ip/firewall/filter/move [find comment="nasnet-panel-installer-forward"] destination=0
+```
+
+### Step 5: Create and start the container
+
+Once the `container` package is installed and device-mode is enabled, Winbox and WebFig show a **Container** menu in the left-hand sidebar. You can create the container there instead of using the terminal.
+
+**Using the Container menu (Winbox/WebFig)**
+
+1. Open **Container** and click the **+** (Add) button.
+2. Set the fields:
+   - **File:** `disk1/nasnet-panel-dev-arm64.tar` (the tar you uploaded; match your architecture)
+   - **Interface:** `veth1`
+   - **Root Dir:** `disk1/images/nnc`
+   - **Name:** `nnc`
+   - **Start On Boot:** ticked
+   - **Logging:** ticked
+3. Click **OK**. The new entry appears in the list and RouterOS begins extracting the image; the status moves through `extracting` to `stopped` once ready.
+4. Select the `nnc` row and click **Start**. The status changes to `running`.
+
+**Using the terminal**
+
+Create the container from the uploaded tarball, attaching it to `veth1`. Replace the filename with the tarball you uploaded.
+
+```
+/container/add file=disk1/nasnet-panel-dev-arm64.tar interface=veth1 root-dir=disk1/images/nnc name=nnc start-on-boot=yes logging=yes
+```
+
+RouterOS extracts the image, which takes a moment. Once the container shows as extracted, start it:
+
+```
+/container/start [find name=nnc]
+```
+
+**Alternative: pull from the registry (not recommended)**
+
+Instead of uploading a tar, RouterOS can pull the image straight from GitHub Container Registry. In the New Container dialog this is the **Remote Image** field rather than **File**; set the registry first in **Container > Config**:
+
+```
+/container/config/set registry-url=https://ghcr.io tmpdir=disk1/pull
+/container/add remote-image=nasnet-community/nasnet-panel:dev interface=veth1 root-dir=disk1/images/nnc name=nnc start-on-boot=yes logging=yes
+```
+
+Use the multi-arch `dev` tag (or `latest`); the registry serves the image matching your board, so no architecture suffix is needed. This route needs working DNS and outbound HTTPS on the router, and `tmpdir` must sit on the external disk.
+
+RouterOS's registry pull is unreliable in practice, which is why the tar route above is the supported method. Treat this as a convenience that may not work on every board or RouterOS version, and fall back to the tar if the pull stalls or errors.
+
+### Step 6: Verify
+
+In the **Container** menu, the `nnc` row should show status `running`. From the terminal you can check the same thing:
+
+```
+/container/print
+```
+
+Then confirm the panel is serving. From a machine on the LAN:
+
+```
+http://<router-ip>:8080/
+```
+
+The health endpoint at `http://<router-ip>:8080/health` should return HTTP 200 once the container is fully up. If it does not, inspect the container and its logs:
+
+```
+/container/print detail where name=nnc
+/log/print where topics~"container"
+```
+
+## Removing Nasnet Panel manually
+
+To undo a manual installation, stop and remove the container, then delete the networking and firewall entries and the uploaded tarball:
+
+```
+/container/stop [find name=nnc]
+/container/remove [find name=nnc]
+
+/ip/firewall/nat/remove [find comment="nasnet-panel-installer-srcnat"]
+/ip/firewall/nat/remove [find comment="nasnet-panel-installer-dstnat"]
+/ip/firewall/filter/remove [find comment="nasnet-panel-installer-forward"]
+
+/interface/bridge/port/remove [find interface=veth1]
+/ip/address/remove [find address=192.168.50.1/24]
+/interface/bridge/remove [find name=containers]
+/interface/veth/remove [find name=veth1]
+
+/file/remove [find name="disk1/nasnet-panel-dev-arm64.tar"]
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 GH_OWNER="nasnet-community"
 GH_REPO="nasnet-panel"
 ASSET_PREFIX="nasnet-panel"
+SNAPSHOT_RELEASE="snapshot"
+SNAPSHOT_CHANNEL="dev"
 
 BRIDGE_NAME="containers"
 BRIDGE_IP_CIDR="192.168.50.1/24"
@@ -22,7 +24,7 @@ CONTAINER_ROOT_DIR="disk1/images/nnc"
 TAR_REMOTE_DIR="disk1"
 
 COMMENT_TAG="nasnet-panel-installer"
-MIN_FREE_MB=128
+MIN_FREE_MB=30
 DEVICE_MODE_TIMEOUT=120
 START_TIMEOUT=120
 
@@ -49,7 +51,7 @@ Usage: install.sh [options]
   --dry-run            Print actions, change nothing.
   --uninstall          Stop+remove container, networking, uploaded tar.
   --config <file>      env-style file: ROUTER_IP=, ROUTER_USER=, ROUTER_PASS=
-  --version <tag>      Release tag to install (default: latest).
+  --version <tag>      Release tag to install (default: snapshot).
   --image-tar <path>   Use a local tar instead of downloading a release asset.
   --lan-port <port>    LAN port for dstnat to panel (default: 8080).
   --no-rollback        Do not undo partial state on failure.
@@ -526,27 +528,32 @@ ensure_device_mode() {
   exit 1
 }
 
-# ---- release download ------------------------------------------------------
-resolve_version() {
-  if [[ -n "$VERSION" ]]; then
-    printf '%s' "$VERSION"; return
-  fi
-  local tag
-  tag="$(curl -fsSL "https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/releases/latest" \
-            | grep -m1 '"tag_name"' | awk -F'"' '{print $4}')"
-  [[ -n "$tag" ]] || { err "could not resolve latest release"; exit 1; }
-  printf '%s' "$tag"
+# ---- image download --------------------------------------------------------
+# RouterOS reports arm/arm64/x86_64; release assets use the image build suffix.
+asset_suffix() {
+  case "$1" in
+    x86_64) printf 'amd64' ;;
+    arm64)  printf 'arm64' ;;
+    arm)    printf 'armv7' ;;
+    *) err "unsupported architecture: $1"; exit 1 ;;
+  esac
 }
 
 download_asset() {
-  local version="$1" arch="$2"
-  local asset="${ASSET_PREFIX}-${version}-${arch}.tar"
-  local url="https://github.com/${GH_OWNER}/${GH_REPO}/releases/download/${version}/${asset}"
-  local sha_url="${url}.sha256"
-  local out_dir="${TMPDIR:-/tmp}/nasnet-panel-installer"
+  local arch="$1" release channel suffix asset url sha_url out_dir out sha
+  if [[ -n "$VERSION" ]]; then
+    release="$VERSION"; channel="${VERSION#v}"
+  else
+    release="$SNAPSHOT_RELEASE"; channel="$SNAPSHOT_CHANNEL"
+  fi
+  suffix="$(asset_suffix "$arch")"
+  asset="${ASSET_PREFIX}-${channel}-${suffix}.tar"
+  url="https://github.com/${GH_OWNER}/${GH_REPO}/releases/download/${release}/${asset}"
+  sha_url="${url}.sha256"
+  out_dir="${TMPDIR:-/tmp}/nasnet-panel-installer"
   mkdir -p "$out_dir"
-  local out="${out_dir}/${asset}"
-  local sha="${out}.sha256"
+  out="${out_dir}/${asset}"
+  sha="${out}.sha256"
 
   log "Downloading ${asset} ..."
   curl -fL --progress-bar "$url"     -o "$out" || { err "download failed: $url"; exit 1; }
@@ -805,9 +812,12 @@ main() {
     log "Using local tar: ${LOCAL_TAR}"
   else
     log ""
-    local tag; tag="$(resolve_version)"
-    log "Release: ${tag}  arch: ${ROUTEROS_ARCH}"
-    download_asset "$tag" "$ROUTEROS_ARCH"
+    if [[ -n "$VERSION" ]]; then
+      log "Release: ${VERSION}  arch: ${ROUTEROS_ARCH}"
+    else
+      log "Snapshot release: ${SNAPSHOT_RELEASE}  arch: ${ROUTEROS_ARCH}"
+    fi
+    download_asset "$ROUTEROS_ARCH"
   fi
 
   upload_tar "$LOCAL_TAR"


### PR DESCRIPTION
## Summary

- Add MikroTik install guide covering the script and the manual Winbox/terminal routes
- Installer now fetches prebuilt per-arch tars from the rolling snapshot release, with the arch mapping and 30 MB RAM gate fixed
- Snapshot CI packages RouterOS container tars via skopeo and publishes them to the snapshot prerelease
