### PR TITLE
feat(fe): remove System tab

### DIFF
--- a/frontend/src/layout/RouterTabBar.tsx
+++ b/frontend/src/layout/RouterTabBar.tsx
@@ -3,7 +3,6 @@ import {
   Activity,
   Cable,
   CircleHelp,
-  Cpu,
   Globe,
   LayoutGrid,
   Network,
@@ -28,7 +27,6 @@ export const ROUTER_TABS: Array<TabItem & { path: string }> = [
   { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} />, disabled: true },
   { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
   { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
-  { id: 'system', label: 'System', path: 'system', icon: <Cpu size={16} />, disabled: true },
   { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },
   {
     id: 'diagnostics',

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -5,7 +5,6 @@ import {
   Blocks,
   Cable,
   CircleHelp,
-  Cpu,
   Globe,
   LayoutGrid,
   Network,
@@ -30,7 +29,6 @@ const TABS: Array<TabItem & { path: string }> = [
   { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} /> },
   { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
   { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
-  { id: 'system', label: 'System', path: 'system', icon: <Cpu size={16} />, disabled: true },
   { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },
   { id: 'plugins', label: 'Plugins', path: 'plugins', icon: <Blocks size={16} /> },
   {

--- a/frontend/tests/e2e/06-router-dashboard-overview.spec.ts
+++ b/frontend/tests/e2e/06-router-dashboard-overview.spec.ts
@@ -28,7 +28,6 @@ test.describe('Router dashboard + Overview tab', () => {
       'LAN',
       'WIFI',
       'VPN Server',
-      'System',
       'Wizard',
       'Diagnostics',
       'Help',


### PR DESCRIPTION
Closes #260

## Summary
- remove the disabled System tab from both router tab bars
- drop it from the expected tabs in the dashboard e2e spec