### PR TITLE
chore(installer): baseline LAN before the setup wizard

### DIFF
--- a/backend/internal/template/cleanup.tmpl
+++ b/backend/internal/template/cleanup.tmpl
@@ -52,8 +52,8 @@
 }
 
 /ip dhcp-client remove [find]
-/ip firewall filter remove [find dynamic=no]
-/ip firewall nat remove [find dynamic=no]
+/ip firewall filter remove [find where dynamic=no && !(comment~"^nasnet-panel-installer")]
+/ip firewall nat remove [find where dynamic=no && !(comment~"^nasnet-panel-installer")]
 /ip firewall mangle remove [find dynamic=no]
 /ip firewall address-list remove [find dynamic=no]
 /ip dns forwarder remove [find]

--- a/backend/internal/template/wizard.tmpl
+++ b/backend/internal/template/wizard.tmpl
@@ -145,6 +145,8 @@ add action=lookup-only-in-table comment="Routing the Domestic-Domestic Link SRC 
 add action=lookup-only-in-table comment="Routing the Domestic-Domestic Link Routing Mark" disabled=no routing-mark="to-Domestic-Domestic Link" table="to-Domestic-Domestic Link"
 
 /interface bridge port
+remove [find bridge="LANBridgeSplit" interface="{{ .ForeignInterface }}"]
+remove [find bridge="LANBridgeSplit" interface="{{ .DomesticInterface }}"]
 {{range .WifiBands}}:if ([:len [/interface/bridge/port find bridge="LANBridgeSplit" interface="wifi{{.}}-SplitLAN"]] = 0) do={
 add bridge="LANBridgeSplit" interface="wifi{{.}}-SplitLAN" comment="Split"
 }
@@ -270,6 +272,10 @@ add list="MikroTik-Cloud-Services" address="cloud.mikrotik.com" comment="Legacy 
 /ip firewall filter
 add chain=input dst-port="53" in-interface-list="WAN" protocol="tcp" action=drop comment="Block Open Recursive DNS"
 add chain=input dst-port="53" in-interface-list="WAN" protocol="udp" action=drop comment="Block Open Recursive DNS"
+
+/ip firewall nat set [find comment="nasnet-panel-installer-dstnat"] in-interface-list="!WAN"
+/ip firewall nat set [find comment="nasnet-panel-installer-srcnat"] out-interface-list="WAN"
+/ip firewall filter set [find comment="nasnet-panel-installer-forward"] in-interface-list="!WAN"
 
 /ip firewall mangle
 add action=accept chain=prerouting comment="Accept" dst-address-list="LOCAL-IP" src-address-list="LOCAL-IP"

--- a/scripts/INSTALL.md
+++ b/scripts/INSTALL.md
@@ -82,19 +82,32 @@ SSHPASS=secret bash install.sh --config router.env
 | `--version <tag>`    | Release tag to install (default: `snapshot`).                           |
 | `--image-tar <path>` | Use a local tar instead of downloading a release asset.                 |
 | `--lan-port <port>`  | LAN port for the panel (default: 8080).                                 |
+| `--no-lan-baseline`  | Skip the baseline LAN setup (see below).                                |
 | `--no-rollback`      | Leave partial state in place on failure rather than undoing it.         |
 | `-v`, `--verbose`    | Verbose output.                                                         |
 | `-h`, `--help`       | Show usage.                                                             |
 
+### The baseline LAN
+
+As its final step, the script moves the router's LAN onto the same bridge the setup wizard uses (`LANBridgeSplit`, `192.168.10.1/24`, with DHCP for `192.168.10.2-254`). This keeps you connected while the wizard later reconfigures the router: the wizard preserves this bridge, so your connection to the panel survives the process. The change runs as a detached RouterOS job, so it completes even though it briefly interrupts your session. Interfaces acting as WAN uplinks (DHCP client or PPPoE) are left out of the bridge. On a device in AP/bridge mode (all ports on one uplink bridge) the bridge is created but has no member ports, so the panel remains at the router's current address until the wizard runs.
+
+The RouterOS commands live in `scripts/nasnet-lan-baseline.rsc`. The script uploads the copy sitting next to `install.sh`; if you downloaded `install.sh` on its own, the file is fetched from the repository automatically.
+
+After it applies, reconnect (or renew your DHCP lease) to get a `192.168.10.x` address; the panel is then at `http://192.168.10.1:8080/`.
+
+The step is skipped entirely when `LANBridgeSplit` already exists (a re-install, or a router already configured by the wizard). Pass `--no-lan-baseline` to opt out and keep your current LAN untouched; note the wizard will then dismantle your LAN mid-run and you will need to reconnect to `192.168.10.x` once it finishes.
+
 ### When it finishes
 
