### PR TITLE
feat(fe): rename "Clients" to "DHCP Clients" on the LAN page

### DIFF
--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -426,7 +426,7 @@ export function DHCPPage() {
 
       <Card data-testid="dhcp-clients">
         <CardHeader>
-          <CardTitle>Clients</CardTitle>
+          <CardTitle>DHCP Clients</CardTitle>
           <CardDescription>
             Interfaces on which this router acts as a DHCP client (WAN).
           </CardDescription>


### PR DESCRIPTION
Closes #255

- rename the DHCP client card title on the LAN page from "Clients" to "DHCP Clients"