### PR TITLE
feat(fe): add diagnostics page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { PluginsPage } from './routes/PluginsPage';
 import { DHCPPage } from './routes/DHCPPage';
 import { DNSPage } from './routes/DNSPage';
 import { FirewallPage } from './routes/FirewallPage';
+import { DiagnosticsPage } from './routes/DiagnosticsPage';
 import { HelpPage } from './routes/HelpPage';
 
 function AddRouterEntry() {
@@ -64,6 +65,7 @@ export function App() {
                   <Route path="dns" element={<DNSPage />} />
                   <Route path="firewall" element={<FirewallPage />} />
                   <Route path="plugins" element={<PluginsPage />} />
+                  <Route path="diagnostics" element={<DiagnosticsPage />} />
                   <Route path="help" element={<HelpPage />} />
                 </Route>
                 <Route

--- a/frontend/src/api/diag.ts
+++ b/frontend/src/api/diag.ts
@@ -1,0 +1,57 @@
+import { apiRequest, ApiError } from './http';
+import { BACKEND_URL } from './config';
+import type { SystemCredentials } from './system';
+
+export interface DiagStatusResponse {
+  progress: number;
+  running: boolean;
+  fileSize?: string;
+  generateTime?: string;
+}
+
+export const DIAG_REPORT_FILENAME = 'nasnet-diagnostic-report.txt';
+
+function authHeaders({ host, username, password }: SystemCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function generateDiag(creds: SystemCredentials): Promise<void> {
+  await apiRequest('/api/diag/generate', {
+    method: 'POST',
+    headers: authHeaders(creds),
+  });
+}
+
+export async function fetchDiagStatus(
+  creds: SystemCredentials,
+  signal?: AbortSignal,
+): Promise<DiagStatusResponse> {
+  return apiRequest<DiagStatusResponse>('/api/diag/status', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}
+
+export async function fetchDiagReport(creds: SystemCredentials): Promise<string> {
+  const response = await fetch(`${BACKEND_URL}/api/diag/download`, {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as {
+      error?: string;
+      message?: string;
+    } | null;
+    throw new ApiError(
+      body?.error || body?.message || `Request failed (${response.status})`,
+      response.status,
+    );
+  }
+  return response.text();
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -93,6 +93,13 @@ export {
   type UpdateInstallResponse,
 } from './updates';
 export {
+  generateDiag,
+  fetchDiagStatus,
+  fetchDiagReport,
+  DIAG_REPORT_FILENAME,
+  type DiagStatusResponse,
+} from './diag';
+export {
   listVPNClients,
   updateVPNClient,
   addL2TPClient,

--- a/frontend/src/layout/RouterTabBar.tsx
+++ b/frontend/src/layout/RouterTabBar.tsx
@@ -33,7 +33,6 @@ export const ROUTER_TABS: Array<TabItem & { path: string }> = [
     label: 'Diagnostics',
     path: 'diagnostics',
     icon: <Activity size={16} />,
-    disabled: true,
   },
   { id: 'help', label: 'Help', path: 'help', icon: <CircleHelp size={16} /> },
   // { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },

--- a/frontend/src/routes/DiagnosticsPage.module.scss
+++ b/frontend/src/routes/DiagnosticsPage.module.scss
@@ -1,0 +1,229 @@
+.timelineScroll {
+  overflow-x: auto;
+  padding-bottom: var(--space-xs);
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(9, minmax(120px, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: min-content;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-right: var(--space-sm);
+  min-width: 0;
+}
+
+.stepTitle {
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+}
+
+.stepTitleActive {
+  color: var(--color-text);
+}
+
+.stepStatus {
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+}
+
+.stepTrack {
+  position: relative;
+  height: 20px;
+  margin-top: auto;
+  padding-top: var(--space-xs);
+  box-sizing: content-box;
+}
+
+.stepDot {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  box-shadow: 0 0 0 3px var(--color-surface-alt);
+  z-index: 1;
+}
+
+.stepDotDone {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  box-shadow: 0 0 0 3px rgba(62, 194, 141, 0.18);
+}
+
+.stepDotActive {
+  border-color: var(--color-success);
+  box-shadow: 0 0 0 3px rgba(62, 194, 141, 0.18);
+  animation: diagPulse 1200ms ease-in-out infinite;
+}
+
+.stepLine {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  right: calc(-1 * var(--space-sm));
+  height: 2px;
+  transform: translateY(-50%);
+  background: var(--color-border);
+}
+
+.stepLineDone {
+  background: var(--color-success);
+}
+
+@keyframes diagPulse {
+  50% {
+    box-shadow: 0 0 0 6px rgba(62, 194, 141, 0.1);
+  }
+}
+
+@media (max-width: 640px) {
+  .timelineScroll {
+    overflow-x: visible;
+    padding-bottom: 0;
+  }
+
+  .timeline {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .step {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-sm);
+    padding-right: 0;
+    min-height: 40px;
+  }
+
+  .stepStatus {
+    display: none;
+  }
+
+  .stepTrack {
+    order: -1;
+    width: 20px;
+    height: auto;
+    align-self: stretch;
+    flex-shrink: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  .stepDot {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .stepLine {
+    top: calc(50% + 9px);
+    bottom: calc(-50% + 9px);
+    left: 50%;
+    right: auto;
+    width: 2px;
+    height: auto;
+    transform: translateX(-50%);
+  }
+}
+
+.errorText {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--color-danger);
+}
+
+.fileTile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 320px;
+  max-width: 100%;
+  align-self: center;
+  margin: var(--space-lg) 0;
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.fileRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.fileIcon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: rgba(62, 194, 141, 0.14);
+  color: var(--color-success);
+}
+
+.fileBody {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  gap: 2px;
+  min-width: 0;
+}
+
+.fileName {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  word-break: break-all;
+}
+
+.fileHint {
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+}
+
+.fileAction {
+  display: flex;
+
+  > * {
+    flex: 1;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+
+  @media (max-width: 640px) {
+    flex-wrap: nowrap;
+
+    > * {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}
+
+.actionsSpaced {
+  margin-top: var(--space-lg);
+}

--- a/frontend/src/routes/DiagnosticsPage.tsx
+++ b/frontend/src/routes/DiagnosticsPage.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Download, FileText, Loader2, MessageCircle, Play, RefreshCw } from 'lucide-react';
+import { Button, Card, Stack, useToast } from '@nasnet/ui';
+import styles from './DiagnosticsPage.module.scss';
+import {
+  DIAG_REPORT_FILENAME,
+  fetchDiagReport,
+  fetchDiagStatus,
+  generateDiag,
+  isAbortError,
+  type SystemCredentials,
+} from '../api';
+import { useSession } from '../state/SessionContext';
+import { useRouter } from '../state/RouterStoreContext';
+
+const POLL_INTERVAL_MS = 1000;
+
+type Phase = 'loading' | 'idle' | 'running' | 'ready' | 'error';
+
+const DIAG_STEPS: Array<{ at: number; label: string; description: string }> = [
+  { at: 10, label: 'System info', description: 'Resources and packages' },
+  { at: 15, label: 'Installation check', description: 'Panel install status' },
+  { at: 25, label: 'Interfaces', description: 'Links and addresses' },
+  { at: 35, label: 'WiFi', description: 'Wireless interfaces' },
+  { at: 45, label: 'Routing', description: 'Tables and rules' },
+  { at: 60, label: 'DNS', description: 'Config and resolution' },
+  { at: 75, label: 'VPN', description: 'Clients and servers' },
+  { at: 90, label: 'Connectivity tests', description: 'WAN and VPN pings' },
+  { at: 95, label: 'Logs', description: 'Recent errors' },
+];
+
+function triggerDownload(filename: string, content: string) {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function DiagnosticsPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter(id);
+  const navigate = useNavigate();
+  const { getCredentials } = useSession();
+  const toast = useToast();
+
+  const creds = useMemo<SystemCredentials | null>(() => {
+    if (!id) return null;
+    const c = getCredentials(id);
+    const host = router?.host;
+    if (!c || !host) return null;
+    return { host, username: c.username, password: c.password };
+  }, [id, router?.host, getCredentials]);
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [fileMeta, setFileMeta] = useState<{ time?: string; size?: string } | null>(null);
+  const freshRunRef = useRef(false);
+
+  useEffect(() => {
+    if (!creds) {
+      setPhase('error');
+      setError('Missing router credentials for this session.');
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const status = await fetchDiagStatus(creds, controller.signal);
+        if (cancelled) return;
+        if (status.running) {
+          setProgress(status.progress);
+          setPhase('running');
+        } else if (status.progress >= 100) {
+          setProgress(100);
+          setFileMeta({ time: status.generateTime, size: status.fileSize });
+          setPhase('ready');
+        } else {
+          setPhase('idle');
+        }
+      } catch (err) {
+        if (cancelled || isAbortError(err)) return;
+        setPhase('error');
+        setError(err instanceof Error ? err.message : 'Failed to load diagnostic status.');
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [creds]);
+
+  useEffect(() => {
+    if (phase !== 'running' || !creds) return;
+    let cancelled = false;
+    let timer: number | undefined;
+    const controller = new AbortController();
+    const tick = async () => {
+      try {
+        const status = await fetchDiagStatus(creds, controller.signal);
+        if (cancelled) return;
+        if (freshRunRef.current && status.progress >= 100) {
+          timer = window.setTimeout(() => {
+            void tick();
+          }, POLL_INTERVAL_MS);
+          return;
+        }
+        freshRunRef.current = false;
+        setProgress(status.progress);
+        if (status.progress >= 100) {
+          setFileMeta({ time: status.generateTime, size: status.fileSize });
+          setPhase('ready');
+          toast.notify({ title: 'Diagnostic complete', tone: 'success' });
+          return;
+        }
+        timer = window.setTimeout(() => {
+          void tick();
+        }, POLL_INTERVAL_MS);
+      } catch (err) {
+        if (cancelled || isAbortError(err)) return;
+        setPhase('error');
+        setError(err instanceof Error ? err.message : 'Failed to check diagnostic progress.');
+      }
+    };
+    void tick();
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [phase, creds, toast]);
+
+  const run = async () => {
+    if (!creds) return;
+    setStarting(true);
+    setError(null);
+    try {
+      await generateDiag(creds);
+      freshRunRef.current = true;
+      setFileMeta(null);
+      setProgress(0);
+      setPhase('running');
+    } catch (err) {
+      toast.notify({
+        title: 'Failed to start diagnostic',
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const download = async () => {
+    if (!creds) return;
+    setDownloading(true);
+    try {
+      triggerDownload(DIAG_REPORT_FILENAME, await fetchDiagReport(creds));
+    } catch (err) {
+      toast.notify({
+        title: 'Failed to download report',
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const contactSupport = () => {
+    if (!id) return;
+    navigate(`/router/${id}/help`);
+  };
+
+  const running = phase === 'running';
+  const ready = phase === 'ready';
+  const activeStepIndex = running ? DIAG_STEPS.findIndex((step) => progress < step.at) : -1;
+
+  return (
+    <Card>
+      <Stack>
+        <div className={styles.timelineScroll}>
+          <ol className={styles.timeline}>
+            {DIAG_STEPS.map((step, index) => {
+              const done = ready || (running && progress >= step.at);
+              const active = running && !done && index === activeStepIndex;
+              return (
+                <li key={step.at} className={styles.step}>
+                  <span
+                    className={`${styles.stepTitle} ${done || active ? styles.stepTitleActive : ''}`}
+                  >
+                    {step.label}
+                  </span>
+                  <span className={styles.stepStatus}>{step.description}</span>
+                  <span className={styles.stepTrack}>
+                    <span
+                      className={`${styles.stepDot} ${done ? styles.stepDotDone : ''} ${
+                        active ? styles.stepDotActive : ''
+                      }`}
+                    />
+                    {index < DIAG_STEPS.length - 1 ? (
+                      <span className={`${styles.stepLine} ${done ? styles.stepLineDone : ''}`} />
+                    ) : null}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+        {phase === 'error' && error ? <p className={styles.errorText}>{error}</p> : null}
+        {ready ? (
+          <div className={styles.fileTile}>
+            <div className={styles.fileRow}>
+              <span className={styles.fileIcon}>
+                <FileText size={24} aria-hidden />
+              </span>
+              <span className={styles.fileBody}>
+                <span className={styles.fileName}>{DIAG_REPORT_FILENAME}</span>
+                {fileMeta?.time ? (
+                  <span className={styles.fileHint}>
+                    {`Generated ${fileMeta.time}${fileMeta.size ? ` (${fileMeta.size})` : ''}`}
+                  </span>
+                ) : null}
+              </span>
+            </div>
+            <div className={styles.fileAction}>
+              <Button variant="success" onClick={download} disabled={downloading}>
+                {downloading ? (
+                  <>
+                    <Loader2 size={14} aria-hidden /> Downloading…
+                  </>
+                ) : (
+                  <>
+                    <Download size={14} aria-hidden /> Download
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+        <div className={`${styles.actions} ${ready ? '' : styles.actionsSpaced}`}>
+          <Button variant="secondary" onClick={contactSupport}>
+            <MessageCircle size={14} aria-hidden /> Send to support
+          </Button>
+          <Button
+            variant={ready ? 'primary' : 'success'}
+            onClick={run}
+            disabled={!creds || phase === 'loading' || running || starting}
+          >
+            {running || starting ? (
+              <>
+                <Loader2 size={14} aria-hidden /> Running…
+              </>
+            ) : ready ? (
+              <>
+                <RefreshCw size={14} aria-hidden /> Run again
+              </>
+            ) : (
+              <>
+                <Play size={14} aria-hidden /> Start
+              </>
+            )}
+          </Button>
+        </div>
+      </Stack>
+    </Card>
+  );
+}

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -36,7 +36,6 @@ const TABS: Array<TabItem & { path: string }> = [
     label: 'Diagnostics',
     path: 'diagnostics',
     icon: <Activity size={16} />,
-    disabled: true,
   },
   { id: 'help', label: 'Help', path: 'help', icon: <CircleHelp size={16} /> },
   // { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },

--- a/frontend/tests/e2e/27-diagnostics-page.spec.ts
+++ b/frontend/tests/e2e/27-diagnostics-page.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from './fixtures';
+
+test.describe('Diagnostics page', () => {
+  test('runs a diagnostic, ticks the timeline, and downloads the report', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockDiagBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_diag', name: 'Diag Router', host: '10.10.10.2' });
+    await mockDiagBackend({ id: 'rtr_diag' });
+    await page.goto('/router/rtr_diag/diagnostics');
+
+    await expect(page.getByText('System info')).toBeVisible();
+    await expect(page.getByText('Connectivity tests')).toBeVisible();
+    await expect(page.getByText('nasnet-diagnostic-report.txt')).toHaveCount(0);
+
+    const startButton = page.getByRole('button', { name: /^start$/i });
+    await expect(startButton).toBeEnabled();
+    await startButton.click();
+
+    await expect(page.getByRole('button', { name: /running/i })).toBeVisible();
+
+    await expect(page.getByText('nasnet-diagnostic-report.txt')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Generated 2026-07-08 01:36:16 (74.15 KB)')).toBeVisible();
+    await expect(page.getByRole('button', { name: /run again/i })).toBeEnabled();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /^download$/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe('nasnet-diagnostic-report.txt');
+  });
+
+  test('shows an existing report on load and opens help via send to support', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockDiagBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_diag2', name: 'Diag Router 2', host: '10.10.10.3' });
+    await mockDiagBackend({ id: 'rtr_diag2', initialProgress: 100 });
+    await page.goto('/router/rtr_diag2/diagnostics');
+
+    await expect(page.getByText('nasnet-diagnostic-report.txt')).toBeVisible();
+    await expect(page.getByText('Generated 2026-07-08 01:36:16 (74.15 KB)')).toBeVisible();
+    await expect(page.getByRole('button', { name: /run again/i })).toBeEnabled();
+
+    await page.getByRole('button', { name: /send to support/i }).click();
+    await expect(page).toHaveURL(/\/router\/rtr_diag2\/help$/);
+  });
+});

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -77,6 +77,11 @@ export interface DhcpBackendOptions {
   id?: string;
 }
 
+export interface DiagBackendOptions {
+  id?: string;
+  initialProgress?: number;
+}
+
 export interface EasyConfigBackendInterface {
   id?: string;
   name: string;
@@ -115,6 +120,7 @@ export interface TestFixtures {
   mockWifiBackend: (router?: WifiBackendRouter) => Promise<void>;
   mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
   mockDhcpBackend: (options?: DhcpBackendOptions) => Promise<void>;
+  mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
   mockEasyConfigBackend: (options: EasyConfigBackendOptions) => Promise<void>;
 }
 
@@ -774,6 +780,69 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope({ macAddress: 'AA:BB:CC:DD:EE:02', id: '*2', address: '192.168.88.102' }),
+        });
+      });
+    });
+  },
+  mockDiagBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      let progress = options.initialProgress ?? 0;
+      let started = false;
+
+      await context.route('**/api/diag/generate', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        started = true;
+        progress = 0;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ message: 'Diagnostic script executed successfully' }),
+        });
+      });
+
+      await context.route('**/api/diag/status**', async (route) => {
+        if (started && progress < 100) progress = Math.min(100, progress + 45);
+        const running = progress > 0 && progress < 100;
+        const data: Record<string, unknown> = { progress, running };
+        if (progress === 100) {
+          data.generateTime = '2026-07-08 01:36:16';
+          data.fileSize = '74.15 KB';
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(data),
+        });
+      });
+
+      await context.route('**/api/diag/download', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/plain',
+          headers: {
+            'Content-Disposition': 'attachment; filename="nasnet-diagnostic-report.txt"',
+          },
+          body: 'NasNet Panel Diagnostic Report',
         });
       });
     });


### PR DESCRIPTION
## Summary

- add diagnostics page that runs the router diagnostic and shows section progress on a horizontal timeline
- report card with generated date and size, download button and send to support shortcut
- enable the diagnostics tab in both tab bars
- e2e coverage for the run flow and the existing report flow