-The panel is reachable at `http://<router-ip>:8080/`, or on whichever port you passed to `--lan-port`. If anything fails partway through, the script rolls back the changes it made, unless you passed `--no-rollback`.
+The panel is reachable at `http://<router-ip>:8080/`, or on whichever port you passed to `--lan-port`. With the baseline LAN applied, use `http://192.168.10.1:8080/` instead. If anything fails partway through, the script rolls back the changes it made, unless you passed `--no-rollback`.
 
-To remove everything later:
+To remove the panel later:
 
 ```bash
 bash install.sh --uninstall --config router.env
 ```
+
+This removes the container, its networking, the installer firewall rules, and the uploaded files. It does not restore your original LAN: the baseline bridge (`LANBridgeSplit`, `192.168.10.1/24`) and its DHCP server stay in place, since that is now the router's LAN.
 
 ## Route 2: Manual installation via Winbox or terminal
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
 # ---- defaults --------------------------------------------------------------
 GH_OWNER="nasnet-community"
 GH_REPO="nasnet-panel"
@@ -23,6 +25,10 @@ CONTAINER_NAME="nnc"
 CONTAINER_ROOT_DIR="disk1/images/nnc"
 TAR_REMOTE_DIR="disk1"
 
+LAN_BRIDGE="LANBridgeSplit"
+LAN_BRIDGE_IP="192.168.10.1"
+LAN_BASELINE_RSC="nasnet-lan-baseline.rsc"
+
 COMMENT_TAG="nasnet-panel-installer"
 MIN_FREE_MB=30
 DEVICE_MODE_TIMEOUT=120
@@ -33,6 +39,8 @@ DRY_RUN=0
 UNINSTALL=0
 VERBOSE=0
 NO_ROLLBACK=0
+NO_LAN_BASELINE=0
+LAN_BASELINE_APPLIED=0
 CONFIG_FILE=""
 VERSION=""
 IMAGE_TAR=""
@@ -54,6 +62,7 @@ Usage: install.sh [options]
   --version <tag>      Release tag to install (default: snapshot).
   --image-tar <path>   Use a local tar instead of downloading a release asset.
   --lan-port <port>    LAN port for dstnat to panel (default: 8080).
+  --no-lan-baseline    Skip the baseline LAN setup (LANBridgeSplit, 192.168.10.0/24).
   --no-rollback        Do not undo partial state on failure.
   -v, --verbose        Verbose output.
   -h, --help           This help.
@@ -92,6 +101,7 @@ while [[ $# -gt 0 ]]; do
     --version)     VERSION="${2:?--version requires a tag}"; shift ;;
     --image-tar)   IMAGE_TAR="${2:?--image-tar requires a path}"; shift ;;
     --lan-port)    LAN_PORT="${2:?--lan-port requires a port}"; shift ;;
+    --no-lan-baseline) NO_LAN_BASELINE=1 ;;
     --no-rollback) NO_ROLLBACK=1 ;;
     -v|--verbose)  VERBOSE=1 ;;
     -h|--help)     usage; exit 0 ;;
@@ -757,6 +767,48 @@ start_and_poll() {
   exit 1
 }
 
