### PR TITLE
fix(fe): disable browser autofill in WireGuard edit dialogs

### DIFF
--- a/frontend/src/routes/vpn/dialogs/EditWgClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/EditWgClientDialog.tsx
@@ -239,6 +239,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                 value={draft.listenPort}
                 onChange={(e) => set('listenPort', e.target.value)}
                 inputMode="numeric"
+                autoComplete="off"
                 aria-label="Listen port"
                 aria-invalid={submitAttempted && !!errors.listenPort}
               />
@@ -255,6 +256,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                 onChange={(e) => set('mtu', e.target.value)}
                 placeholder="leave empty to keep current"
                 inputMode="numeric"
+                autoComplete="off"
                 aria-label="MTU"
                 aria-invalid={submitAttempted && !!errors.mtu}
               />
@@ -266,6 +268,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                 value={draft.comment}
                 onChange={(e) => set('comment', e.target.value)}
                 placeholder="optional"
+                autoComplete="off"
                 aria-label="Comment"
               />
             </Label>
@@ -278,7 +281,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                 onChange={(e) => set('interfacePrivateKey', e.target.value)}
                 placeholder="leave empty to keep current"
                 aria-label="Interface private key"
-                autoComplete="off"
+                autoComplete="new-password"
               />
             </Label>
           </FieldRow>
@@ -301,6 +304,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                   <Input
                     value={draft.endpointAddress}
                     onChange={(e) => set('endpointAddress', e.target.value)}
+                    autoComplete="off"
                     aria-label="Endpoint address"
                   />
                 </Label>
@@ -310,6 +314,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                     value={draft.endpointPort}
                     onChange={(e) => set('endpointPort', e.target.value)}
                     inputMode="numeric"
+                    autoComplete="off"
                     aria-label="Endpoint port"
                     aria-invalid={submitAttempted && !!errors.endpointPort}
                   />
@@ -325,6 +330,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                     value={draft.allowedAddresses}
                     onChange={(e) => set('allowedAddresses', e.target.value)}
                     placeholder="0.0.0.0/0"
+                    autoComplete="off"
                     aria-label="Allowed addresses"
                   />
                 </Label>
@@ -335,6 +341,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                     onChange={(e) => set('persistentKeepalive', e.target.value)}
                     placeholder="empty = off"
                     inputMode="numeric"
+                    autoComplete="off"
                     aria-label="Persistent keepalive"
                     aria-invalid={submitAttempted && !!errors.persistentKeepalive}
                   />
@@ -350,6 +357,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                     value={draft.peerPublicKey}
                     onChange={(e) => set('peerPublicKey', e.target.value)}
                     placeholder="leave empty to keep current"
+                    autoComplete="off"
                     aria-label="Peer public key"
                   />
                 </Label>
@@ -360,7 +368,7 @@ export function EditWgClientDialog({ creds, client, onCancel, onSaved }: Props) 
                     onChange={(e) => set('preSharedKey', e.target.value)}
                     placeholder="leave empty to keep current"
                     aria-label="Preshared key"
-                    autoComplete="off"
+                    autoComplete="new-password"
                   />
                 </Label>
               </FieldRow>

--- a/frontend/src/routes/vpn/dialogs/EditWgInterfaceDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/EditWgInterfaceDialog.tsx
@@ -171,6 +171,7 @@ export function EditWgInterfaceDialog({ creds, server, onCancel, onSaved }: Prop
                 onChange={(e) => set('listenPort', e.target.value)}
                 onBlur={() => markTouched('listenPort')}
                 inputMode="numeric"
+                autoComplete="off"
                 aria-label="Listen port"
                 aria-invalid={touched.listenPort && !!errors.listenPort}
               />
@@ -188,6 +189,7 @@ export function EditWgInterfaceDialog({ creds, server, onCancel, onSaved }: Prop
                 onBlur={() => markTouched('mtu')}
                 placeholder="leave empty to keep current"
                 inputMode="numeric"
+                autoComplete="off"
                 aria-label="MTU"
                 aria-invalid={touched.mtu && !!errors.mtu}
               />
@@ -199,6 +201,7 @@ export function EditWgInterfaceDialog({ creds, server, onCancel, onSaved }: Prop
                 value={draft.comment}
                 onChange={(e) => set('comment', e.target.value)}
                 placeholder="leave empty to keep current"
+                autoComplete="off"
                 aria-label="Comment"
               />
             </Label>
@@ -211,7 +214,7 @@ export function EditWgInterfaceDialog({ creds, server, onCancel, onSaved }: Prop
                 onChange={(e) => set('privateKey', e.target.value)}
                 placeholder="leave empty to keep current"
                 aria-label="Private key"
-                autoComplete="off"
+                autoComplete="new-password"
               />
             </Label>
           </FieldRow>

--- a/frontend/src/routes/vpn/dialogs/EditWgPeerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/EditWgPeerDialog.tsx
@@ -144,6 +144,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
             <Input
               value={draft.name}
               onChange={(e) => set('name', e.target.value)}
+              autoComplete="off"
               aria-label="Name"
             />
           </Label>
@@ -154,6 +155,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
             <Input
               value={draft.endpointAddress}
               onChange={(e) => set('endpointAddress', e.target.value)}
+              autoComplete="off"
               aria-label="Endpoint address"
             />
           </Label>
@@ -164,6 +166,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
               onChange={(e) => set('endpointPort', e.target.value)}
               onBlur={() => markTouched('endpointPort')}
               inputMode="numeric"
+              autoComplete="off"
               aria-label="Endpoint port"
               aria-invalid={touched.endpointPort && !!errors.endpointPort}
             />
@@ -178,6 +181,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
             <Input
               value={draft.allowedAddresses}
               onChange={(e) => set('allowedAddresses', e.target.value)}
+              autoComplete="off"
               aria-label="Allowed addresses"
             />
           </Label>
@@ -189,6 +193,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
               onBlur={() => markTouched('persistentKeepalive')}
               placeholder="empty = off"
               inputMode="numeric"
+              autoComplete="off"
               aria-label="Persistent keepalive"
               aria-invalid={touched.persistentKeepalive && !!errors.persistentKeepalive}
             />
@@ -204,7 +209,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
               value={draft.preSharedKey}
               onChange={(e) => set('preSharedKey', e.target.value)}
               aria-label="Preshared key"
-              autoComplete="off"
+              autoComplete="new-password"
             />
           </Label>
           <Label>
@@ -213,6 +218,7 @@ export function EditWgPeerDialog({ creds, peer, onCancel, onSaved }: Props) {
               value={draft.comment}
               onChange={(e) => set('comment', e.target.value)}
               placeholder="leave empty to keep current"
+              autoComplete="off"
               aria-label="Comment"
             />
           </Label>


### PR DESCRIPTION
Closes #289

- use new-password on private and preshared key fields since Chrome ignores autocomplete off for passwords
- turn off autocomplete on the surrounding text fields so saved usernames are not filled in