### PR TITLE
Feat(be): Added endpoint to get traffic graph data for each interface (ether,wifi,vpn, etc.)

### DIFF
--- a/backend/internal/graph/monitor.go
+++ b/backend/internal/graph/monitor.go
@@ -1,0 +1,320 @@
+package graph
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"nasnet-panel/pkg/routeros"
+	"nasnet-panel/pkg/simplequeue"
+	"nasnet-panel/pkg/utils"
+)
+
+// RouterCredentials stores connection info for a RouterOS device.
+type RouterCredentials struct {
+	IP       string
+	Username string
+	Password string
+	Port     int
+}
+
+// InterfaceStats holds traffic statistics for an interface.
+type InterfaceStats struct {
+	RxBytes   int64
+	TxBytes   int64
+	Timestamp time.Time
+}
+
+// RouterMonitor tracks interface traffic for a single RouterOS device.
+type RouterMonitor struct {
+	credentials        RouterCredentials
+	client             *routeros.Client
+	queues             map[string]*simplequeue.Queue[TrafficData]
+	previousStats      map[string]InterfaceStats
+	previousInterfaces []string
+	queueSize          int
+	mu                 sync.RWMutex
+	done               chan struct{}
+	ticker             *time.Ticker
+	stopOnce           sync.Once
+}
+
+var (
+	activeMonitors = make(map[string]*RouterMonitor)
+	monitorsMu     sync.RWMutex
+)
+
+// StartMonitoring creates and starts a monitoring goroutine for a RouterOS device.
+// The function runs in a separate goroutine and periodically fetches interface statistics.
+// If a monitor already exists for the given IP, it is reused and not recreated.
+// queueSize specifies the capacity for each interface's traffic data queue.
+func StartMonitoring(credentials RouterCredentials, interval time.Duration, queueSize int) error {
+	monitorsMu.Lock()
+	defer monitorsMu.Unlock()
+
+	// If monitor already exists for this IP, reuse it without recreating
+	if _, ok := activeMonitors[credentials.IP]; ok {
+		log.Printf("Monitor already running for router %s, reusing existing monitor", credentials.IP)
+		return nil
+	}
+
+	client, err := routeros.NewClient(routeros.ConnectionConfig{
+		Address:  credentials.IP,
+		Username: credentials.Username,
+		Password: credentials.Password,
+		Port:     credentials.Port,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create RouterOS client for %s: %w", credentials.IP, err)
+	}
+
+	monitor := &RouterMonitor{
+		credentials:        credentials,
+		client:             client,
+		queues:             make(map[string]*simplequeue.Queue[TrafficData]),
+		previousStats:      make(map[string]InterfaceStats),
+		previousInterfaces: []string{},
+		queueSize:          queueSize,
+		done:               make(chan struct{}),
+		ticker:             time.NewTicker(interval),
+	}
+
+	activeMonitors[credentials.IP] = monitor
+
+	// Start monitoring in a separate goroutine
+	go monitor.run()
+
+	log.Printf("Started monitoring interfaces for router %s", credentials.IP)
+	return nil
+}
+
+// StopMonitoring stops the monitoring goroutine for a RouterOS device.
+func StopMonitoring(ip string) {
+	monitorsMu.Lock()
+	defer monitorsMu.Unlock()
+
+	if monitor, ok := activeMonitors[ip]; ok {
+		monitor.Stop()
+		delete(activeMonitors, ip)
+		log.Printf("Stopped monitoring router %s", ip)
+	}
+}
+
+// GetMonitor returns the monitor for a given router IP.
+func GetMonitor(ip string) *RouterMonitor {
+	monitorsMu.RLock()
+	defer monitorsMu.RUnlock()
+	return activeMonitors[ip]
+}
+
+// GetInterfaceQueue returns the traffic queue for a specific interface.
+func (m *RouterMonitor) GetInterfaceQueue(interfaceName string) *simplequeue.Queue[TrafficData] {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.queues[interfaceName]
+}
+
+// Stop gracefully stops the monitor.
+func (m *RouterMonitor) Stop() {
+	m.stopOnce.Do(func() {
+		close(m.done)
+		m.ticker.Stop()
+		if m.client != nil {
+			m.client.Close()
+		}
+	})
+}
+
+// run is the main monitoring loop.
+func (m *RouterMonitor) run() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Monitor for %s crashed: %v", m.credentials.IP, r)
+		}
+	}()
+
+	// Initial fetch
+	m.fetchAndUpdateStats()
+
+	for {
+		select {
+		case <-m.done:
+			return
+		case <-m.ticker.C:
+			m.fetchAndUpdateStats()
+		}
+	}
+}
+
+// fetchAndUpdateStats fetches current interface statistics and updates queues.
+func (m *RouterMonitor) fetchAndUpdateStats() {
+	interfaces, err := m.client.ListInterfaces()
+	if err != nil {
+		if isCredentialError(err) {
+			log.Printf("Credentials invalid for router %s - stopping monitor", m.credentials.IP)
+			m.Stop()
+			// Remove from active monitors
+			monitorsMu.Lock()
+			delete(activeMonitors, m.credentials.IP)
+			monitorsMu.Unlock()
+			return
+		}
+		log.Printf("Failed to fetch interfaces from %s: %v", m.credentials.IP, err)
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Build current interface list
+	currentInterfaces := make([]string, 0, len(interfaces))
+	currentStats := make(map[string]InterfaceStats)
+
+	now := time.Now()
+
+	for _, iface := range interfaces {
+		ifName := iface.Name
+		currentInterfaces = append(currentInterfaces, ifName)
+
+		var rxBytes, txBytes int64
+		if iface.RxByte != nil {
+			rxBytes = *iface.RxByte
+		}
+		if iface.TxByte != nil {
+			txBytes = *iface.TxByte
+		}
+
+		currentStats[ifName] = InterfaceStats{
+			RxBytes:   rxBytes,
+			TxBytes:   txBytes,
+			Timestamp: now,
+		}
+
+		// Create queue for new interfaces
+		if _, exists := m.queues[ifName]; !exists {
+			m.queues[ifName] = simplequeue.New[TrafficData](ifName, m.queueSize)
+		}
+
+		// Calculate rate and push to queue
+		m.calculateAndPushTraffic(ifName, currentStats[ifName])
+	}
+
+	// Remove queues for deleted interfaces
+	for _, prevIfName := range m.previousInterfaces {
+		found := false
+		for _, currIfName := range currentInterfaces {
+			if prevIfName == currIfName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			delete(m.queues, prevIfName)
+			delete(m.previousStats, prevIfName)
+			log.Printf("Interface %s removed from monitoring on %s", prevIfName, m.credentials.IP)
+		}
+	}
+
+	m.previousInterfaces = currentInterfaces
+	m.previousStats = currentStats
+}
+
+// calculateAndPushTraffic calculates traffic rate and pushes data to the queue.
+func (m *RouterMonitor) calculateAndPushTraffic(ifName string, currentStats InterfaceStats) {
+	rxStr, txStr := "0 B/s", "0 B/s"
+
+	if prevStats, exists := m.previousStats[ifName]; exists {
+		timeDiffSecs := currentStats.Timestamp.Sub(prevStats.Timestamp).Seconds()
+		if timeDiffSecs > 0 {
+			rxRate := float64(currentStats.RxBytes-prevStats.RxBytes) / timeDiffSecs
+			txRate := float64(currentStats.TxBytes-prevStats.TxBytes) / timeDiffSecs
+
+			rxStr = formatRate(int64(rxRate))
+			txStr = formatRate(int64(txRate))
+		}
+	}
+
+	traffic := TrafficData{
+		RxBytes:   currentStats.RxBytes,
+		TxBytes:   currentStats.TxBytes,
+		RX:        rxStr,
+		TX:        txStr,
+		Timestamp: currentStats.Timestamp,
+	}
+
+	if queue, exists := m.queues[ifName]; exists {
+		queue.Push(traffic)
+	}
+}
+
+// formatRate formats bytes per second as a human-readable string.
+func formatRate(bytesPerSecond int64) string {
+	if bytesPerSecond < 0 {
+		bytesPerSecond = 0
+	}
+	return utils.BytesToSizeString(bytesPerSecond) + "/s"
+}
+
+// GetRouterStats returns all current traffic stats for a router.
+func (m *RouterMonitor) GetRouterStats() map[string][]TrafficData {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	stats := make(map[string][]TrafficData)
+	for ifName, queue := range m.queues {
+		stats[ifName] = queue.GetAll()
+	}
+	return stats
+}
+
+// GetInterfaceStats returns traffic stats for a specific interface.
+func (m *RouterMonitor) GetInterfaceStats(ifName string) []TrafficData {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if queue, exists := m.queues[ifName]; exists {
+		return queue.GetAll()
+	}
+	return nil
+}
+
+// GetActiveRouters returns a list of currently monitored router IPs.
+func GetActiveRouters() []string {
+	monitorsMu.RLock()
+	defer monitorsMu.RUnlock()
+
+	ips := make([]string, 0, len(activeMonitors))
+	for ip := range activeMonitors {
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+// isCredentialError checks if an error is due to invalid credentials.
+func isCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+
+	credentialKeywords := []string{
+		"after login:",
+		"no such user",
+		"invalid user",
+		"invalid password",
+		"authentication failed",
+		"login failed",
+		"unauthorized",
+	}
+
+	for _, keyword := range credentialKeywords {
+		if strings.Contains(errMsg, keyword) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/backend/internal/graph/monitor.go
+++ b/backend/internal/graph/monitor.go
@@ -1,3 +1,4 @@
+// Package graph provides traffic monitoring for RouterOS interfaces.
 package graph
 
 import (
@@ -7,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"nasnet-panel/pkg/routeros"
+	"nasnet-panel/pkg/routeros" //nolint:misspell // routeros is a valid package name
 	"nasnet-panel/pkg/simplequeue"
 	"nasnet-panel/pkg/utils"
 )
@@ -30,7 +31,7 @@ type InterfaceStats struct {
 // RouterMonitor tracks interface traffic for a single RouterOS device.
 type RouterMonitor struct {
 	credentials        RouterCredentials
-	client             *routeros.Client
+	client             *routeros.Client //nolint:misspell // routeros is a valid package name
 	queues             map[string]*simplequeue.Queue[TrafficData]
 	previousStats      map[string]InterfaceStats
 	previousInterfaces []string
@@ -49,7 +50,7 @@ var (
 // StartMonitoring creates and starts a monitoring goroutine for a RouterOS device.
 // The function runs in a separate goroutine and periodically fetches interface statistics.
 // If a monitor already exists for the given IP, it is reused and not recreated.
-// queueSize specifies the capacity for each interface's traffic data queue.
+// QueueSize specifies the capacity for each interface's traffic data queue.
 func StartMonitoring(credentials RouterCredentials, interval time.Duration, queueSize int) error {
 	monitorsMu.Lock()
 	defer monitorsMu.Unlock()
@@ -60,6 +61,7 @@ func StartMonitoring(credentials RouterCredentials, interval time.Duration, queu
 		return nil
 	}
 
+	//nolint:misspell // routeros is a valid package name
 	client, err := routeros.NewClient(routeros.ConnectionConfig{
 		Address:  credentials.IP,
 		Username: credentials.Username,
@@ -122,7 +124,7 @@ func (m *RouterMonitor) Stop() {
 		close(m.done)
 		m.ticker.Stop()
 		if m.client != nil {
-			m.client.Close()
+			_ = m.client.Close()
 		}
 	})
 }
@@ -174,7 +176,8 @@ func (m *RouterMonitor) fetchAndUpdateStats() {
 
 	now := time.Now()
 
-	for _, iface := range interfaces {
+	for i := range interfaces {
+		iface := &interfaces[i]
 		ifName := iface.Name
 		currentInterfaces = append(currentInterfaces, ifName)
 

--- a/backend/internal/graph/traffic.go
+++ b/backend/internal/graph/traffic.go
@@ -1,0 +1,12 @@
+package graph
+
+import "time"
+
+// TrafficData represents RX/TX traffic data with timestamp.
+type TrafficData struct {
+	RxBytes   int64     `json:"rxBytes"`
+	TxBytes   int64     `json:"txBytes"`
+	RX        string    `json:"rx"`
+	TX        string    `json:"tx"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/backend/internal/handler/interface.go
+++ b/backend/internal/handler/interface.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"nasnet-panel/internal/graph"
 	"nasnet-panel/pkg/routeros"
 )
 
@@ -210,5 +211,44 @@ func HandleUpdateWANInterface(c echo.Context) error {
 		"name":    name,
 		"type":    req.Type,
 		"comment": comment,
+	})
+}
+
+// HandleGetInterfaceGraph returns traffic statistics for a specific interface.
+// @Summary Get interface traffic graph
+// @Description Returns historical traffic data (send/receive rates) for a specific interface
+// @Tags Interface
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param nameOrID path string true "Interface name or ID"
+// @Produce json
+// @Success 200 {object} Response{data=map[string]interface{}}
+// @Failure 401 {object} Response
+// @Failure 404 {object} Response
+// @Router /api/interface/graph/{nameOrID} [get].
+func HandleGetInterfaceGraph(c echo.Context) error {
+	nameOrID := c.Param("nameOrID")
+	if nameOrID == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "Interface name or ID is required", nil)
+	}
+
+	creds, err := GetRouterOSCredentials(c)
+	if err != nil {
+		return ErrorResponse(c, http.StatusUnauthorized, "Authentication required", err)
+	}
+
+	monitor := graph.GetMonitor(creds.RouterOSHost)
+	if monitor == nil {
+		return ErrorResponse(c, http.StatusNotFound, "Router is not being monitored", nil)
+	}
+
+	stats := monitor.GetInterfaceStats(nameOrID)
+	if stats == nil {
+		return ErrorResponse(c, http.StatusNotFound, "Interface not found or has no traffic data", nil)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Interface traffic statistics retrieved successfully", map[string]interface{}{
+		"interfaceName": nameOrID,
+		"trafficData":   stats,
 	})
 }

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -1,8 +1,12 @@
 package middleware
 
 import (
+	"log"
+	"time"
+
 	"nasnet-panel/internal/auth"
 	ctxpkg "nasnet-panel/internal/context"
+	"nasnet-panel/internal/graph"
 
 	"github.com/labstack/echo/v4"
 )
@@ -33,6 +37,21 @@ func RouterOSAuth(next echo.HandlerFunc) echo.HandlerFunc {
 		credentials.RouterOSHost = routerOSHost
 
 		ctxpkg.SetCredentials(c, credentials)
+
+		// Start monitoring traffic for this router in the background
+		go func() {
+			routerCreds := graph.RouterCredentials{
+				IP:       routerOSHost,
+				Username: credentials.Username,
+				Password: credentials.Password,
+				Port:     8728,
+			}
+
+			err := graph.StartMonitoring(routerCreds, 10*time.Second, 30)
+			if err != nil {
+				log.Printf("Failed to start monitoring for router %s: %v", routerOSHost, err)
+			}
+		}()
 
 		return next(c)
 	}

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -68,6 +68,7 @@ func RegisterRoutes(e *echo.Echo) {
 	interfaceGroup.GET("/interfaces", handler.HandleListInterfaces)
 	interfaceGroup.GET("/ethernets", handler.HandleGetEthernetInterfaces)
 	interfaceGroup.GET("/ethernet/:nameOrID", handler.HandleGetEthernetInterface)
+	interfaceGroup.GET("/graph/:nameOrID", handler.HandleGetInterfaceGraph)
 	interfaceGroup.PUT("/wan/:name", handler.HandleUpdateWANInterface)
 
 	dnsGroup := e.Group("/api/dns")

--- a/backend/pkg/simplequeue/queue.go
+++ b/backend/pkg/simplequeue/queue.go
@@ -1,0 +1,115 @@
+package simplequeue
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Queue is a thread-safe generic FIFO queue with fixed capacity.
+type Queue[T any] struct {
+	name     string
+	capacity int
+	data     []T
+	mu       sync.RWMutex
+}
+
+// New creates a new FIFO queue with the given name and capacity.
+func New[T any](name string, capacity int) *Queue[T] {
+	if capacity <= 0 {
+		capacity = 10
+	}
+	return &Queue[T]{
+		name:     name,
+		capacity: capacity,
+		data:     make([]T, 0, capacity),
+	}
+}
+
+// Push adds an item to the queue. If the queue is at capacity, the oldest item is removed.
+func (q *Queue[T]) Push(item T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.data) >= q.capacity {
+		q.data = q.data[1:]
+	}
+	q.data = append(q.data, item)
+}
+
+// Pop removes and returns the first item in the queue.
+// Returns error if queue is empty.
+func (q *Queue[T]) Pop() (T, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var zero T
+	if len(q.data) == 0 {
+		return zero, fmt.Errorf("queue %s is empty", q.name)
+	}
+
+	item := q.data[0]
+	q.data = q.data[1:]
+	return item, nil
+}
+
+// Peek returns the first item without removing it.
+// Returns error if queue is empty.
+func (q *Queue[T]) Peek() (T, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	var zero T
+	if len(q.data) == 0 {
+		return zero, fmt.Errorf("queue %s is empty", q.name)
+	}
+
+	return q.data[0], nil
+}
+
+// Size returns the current number of items in the queue.
+func (q *Queue[T]) Size() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.data)
+}
+
+// Capacity returns the maximum capacity of the queue.
+func (q *Queue[T]) Capacity() int {
+	return q.capacity
+}
+
+// Name returns the name of the queue.
+func (q *Queue[T]) Name() string {
+	return q.name
+}
+
+// IsFull returns true if the queue is at capacity.
+func (q *Queue[T]) IsFull() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.data) >= q.capacity
+}
+
+// IsEmpty returns true if the queue has no items.
+func (q *Queue[T]) IsEmpty() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.data) == 0
+}
+
+// GetAll returns a copy of all items in the queue.
+func (q *Queue[T]) GetAll() []T {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	result := make([]T, len(q.data))
+	copy(result, q.data)
+	return result
+}
+
+// Clear removes all items from the queue.
+func (q *Queue[T]) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.data = make([]T, 0, q.capacity)
+}

--- a/backend/pkg/simplequeue/queue.go
+++ b/backend/pkg/simplequeue/queue.go
@@ -1,3 +1,4 @@
+// Package simplequeue provides a generic thread-safe FIFO queue with fixed capacity.
 package simplequeue
 
 import (


### PR DESCRIPTION
* implemented a simple queue (FIFO) for graph data
* gets samples of all interfaces every 10 seconds after the first successful login starts monitoring
* saves stats in memory for last 30 items
*keeps running monitor for all successful router logins for all interfaces
* auto recovery, auto remove member from queue
* Type-Safe Generics: Queue works with any type via Go 1.18+ generics
* Thread-Safe: All shared state protected with appropriate locks
* Goroutine Management: Graceful shutdown with done channels and sync.Once
* Smart Persistence: Monitors survive client disconnects and reconnects
* Error Resilience: Retries on transient errors, stops only on auth failures
* Configurable: Queue size parameterized in StartMonitoring()
* Minimal Overhead: Single goroutine per router, no per-request overhead
fixes #248