### PR TITLE
fix(fe): show device identity and real serial on home page

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -16,6 +16,7 @@ export interface SystemInfoResponse {
   buildTime: string;
   license: string;
   updateChannel: string;
+  systemId: string;
 }
 
 export interface ResourceInfoResponse {
@@ -305,7 +306,7 @@ export async function fetchSystemOverview(
     buildTime: info.buildTime || '',
     updateChannel: info.updateChannel || '',
     license: info.license || '',
-    serial: `NN-${routerId.slice(-4).toUpperCase()}`,
+    serial: info.systemId || '',
     temperatureC: 0,
     interfaceCount: 0,
     ...dynamic,

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -567,7 +567,7 @@ export function OverviewTab() {
               <CardTitle>Hardware Details</CardTitle>
             </CardHeader>
             <div className={styles.infoRow}>
-              <span className={styles.infoKey}>Platform</span>
+              <span className={styles.infoKey}>Identity</span>
               <span className={styles.infoVal}>{overview.identity || '—'}</span>
             </div>
             <div className={styles.infoRow}>
@@ -584,7 +584,7 @@ export function OverviewTab() {
             </div>
             <div className={styles.infoRow}>
               <span className={styles.infoKey}>Serial</span>
-              <span className={styles.infoVal}>{overview.serial}</span>
+              <span className={styles.infoVal}>{overview.serial || '—'}</span>
             </div>
           </Card>
         </SectionGrid>


### PR DESCRIPTION
Closes #249

## Summary
- rename the mislabeled Platform row to Identity in hardware details
- show the router's real system id as the serial instead of a value derived from the local router id