### PR TITLE
feat(fe): show hostname and IP in the wireless clients list

### DIFF
--- a/frontend/src/api/wifi.ts
+++ b/frontend/src/api/wifi.ts
@@ -43,6 +43,8 @@ export interface WifiConnectedClientResponse {
   txBitsPerSecond: string;
   rxBitsPerSecond: string;
   authorized: boolean;
+  ipAddress: string;
+  hostname: string;
 }
 
 export interface WifiPassphraseResponse {

--- a/frontend/src/routes/wireless/useWireless.ts
+++ b/frontend/src/routes/wireless/useWireless.ts
@@ -58,8 +58,8 @@ const toInterface = (wi: WifiInterfaceResponse): Interface => ({
 
 const toWirelessClient = (c: WifiConnectedClientResponse): WirelessClient => ({
   mac: c.macAddress,
-  hostname: c.macAddress,
-  ip: '',
+  hostname: c.hostname || c.macAddress,
+  ip: c.ipAddress,
   signalDbm: parseNumber(c.signal),
   band: toBand(c.band),
   txKbps: bpsToKbps(c.txBitsPerSecond),


### PR DESCRIPTION
Closes #269

## Summary
- map the hostname and IP address fields added by #268 into the wireless connected clients table
- fall back to the MAC address when a client has no hostname