### PR TITLE
feat(fe): remove DHCP servers section from LAN page

### DIFF
--- a/frontend/src/api/dhcp.ts
+++ b/frontend/src/api/dhcp.ts
@@ -37,20 +37,6 @@ export interface DhcpClient {
   comment?: string;
 }
 
-export interface DhcpServer {
-  id: string;
-  name: string;
-  interface: string;
-  addressPool: string;
-  ranges: string[];
-  gateway?: string;
-  dnsServers?: string;
-  leaseTime?: string;
-  disabled: boolean;
-  comment?: string;
-  localAddress?: string;
-}
-
 export interface DhcpLeaseAction {
   macAddress: string;
   id: string;
@@ -88,19 +74,6 @@ export async function fetchDhcpClients(
     signal,
   });
   return clients ?? [];
-}
-
-export async function fetchDhcpServers(
-  creds: DhcpCredentials,
-  signal?: AbortSignal,
-): Promise<DhcpServer[]> {
-  const servers = await apiRequest<DhcpServer[] | null>('/api/dhcp/servers', {
-    method: 'GET',
-    headers: authHeaders(creds),
-    cache: 'no-store',
-    signal,
-  });
-  return servers ?? [];
 }
 
 export async function makeDhcpLeaseStatic(

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -75,13 +75,11 @@ export {
 export {
   fetchDhcpLeases,
   fetchDhcpClients,
-  fetchDhcpServers,
   makeDhcpLeaseStatic,
   removeDhcpLease,
   type DhcpCredentials,
   type DhcpLease,
   type DhcpClient,
-  type DhcpServer,
   type DhcpLeaseAction,
 } from './dhcp';
 export { fetchFirewallRules, type FirewallCredentials, type FirewallRule } from './firewall';

--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Cable, Inbox, Pin, Server, Trash2 } from 'lucide-react';
+import { Cable, Inbox, Pin, Trash2 } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -19,14 +19,12 @@ import styles from './DHCPPage.module.scss';
 import {
   fetchDhcpClients,
   fetchDhcpLeases,
-  fetchDhcpServers,
   fetchInterfaces,
   fetchSystemOverview,
   makeDhcpLeaseStatic,
   removeDhcpLease,
   type DhcpClient,
   type DhcpLease,
-  type DhcpServer,
   type InterfaceResponse,
 } from '../api';
 import { useSession } from '../state/SessionContext';
@@ -60,7 +58,6 @@ export function DHCPPage() {
   const { getCredentials } = useSession();
   const toast = useToast();
 
-  const [servers, setServers] = useState<SectionState<DhcpServer>>(initial<DhcpServer>());
   const [leases, setLeases] = useState<SectionState<DhcpLease>>(initial<DhcpLease>());
   const [clients, setClients] = useState<SectionState<DhcpClient>>(initial<DhcpClient>());
   const [model, setModel] = useState<string | null>(null);
@@ -77,21 +74,18 @@ export function DHCPPage() {
       const host = router?.host;
       if (!creds || !host) {
         const missing = 'Missing router credentials for this session.';
-        setServers({ data: [], loading: false, error: missing });
         setLeases({ data: [], loading: false, error: missing });
         setClients({ data: [], loading: false, error: missing });
         return;
       }
       if (!silent) {
-        setServers((s) => ({ ...s, loading: true, error: null }));
         setLeases((s) => ({ ...s, loading: true, error: null }));
         setClients((s) => ({ ...s, loading: true, error: null }));
       }
 
       inFlightRef.current = true;
       const full = { host, ...creds };
-      const [sResult, lResult, cResult, oResult, iResult] = await Promise.allSettled([
-        fetchDhcpServers(full),
+      const [lResult, cResult, oResult, iResult] = await Promise.allSettled([
         fetchDhcpLeases(full),
         fetchDhcpClients(full),
         fetchSystemOverview(id, full),
@@ -102,15 +96,6 @@ export function DHCPPage() {
       if (oResult.status === 'fulfilled') setModel(oResult.value.model);
       if (iResult.status === 'fulfilled') setInterfaces(iResult.value);
 
-      setServers(
-        sResult.status === 'fulfilled'
-          ? { data: sResult.value, loading: false, error: null }
-          : {
-              data: [],
-              loading: false,
-              error: errorMessage(sResult.reason, 'Failed to load servers.'),
-            },
-      );
       setLeases(
         lResult.status === 'fulfilled'
           ? { data: lResult.value, loading: false, error: null }
@@ -197,37 +182,6 @@ export function DHCPPage() {
   }, [id, router?.host, getCredentials, leaseToRemove, reload, toast]);
 
   const wanNames = useMemo(() => wanInterfaceNames(interfaces), [interfaces]);
-
-  const serverColumns: DataTableColumn<DhcpServer>[] = [
-    { key: 'name', header: 'Name', render: (r) => r.name || '—' },
-    {
-      key: 'interface',
-      header: 'Interface',
-      render: (r) => <span className={styles.mono}>{r.interface}</span>,
-    },
-    { key: 'pool', header: 'Address pool', render: (r) => r.addressPool || '—' },
-    {
-      key: 'ranges',
-      header: 'Ranges',
-      render: (r) =>
-        r.ranges.length > 0 ? (
-          <span className={styles.mono}>{r.ranges.join(', ')}</span>
-        ) : (
-          <span className={styles.muted}>—</span>
-        ),
-    },
-    {
-      key: 'lease',
-      header: 'Lease time',
-      render: (r) => r.leaseTime || <span className={styles.muted}>—</span>,
-    },
-    {
-      key: 'status',
-      header: 'Status',
-      render: (r) =>
-        r.disabled ? <Badge tone="warning">disabled</Badge> : <Badge tone="success">enabled</Badge>,
-    },
-  ];
 
   const leaseColumns: DataTableColumn<DhcpLease>[] = [
     {
@@ -441,24 +395,6 @@ export function DHCPPage() {
           </div>
         ) : (
           <DataTable columns={clientColumns} rows={clients.data} rowKey={(r) => r.id} />
-        )}
-      </Card>
-
-      <Card data-testid="dhcp-servers">
-        <CardHeader>
-          <CardTitle>Servers</CardTitle>
-          <CardDescription>DHCP server instances bound to router interfaces.</CardDescription>
-        </CardHeader>
-        {servers.error ? <div className={styles.errorBanner}>{servers.error}</div> : null}
-        {servers.loading ? (
-          loadingRows(6)
-        ) : servers.data.length === 0 ? (
-          <div className={styles.empty}>
-            <Server size={22} aria-hidden className={styles.emptyIcon} />
-            <p>No DHCP servers configured.</p>
-          </div>
-        ) : (
-          <DataTable columns={serverColumns} rows={servers.data} rowKey={(r) => r.id} />
         )}
       </Card>
 

--- a/frontend/tests/e2e/19-dhcp-page.spec.ts
+++ b/frontend/tests/e2e/19-dhcp-page.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test.describe('LAN page (DHCP + port diagram)', () => {
-  test('renders servers, leases, and clients loaded from the backend', async ({
+  test('renders leases and clients loaded from the backend', async ({
     page,
     resetMocks,
     seedRouter,
@@ -13,11 +13,6 @@ test.describe('LAN page (DHCP + port diagram)', () => {
     await mockOverviewBackend({ id: 'rtr_dhcp', model: 'hAP ax3' });
     await mockDhcpBackend({ id: 'rtr_dhcp' });
     await page.goto('/router/rtr_dhcp/lan');
-
-    const servers = page.getByTestId('dhcp-servers');
-    await expect(servers).toBeVisible();
-    await expect(servers).toContainText('default-lan');
-    await expect(servers).toContainText('192.168.88.100-192.168.88.200');
 
     const leases = page.getByTestId('dhcp-leases');
     await expect(leases).toBeVisible();

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -704,21 +704,6 @@ export const test = base.extend<TestFixtures>({
       const envelope = <T>(data: T, status = 200) =>
         JSON.stringify({ status, message: 'OK', data });
 
-      const servers = [
-        {
-          id: '*1',
-          name: 'default-lan',
-          interface: 'bridge1',
-          addressPool: 'lan-pool',
-          ranges: ['192.168.88.100-192.168.88.200'],
-          gateway: '192.168.88.1',
-          dnsServers: '1.1.1.1,8.8.8.8',
-          leaseTime: '10m',
-          disabled: false,
-          localAddress: '192.168.88.1',
-        },
-      ];
-
       const leases = [
         {
           id: '*1',
@@ -757,13 +742,6 @@ export const test = base.extend<TestFixtures>({
         },
       ];
 
-      await context.route('**/api/dhcp/servers', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: envelope(servers),
-        });
-      });
       await context.route('**/api/dhcp/leases', async (route) => {
         await route.fulfill({
           status: 200,


### PR DESCRIPTION
Closes #256

- remove the DHCP servers section from the LAN page
- drop the unused server fetch and type from the API client
- update e2e mocks and assertions accordingly