+# ---- LAN baseline ----------------------------------------------------------
+setup_lan_baseline() {
+  log ""
+  log "Configuring baseline LAN (bridge ${LAN_BRIDGE}, ${LAN_BRIDGE_IP}/24) ..."
+
+  if ros_exists /interface/bridge "name=${LAN_BRIDGE}"; then
+    printf '  \033[32m✓\033[0m bridge %s (exists, skipping LAN baseline)\n' "$LAN_BRIDGE"
+    return 0
+  fi
+  if (( DRY_RUN )); then
+    log "[dry-run] would move LAN to ${LAN_BRIDGE_IP}/24 via detached RouterOS job"
+    return 0
+  fi
+
+  local rsc="${SCRIPT_DIR}/${LAN_BASELINE_RSC}" tmp=""
+  if [[ ! -r "$rsc" ]]; then
+    local ref="${VERSION:-$SNAPSHOT_CHANNEL}"
+    local url="https://raw.githubusercontent.com/${GH_OWNER}/${GH_REPO}/${ref}/scripts/${LAN_BASELINE_RSC}"
+    tmp="$(mktemp)"
+    if ! spin "downloading LAN baseline script" curl -fsSL "$url" -o "$tmp"; then
+      rm -f "$tmp"
+      err "LAN baseline script not found next to install.sh and download failed: ${url}"
+      err "skipping LAN baseline; run the wizard from a wired connection or re-run install.sh"
+      return 0
+    fi
+    rsc="$tmp"
+  fi
+  if ! spin "uploading LAN baseline script" \
+       scp_pw "$rsc" "${ROUTER_USER}@${ROUTER_IP}:${LAN_BASELINE_RSC}"; then
+    [[ -n "$tmp" ]] && rm -f "$tmp"
+    err "LAN baseline upload failed; run the wizard from a wired connection or re-run install.sh"
+    return 0
+  fi
+  [[ -n "$tmp" ]] && rm -f "$tmp"
+  if ! spin "starting detached LAN baseline job" \
+       ros_cmd ":execute script={/import file-name=${LAN_BASELINE_RSC}}"; then
+    err "LAN baseline job failed to start; run the wizard from a wired connection or re-run install.sh"
+    return 0
+  fi
+  LAN_BASELINE_APPLIED=1
+}
+
 # ---- uninstall -------------------------------------------------------------
 uninstall_path() {
   log ""
@@ -783,6 +835,7 @@ uninstall_path() {
   if (( ! DRY_RUN )); then
     ros_cmd "/file/remove [find where (name~\"^${TAR_REMOTE_DIR}/${ASSET_PREFIX}-\") and (name~\"\\.tar\$\")]" \
       >/dev/null 2>&1 || true
+    remove_remote_file "$LAN_BASELINE_RSC"
   fi
 
   log ""
@@ -829,8 +882,20 @@ main() {
   final_port="$(ros_cmd "/ip/firewall/nat/print detail where comment=\"${COMMENT_TAG}-dstnat\"" 2>/dev/null \
                   | sed -nE 's/.*dst-port=([0-9]+).*/\1/p' | head -1)"
   [[ -z "$final_port" ]] && final_port="$LAN_PORT"
+
+  if (( ! NO_LAN_BASELINE )); then
+    setup_lan_baseline
+  fi
+
   log ""
-  log "\033[32m✓ Done. Panel reachable at http://${ROUTER_IP}:${final_port}/\033[0m"
+  if (( LAN_BASELINE_APPLIED )); then
+    log "\033[32m✓ Done. Baseline LAN ${LAN_BRIDGE_IP%.*}.0/24 (bridge ${LAN_BRIDGE}) configured.\033[0m"
+    log "  Reconnect (or renew your DHCP lease) on the ${LAN_BRIDGE_IP%.*}.x network,"
+    log "  then open \033[1mhttp://${LAN_BRIDGE_IP}:${final_port}/\033[0m"
+    log "  If it does not respond, the panel is still at \033[1mhttp://${ROUTER_IP}:${final_port}/\033[0m"
+  else
+    log "\033[32m✓ Done. Panel reachable at http://${ROUTER_IP}:${final_port}/\033[0m"
+  fi
 }
 
 main

--- a/scripts/nasnet-lan-baseline.rsc
+++ b/scripts/nasnet-lan-baseline.rsc
@@ -1,0 +1,92 @@
+:if ([:len [/interface/bridge find name="LANBridgeSplit"]] > 0) do={
+  :log info "nasnet-panel: LANBridgeSplit already exists, skipping LAN baseline"
+} else={
+  :log info "nasnet-panel: applying LAN baseline (192.168.10.0/24)"
+  :local wanIfaces [:toarray ""]
+  :foreach c in=[/ip/dhcp-client find] do={
+    :set wanIfaces ($wanIfaces , [/ip/dhcp-client get $c interface])
+  }
+  :do {
+    :foreach p in=[/interface/pppoe-client find] do={
+      :set wanIfaces ($wanIfaces , [/interface/pppoe-client get $p interface])
+    }
+  } on-error={}
+  :local isWanIf do={
+    :foreach w in=$2 do={
+      :if ($1 = $w) do={ :return true }
+    }
+    :return false
+  }
+  :foreach w in=$wanIfaces do={
+    :if ([:len [/interface/ethernet find name=$w]] = 0) do={
+      :log warning ("nasnet-panel: WAN uplink " . $w . " is not a plain ethernet (VLAN/bridge); its parent may be bridged into the LAN - review manually")
+    }
+  }
+  /interface/bridge add name="LANBridgeSplit" comment="Split"
+  /ip/address add address="192.168.10.1/24" interface="LANBridgeSplit" network="192.168.10.0" comment="Split"
+  :if ([:len [/ip/pool find name="DHCP-pool-Split"]] = 0) do={
+    /ip/pool add name="DHCP-pool-Split" ranges="192.168.10.2-192.168.10.254" comment="Split"
+  }
+  :if ([:len [/ip/dhcp-server find name="DHCP-Split"]] = 0) do={
+    /ip/dhcp-server add name="DHCP-Split" interface="LANBridgeSplit" address-pool="DHCP-pool-Split" comment="Split"
+  }
+  :if ([:len [/ip/dhcp-server/network find comment="Split"]] = 0) do={
+    /ip/dhcp-server/network add address="192.168.10.0/24" gateway="192.168.10.1" dns-server="192.168.10.1" comment="Split"
+  }
+  :do { /interface/macvlan remove [find] } on-error={}
+  :foreach e in=[/interface/ethernet find] do={
+    :local en [/interface/ethernet get $e name]
+    :if (![$isWanIf $en $wanIfaces]) do={
+      :local blocked false
+      :foreach pid in=[/interface/bridge/port find interface=$en] do={
+        :local pbr [/interface/bridge/port get $pid bridge]
+        :if ($pbr = "containers" || $pbr = "LANBridgeSplit" || [$isWanIf $pbr $wanIfaces]) do={
+          :set blocked true
+        } else={
+          :do { /interface/bridge/port remove $pid } on-error={}
+        }
+      }
+      :if (!$blocked) do={
+        :do { /interface/bridge/port add bridge="LANBridgeSplit" interface=$en comment="Split" } on-error={
+          :log warning ("nasnet-panel: could not add " . $en . " to LANBridgeSplit")
+        }
+      }
+    }
+  }
+  :do {
+    :foreach w in=[/interface/wifi find] do={
+      :local wn [/interface/wifi get $w name]
+      :local mode ""
+      :do { :set mode [/interface/wifi get $w configuration.mode] } on-error={}
+      :if ($mode != "station" && $mode != "station-bridge" && ![$isWanIf $wn $wanIfaces]) do={
+        :local blocked false
+        :foreach pid in=[/interface/bridge/port find interface=$wn] do={
+          :local pbr [/interface/bridge/port get $pid bridge]
+          :if ($pbr = "containers" || $pbr = "LANBridgeSplit" || [$isWanIf $pbr $wanIfaces]) do={
+            :set blocked true
+          } else={
+            :do { /interface/bridge/port remove $pid } on-error={}
+          }
+        }
+        :if (!$blocked) do={
+          :do { /interface/bridge/port add bridge="LANBridgeSplit" interface=$wn comment="Split" } on-error={
+            :log warning ("nasnet-panel: could not add " . $wn . " to LANBridgeSplit")
+          }
+        }
+      }
+    }
+  } on-error={}
+  :foreach b in=[/interface/bridge find] do={
+    :local bn [/interface/bridge get $b name]
+    :if ($bn != "containers" && $bn != "LANBridgeSplit" && ![$isWanIf $bn $wanIfaces]) do={
+      :do { /ip/dhcp-server remove [find interface=$bn] } on-error={}
+      :do { /ip/address remove [find interface=$bn] } on-error={}
+      :do { /interface/bridge/port remove [find bridge=$bn] } on-error={}
+      :do { /interface/bridge remove $b } on-error={}
+    }
+  }
+  :if ([:len [/interface/bridge/port find bridge="LANBridgeSplit"]] = 0) do={
+    :log warning "nasnet-panel: LANBridgeSplit has no member ports (single-bridge/AP-mode router); reach the panel at the router's current address until the wizard runs"
+  }
+  :log info "nasnet-panel: LAN baseline applied, gateway is 192.168.10.1"
+}


### PR DESCRIPTION
Closes #267

- Pre-stage the wizard's LAN (LANBridgeSplit, 192.168.10.1/24, DHCP) at the end of install.sh so the wizard preserves it rather than dropping the user mid-run
- Keep the panel's firewall rules through the wizard cleanup and scope them to LAN so the panel is never reachable from WAN
- Apply the LAN change as a detached RouterOS job, leaving WAN uplinks and the containers bridge untouched
