### PR TITLE
feat(fe): embed Chatwoot SDK widget on help page

### DIFF
--- a/frontend/src/api/chatwoot.ts
+++ b/frontend/src/api/chatwoot.ts
@@ -1,151 +1,73 @@
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __CHATWOOT_BASE_URL__: string | undefined;
 // eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __CHATWOOT_INBOX_IDENTIFIER__: string | undefined;
+declare const __CHATWOOT_WEBSITE_TOKEN__: string | undefined;
 
 const BASE_URL = (
-  typeof __CHATWOOT_BASE_URL__ === 'string' ? __CHATWOOT_BASE_URL__ : 'https://chatwoot.example.com'
+  typeof __CHATWOOT_BASE_URL__ === 'string' ? __CHATWOOT_BASE_URL__ : 'https://app.chatwoot.com'
 ).replace(/\/$/, '');
 
-const INBOX_IDENTIFIER =
-  typeof __CHATWOOT_INBOX_IDENTIFIER__ === 'string'
-    ? __CHATWOOT_INBOX_IDENTIFIER__
-    : 'nasnet-inbox';
+const WEBSITE_TOKEN =
+  typeof __CHATWOOT_WEBSITE_TOKEN__ === 'string'
+    ? __CHATWOOT_WEBSITE_TOKEN__
+    : '6bf25JZcWyhrbtLMgiv4oNuy';
 
-const STORAGE_KEY = 'nasnet-panel.chatwoot.v1';
-
-export type ChatRole = 'user' | 'agent';
-
-export interface ChatwootMessage {
-  id: number;
-  content: string;
-  role: ChatRole;
+interface ChatwootApi {
+  toggle: (state?: 'open' | 'close') => void;
 }
 
-interface ChatwootSession {
-  contactIdentifier: string;
-  conversationId: number;
-}
-
-interface ContactResponse {
-  source_id: string;
-  pubsub_token?: string;
-}
-
-interface ConversationResponse {
-  id: number;
-}
-
-interface RawMessage {
-  id: number;
-  content?: string | null;
-  message_type?: number;
-}
-
-function loadSession(): ChatwootSession | null {
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<ChatwootSession>;
-    if (typeof parsed.contactIdentifier === 'string' && typeof parsed.conversationId === 'number') {
-      return { contactIdentifier: parsed.contactIdentifier, conversationId: parsed.conversationId };
-    }
-  } catch {
-    /* ignore */
-  }
-  return null;
-}
-
-function saveSession(session: ChatwootSession): void {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
-  } catch {
-    /* ignore */
-  }
-}
-
-export function resetChatwootSession(): void {
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
-}
-
-async function cw<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const headers = new Headers(init.headers);
-  if (init.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
-  headers.set('Accept', 'application/json');
-
-  const res = await fetch(`${BASE_URL}/public/api/v1/inboxes/${INBOX_IDENTIFIER}${path}`, {
-    mode: 'cors',
-    ...init,
-    headers,
-  });
-  if (!res.ok) throw new Error(`Chatwoot request failed (${res.status})`);
-  return (await res.json()) as T;
-}
-
-async function createSession(): Promise<ChatwootSession> {
-  const contact = await cw<ContactResponse>('/contacts', { method: 'POST', body: '{}' });
-  const conversation = await cw<ConversationResponse>(
-    `/contacts/${encodeURIComponent(contact.source_id)}/conversations`,
-    { method: 'POST', body: '{}' },
-  );
-  const session: ChatwootSession = {
-    contactIdentifier: contact.source_id,
-    conversationId: conversation.id,
+interface ChatwootWindow extends Window {
+  chatwootSettings?: {
+    position?: 'left' | 'right';
+    type?: 'standard' | 'expanded_bubble';
+    launcherTitle?: string;
+    hideMessageBubble?: boolean;
   };
-  saveSession(session);
-  return session;
+  chatwootSDK?: { run: (config: { websiteToken: string; baseUrl: string }) => void };
+  $chatwoot?: ChatwootApi;
 }
 
-let sessionPromise: Promise<ChatwootSession> | null = null;
+const win = window as ChatwootWindow;
 
-async function ensureSession(): Promise<ChatwootSession> {
-  const existing = loadSession();
-  if (existing) return existing;
-  if (!sessionPromise) {
-    sessionPromise = createSession().catch((err) => {
-      sessionPromise = null;
-      throw err;
-    });
-  }
-  return sessionPromise;
+let loadPromise: Promise<void> | null = null;
+
+export function loadChatwoot(): Promise<void> {
+  if (win.$chatwoot) return Promise.resolve();
+  if (loadPromise) return loadPromise;
+  loadPromise = new Promise<void>((resolve, reject) => {
+    win.chatwootSettings = {
+      position: 'right',
+      type: 'standard',
+      launcherTitle: '',
+    };
+    const script = document.createElement('script');
+    script.src = `${BASE_URL}/packs/js/sdk.js`;
+    script.async = true;
+    script.onload = () => {
+      if (!win.chatwootSDK) {
+        loadPromise = null;
+        reject(new Error('Chatwoot SDK failed to initialise'));
+        return;
+      }
+      window.addEventListener(
+        'chatwoot:ready',
+        () => {
+          resolve();
+        },
+        { once: true },
+      );
+      win.chatwootSDK.run({ websiteToken: WEBSITE_TOKEN, baseUrl: BASE_URL });
+    };
+    script.onerror = () => {
+      loadPromise = null;
+      script.remove();
+      reject(new Error('Failed to load Chatwoot SDK'));
+    };
+    document.head.appendChild(script);
+  });
+  return loadPromise;
 }
 
-function toMessage(raw: RawMessage): ChatwootMessage | null {
-  const content = (raw.content ?? '').trim();
-  if (!content) return null;
-  if (raw.message_type === 0) return { id: raw.id, content, role: 'user' };
-  if (raw.message_type === 1 || raw.message_type === 3) {
-    return { id: raw.id, content, role: 'agent' };
-  }
-  return null;
-}
-
-export async function sendChatMessage(content: string): Promise<void> {
-  const { contactIdentifier, conversationId } = await ensureSession();
-  await cw(
-    `/contacts/${encodeURIComponent(contactIdentifier)}/conversations/${conversationId}/messages`,
-    { method: 'POST', body: JSON.stringify({ content }) },
-  );
-}
-
-export function hasChatwootSession(): boolean {
-  return loadSession() !== null;
-}
-
-export async function fetchChatMessages(): Promise<ChatwootMessage[]> {
-  const session = loadSession();
-  if (!session) return [];
-  const { contactIdentifier, conversationId } = session;
-  const raw = await cw<RawMessage[]>(
-    `/contacts/${encodeURIComponent(contactIdentifier)}/conversations/${conversationId}/messages`,
-    { method: 'GET' },
-  );
-  return raw
-    .map(toMessage)
-    .filter((m): m is ChatwootMessage => m !== null)
-    .sort((a, b) => a.id - b.id);
+export function toggleChatwoot(state: 'open' | 'close'): void {
+  win.$chatwoot?.toggle(state);
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -164,13 +164,6 @@ export {
 export { ApiError } from './http';
 export { isAbortError } from './abort';
 export { BACKEND_URL } from './config';
-export {
-  sendChatMessage,
-  fetchChatMessages,
-  hasChatwootSession,
-  resetChatwootSession,
-  type ChatwootMessage,
-  type ChatRole,
-} from './chatwoot';
+export { loadChatwoot, toggleChatwoot } from './chatwoot';
 
 export type * from '@nasnet/mocks';

--- a/frontend/src/routes/HelpPage.module.scss
+++ b/frontend/src/routes/HelpPage.module.scss
@@ -2,7 +2,10 @@
   width: 100%;
 }
 
-.chatFrame {
+.chatHost {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 600px;
   border: 1px solid var(--color-border);
@@ -10,225 +13,16 @@
   background: var(--color-surface);
 }
 
-.chat {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-}
-
-.chatLog {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  max-height: 360px;
-  overflow-y: auto;
-}
-
-.suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
-}
-
-.suggestionChip {
-  appearance: none;
-  cursor: pointer;
-  padding: var(--space-sm) var(--space-lg);
-  font-size: var(--font-md);
-  color: var(--color-text);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-sm);
-  transition:
-    border-color 0.15s ease,
-    background 0.15s ease,
-    transform 0.15s ease;
-
-  &:hover:not(:disabled) {
-    border-color: var(--color-borderStrong, var(--color-border));
-    background: var(--color-surface-alt);
-    transform: translateY(-1px);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-}
-
-.rowUser,
-.rowAgent {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--space-sm);
-  max-width: 80%;
-}
-
-.rowUser {
-  align-self: flex-end;
-  flex-direction: row-reverse;
-}
-
-.rowAgent {
-  align-self: flex-start;
-}
-
-.avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  flex-shrink: 0;
-  border-radius: var(--radius-pill);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-muted);
-}
-
-.bubbleUser,
-.bubbleAgent {
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-lg);
+.chatLoading {
+  margin: 0;
   font-size: var(--font-sm);
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.bubbleUser {
-  background: #16a34a;
-  color: #fff;
-  border-bottom-right-radius: var(--radius-sm);
-}
-
-.bubbleAgent {
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-bottom-left-radius: var(--radius-sm);
-}
-
-.typing {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-
-  span {
-    width: 6px;
-    height: 6px;
-    border-radius: var(--radius-pill);
-    background: var(--color-text-muted);
-    animation: helpTypingBlink 1.2s infinite ease-in-out;
-  }
-
-  span:nth-child(2) {
-    animation-delay: 0.15s;
-  }
-
-  span:nth-child(3) {
-    animation-delay: 0.3s;
-  }
-}
-
-@keyframes helpTypingBlink {
-  0%,
-  80%,
-  100% {
-    opacity: 0.3;
-  }
-  40% {
-    opacity: 1;
-  }
+  color: var(--color-text-muted);
 }
 
 .chatError {
   margin: 0;
   font-size: var(--font-sm);
   color: var(--color-danger);
-}
-
-.composer {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  padding: var(--space-lg);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  box-shadow: var(--shadow-sm);
-
-  &:focus-within {
-    border-color: var(--color-borderStrong, var(--color-border));
-  }
-}
-
-.composerInput {
-  width: 100%;
-  min-height: 56px;
-  padding: 0;
-  border: none;
-  outline: none;
-  resize: none;
-  background: transparent;
-  color: var(--color-text);
-  font: inherit;
-  font-size: var(--font-lg);
-  line-height: 1.5;
-
-  &::placeholder {
-    color: var(--color-text-muted);
-  }
-}
-
-.composerBar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.attach {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-muted);
-}
-
-.sendButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  flex-shrink: 0;
-  border: none;
-  border-radius: var(--radius-pill);
-  background: var(--color-text);
-  color: var(--color-background);
-  cursor: pointer;
-  transition:
-    opacity 0.15s ease,
-    transform 0.15s ease;
-
-  &:hover:not(:disabled) {
-    transform: scale(1.05);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
 }
 
 .links {

--- a/frontend/src/routes/HelpPage.tsx
+++ b/frontend/src/routes/HelpPage.tsx
@@ -1,10 +1,8 @@
 import { MessagesSquare } from 'lucide-react';
 import { Card, CardDescription, CardHeader, CardTitle, Inline, Stack } from '@nasnet/ui';
 import styles from './HelpPage.module.scss';
+import { ChatPanel } from './help/ChatPanel';
 import { SupportLinks } from './help/SupportLinks';
-
-const CHATWOOT_WIDGET_URL =
-  'https://app.chatwoot.com/widget?website_token=6bf25JZcWyhrbtLMgiv4oNuy';
 
 export function HelpPage() {
   return (
@@ -25,12 +23,7 @@ export function HelpPage() {
             </CardDescription>
           </div>
         </CardHeader>
-        <iframe
-          className={styles.chatFrame}
-          src={CHATWOOT_WIDGET_URL}
-          title="AI Assistant chat"
-          allow="microphone; camera; clipboard-write"
-        />
+        <ChatPanel />
       </Card>
     </Stack>
   );

--- a/frontend/src/routes/help/ChatPanel.tsx
+++ b/frontend/src/routes/help/ChatPanel.tsx
@@ -1,192 +1,88 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowUp, Bot, Paperclip, User } from 'lucide-react';
-import {
-  fetchChatMessages,
-  hasChatwootSession,
-  sendChatMessage,
-  type ChatwootMessage,
-} from '../../api';
+import { useEffect, useRef, useState } from 'react';
+import { loadChatwoot, toggleChatwoot } from '../../api';
 import styles from '../HelpPage.module.scss';
 
-const POLL_INTERVAL_MS = 4000;
+const HOLDER_SELECTOR = '.woot-widget-holder';
+const HIDDEN_CLASS = 'woot--hide';
 
-const SUGGESTED_PROMPTS = [
-  'How do I set up a VPN client?',
-  'My Wi-Fi keeps dropping — what can I check?',
-  'How do I update RouterOS firmware?',
-  'How do I port-forward to a device?',
-];
+type ChatState = 'loading' | 'ready' | 'error';
 
 export function ChatPanel() {
-  const [messages, setMessages] = useState<ChatwootMessage[]>([]);
-  const [optimistic, setOptimistic] = useState<ChatwootMessage[]>([]);
-  const [input, setInput] = useState('');
-  const [sending, setSending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<ChatState>('loading');
 
-  const mountedRef = useRef(true);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pollingRef = useRef(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    let disposed = false;
+    let frame = 0;
+    let holder: HTMLElement | null = null;
+    let keepOpenObserver: MutationObserver | null = null;
 
-  const refresh = useCallback(async () => {
-    const list = await fetchChatMessages();
-    if (mountedRef.current) setMessages(list);
+    const pin = () => {
+      const host = hostRef.current;
+      holder ??= document.querySelector<HTMLElement>(HOLDER_SELECTOR);
+      if (!host || !holder) return;
+      const rect = host.getBoundingClientRect();
+      const style = holder.style;
+      style.setProperty('position', 'absolute', 'important');
+      style.setProperty('top', `${rect.top + window.scrollY + 1}px`, 'important');
+      style.setProperty('left', `${rect.left + window.scrollX + 1}px`, 'important');
+      style.setProperty('width', `${rect.width - 2}px`, 'important');
+      style.setProperty('height', `${rect.height - 2}px`, 'important');
+      style.setProperty('right', 'auto', 'important');
+      style.setProperty('bottom', 'auto', 'important');
+      style.setProperty('max-height', 'none', 'important');
+      style.setProperty('border-radius', 'calc(var(--radius-md) - 1px)', 'important');
+      style.setProperty('overflow', 'hidden', 'important');
+      style.setProperty('box-shadow', 'none', 'important');
+      if (!keepOpenObserver) {
+        keepOpenObserver = new MutationObserver(() => {
+          if (holder?.classList.contains(HIDDEN_CLASS)) toggleChatwoot('open');
+        });
+        keepOpenObserver.observe(holder, { attributes: true, attributeFilter: ['class'] });
+      }
+    };
+
+    const schedulePin = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(pin);
+    };
+
+    void loadChatwoot()
+      .then(() => {
+        if (disposed) return;
+        setState('ready');
+        toggleChatwoot('open');
+        schedulePin();
+      })
+      .catch(() => {
+        if (!disposed) setState('error');
+      });
+
+    window.addEventListener('resize', schedulePin);
+    window.addEventListener('scroll', schedulePin, true);
+    const resizeObserver = new ResizeObserver(schedulePin);
+    if (hostRef.current) resizeObserver.observe(hostRef.current);
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      keepOpenObserver?.disconnect();
+      window.removeEventListener('resize', schedulePin);
+      window.removeEventListener('scroll', schedulePin, true);
+      toggleChatwoot('close');
+      if (holder) holder.style.cssText = '';
+    };
   }, []);
 
-  const scheduleNextPoll = useCallback(() => {
-    if (!mountedRef.current) return;
-    timerRef.current = setTimeout(async () => {
-      try {
-        await refresh();
-      } catch {
-        /* transient */
-      }
-      scheduleNextPoll();
-    }, POLL_INTERVAL_MS);
-  }, [refresh]);
-
-  const startPolling = useCallback(() => {
-    if (pollingRef.current) return;
-    pollingRef.current = true;
-    scheduleNextPoll();
-  }, [scheduleNextPoll]);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    if (hasChatwootSession()) {
-      void refresh().catch(() => undefined);
-      startPolling();
-    }
-    return () => {
-      mountedRef.current = false;
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [refresh, startPolling]);
-
-  const rendered: ChatwootMessage[] = [
-    ...messages,
-    ...optimistic.filter(
-      (o) => !messages.some((m) => m.role === 'user' && m.content === o.content),
-    ),
-  ];
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [rendered.length, sending]);
-
-  const submit = useCallback(
-    async (raw: string) => {
-      const text = raw.trim();
-      if (!text || sending) return;
-      setError(null);
-      setInput('');
-      setOptimistic((prev) => [...prev, { id: -Date.now(), content: text, role: 'user' }]);
-      setSending(true);
-      try {
-        await sendChatMessage(text);
-        await refresh();
-        startPolling();
-      } catch {
-        setError("Couldn't reach support chat. Check your connection and try again.");
-      } finally {
-        if (mountedRef.current) setSending(false);
-      }
-    },
-    [sending, refresh, startPolling],
-  );
-
-  const handleSend = useCallback(() => {
-    void submit(input);
-  }, [submit, input]);
-
-  const hasThread = rendered.length > 0 || sending;
-
   return (
-    <div className={styles.chat} data-testid="help-chat">
-      {hasThread ? (
-        <div className={styles.chatLog} ref={scrollRef}>
-          {rendered.map((m) => (
-            <div key={m.id} className={m.role === 'user' ? styles.rowUser : styles.rowAgent}>
-              <span className={styles.avatar} aria-hidden>
-                {m.role === 'user' ? <User size={14} /> : <Bot size={14} />}
-              </span>
-              <div className={m.role === 'user' ? styles.bubbleUser : styles.bubbleAgent}>
-                {m.content}
-              </div>
-            </div>
-          ))}
-          {sending ? (
-            <div className={styles.rowAgent}>
-              <span className={styles.avatar} aria-hidden>
-                <Bot size={14} />
-              </span>
-              <div className={styles.bubbleAgent}>
-                <span className={styles.typing} aria-label="Assistant is typing">
-                  <span />
-                  <span />
-                  <span />
-                </span>
-              </div>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {error ? (
+    <div className={styles.chatHost} ref={hostRef} data-testid="help-chat">
+      {state === 'error' ? (
         <p className={styles.chatError} role="alert">
-          {error}
+          Couldn&apos;t load the support chat. Check your internet connection and reload the page.
         </p>
-      ) : null}
-
-      <div className={styles.composer}>
-        <textarea
-          className={styles.composerInput}
-          aria-label="Message"
-          placeholder="Ask me anything…"
-          rows={3}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              handleSend();
-            }
-          }}
-        />
-        <div className={styles.composerBar}>
-          <span className={styles.attach} aria-hidden>
-            <Paperclip size={18} />
-          </span>
-          <button
-            type="button"
-            className={styles.sendButton}
-            aria-label="Send message"
-            disabled={!input.trim() || sending}
-            onClick={() => handleSend()}
-          >
-            <ArrowUp size={18} aria-hidden />
-          </button>
-        </div>
-      </div>
-
-      {!hasThread ? (
-        <div className={styles.suggestions}>
-          {SUGGESTED_PROMPTS.map((p) => (
-            <button
-              key={p}
-              type="button"
-              className={styles.suggestionChip}
-              onClick={() => {
-                void submit(p);
-              }}
-              disabled={sending}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
+      ) : state === 'loading' ? (
+        <p className={styles.chatLoading}>Loading chat…</p>
       ) : null}
     </div>
   );

--- a/frontend/src/ui/global.scss
+++ b/frontend/src/ui/global.scss
@@ -89,3 +89,7 @@ textarea {
   font-family: inherit;
   color: inherit;
 }
+
+.woot--bubble-holder {
+  display: none !important;
+}

--- a/frontend/tests/e2e/25-help-page.spec.ts
+++ b/frontend/tests/e2e/25-help-page.spec.ts
@@ -20,7 +20,7 @@ test.describe('Help page', () => {
     await helpTab.click();
 
     await expect(page).toHaveURL(new RegExp(`/router/${ROUTER.id}/help$`));
-    await expect(page.getByTitle('AI Assistant chat')).toBeVisible();
+    await expect(page.getByTestId('help-chat')).toBeVisible();
   });
 
   test('support buttons link to knowledge base, Telegram and GitHub in a new tab', async ({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -6,8 +6,8 @@ const CopyPlugin = require('copy-webpack-plugin');
 module.exports = (_env, argv) => {
   const isProduction = argv.mode === 'production';
   const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
-  const chatwootBaseUrl = process.env.CHATWOOT_BASE_URL ?? 'https://chatwoot.example.com';
-  const chatwootInbox = process.env.CHATWOOT_INBOX_IDENTIFIER ?? 'nasnet-inbox';
+  const chatwootBaseUrl = process.env.CHATWOOT_BASE_URL ?? 'https://app.chatwoot.com';
+  const chatwootWebsiteToken = process.env.CHATWOOT_WEBSITE_TOKEN ?? '6bf25JZcWyhrbtLMgiv4oNuy';
   const appVersion = require('../package.json').version;
 
   return {
@@ -74,7 +74,7 @@ module.exports = (_env, argv) => {
       new webpack.DefinePlugin({
         __BACKEND_URL__: JSON.stringify(backendUrl),
         __CHATWOOT_BASE_URL__: JSON.stringify(chatwootBaseUrl),
-        __CHATWOOT_INBOX_IDENTIFIER__: JSON.stringify(chatwootInbox),
+        __CHATWOOT_WEBSITE_TOKEN__: JSON.stringify(chatwootWebsiteToken),
         __APP_VERSION__: JSON.stringify(appVersion),
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION

<img width="1215" height="712" alt="Screenshot 2026-07-03 at 16 10 04" src="https://github.com/user-attachments/assets/dc43710b-46a6-4c91-9db2-f617458a5dd7" />

## Summary
- install the chat via the official Chatwoot SDK with the new website token, replacing the iframe embed
- pin the widget inside the AI Assistant card so it reads as part of the page, with no launcher bubble or close button
- base URL and website token stay overridable via env at build time

Closes #273