### PR TITLE
feat(fe): route foreign traffic through a single active VPN client

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -24,7 +24,9 @@ export {
   fetchInterfaces,
   updateWanInterface,
   type WanInterfaceType,
-  fetchRoutes,
+  fetchForeignGateway,
+  updateForeignGateway,
+  type ForeignGatewayResponse,
   fetchVPNClients,
   rebootSystem,
   setSystemIdentity,
@@ -39,7 +41,6 @@ export {
   type InterfaceGraphSample,
   type InterfaceResponse,
   type IpAddressResponse,
-  type RouteResponse,
 } from './system';
 export {
   fetchWifiInterfaces,

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -129,15 +129,6 @@ export interface IpAddressResponse {
   disabled: boolean;
 }
 
-export interface RouteResponse {
-  id: string;
-  dstAddress: string;
-  gateway: string;
-  interface?: string;
-  active: boolean;
-  distance: number;
-}
-
 export async function fetchInterfaces(
   creds: SystemCredentials,
   signal?: AbortSignal,
@@ -168,17 +159,37 @@ export async function updateWanInterface(
   });
 }
 
-export async function fetchRoutes(
+export interface ForeignGatewayResponse {
+  gateway: string | null;
+}
+
+export async function fetchForeignGateway(
   creds: SystemCredentials,
   signal?: AbortSignal,
-): Promise<RouteResponse[]> {
-  const list = await apiRequest<RouteResponse[] | null>('/api/routes', {
+): Promise<string | null> {
+  const data = await apiRequest<ForeignGatewayResponse | null>('/api/route/foreign-gateway', {
     method: 'GET',
     headers: authHeaders(creds),
     cache: 'no-store',
     signal,
   });
-  return list ?? [];
+  return data?.gateway ?? null;
+}
+
+export async function updateForeignGateway(
+  creds: SystemCredentials,
+  gateway: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiRequest<unknown>('/api/route/foreign-gateway', {
+    method: 'PUT',
+    headers: {
+      ...authHeaders(creds),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ gateway }),
+    signal,
+  });
 }
 
 export async function fetchVPNClients(

--- a/frontend/src/routes/InternetPage.tsx
+++ b/frontend/src/routes/InternetPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, CardDescription, CardHeader, CardTitle, Stack, useToast } from '@nasnet/ui';
 import type { RoutingTopology } from '@nasnet/mocks';
-import { ApiError, updateVPNClient } from '../api';
+import { ApiError, updateForeignGateway, updateVPNClient } from '../api';
 import { useRouter } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
 import { usePolling } from '../utils/usePolling';
@@ -79,6 +79,15 @@ export function InternetPage() {
       const vpnName = target.id.replace(/^vpn_/, '');
       try {
         await updateVPNClient(creds, vpnName, { disabled: !isActive });
+        if (isActive) {
+          await updateForeignGateway(creds, vpnName);
+          const others = topology.nodes.filter((n) => n.kind === 'vpn' && n.id !== target.id);
+          await Promise.all(
+            others.map((n) =>
+              updateVPNClient(creds, n.id.replace(/^vpn_/, ''), { disabled: true }),
+            ),
+          );
+        }
         await reload();
         toast.notify({ title: 'VPN tunnel updated', tone: 'success' });
       } catch (err) {

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -35,7 +35,6 @@ import {
   fetchDynamicOverview,
   fetchInterfaceGraph,
   fetchInterfaces,
-  fetchRoutes,
   fetchSystemOverview,
   fetchVPNClients,
   rebootSystem,
@@ -46,7 +45,6 @@ import {
   type InterfaceGraphSample,
   type InterfaceResponse,
   type IpAddressResponse,
-  type RouteResponse,
   type SystemOverview,
   type TrafficSample,
   type VPNActiveClient,
@@ -115,7 +113,6 @@ export function OverviewTab() {
   const [vpnClients, setVpnClients] = useState<VPNActiveClient[]>([]);
   const [dhcpLeaseList, setDhcpLeaseList] = useState<DHCPLeaseResponse[]>([]);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
-  const [routes, setRoutes] = useState<RouteResponse[]>([]);
   const [dhcpClients, setDhcpClients] = useState<DhcpClient[]>([]);
   const [selectedIface, setSelectedIface] = useState<string>(DEFAULT_TRAFFIC_INTERFACE);
   const [graphLoading, setGraphLoading] = useState(false);
@@ -192,16 +189,14 @@ export function OverviewTab() {
 
     const loadInitial = async () => {
       try {
-        const [ov, list, routeList, clients] = await Promise.all([
+        const [ov, list, clients] = await Promise.all([
           fetchSystemOverview(id, { host, ...creds }),
           fetchInterfaces({ host, ...creds }).catch(() => [] as InterfaceResponse[]),
-          fetchRoutes({ host, ...creds }).catch(() => [] as RouteResponse[]),
           fetchDhcpClients({ host, ...creds }).catch(() => [] as DhcpClient[]),
         ]);
         if (cancelled) return;
         setOverview(ov);
         setInterfaces(list);
-        setRoutes(routeList);
         setDhcpClients(clients);
         if (list.length > 0) {
           setSelectedIface((prev) => {
@@ -540,7 +535,7 @@ export function OverviewTab() {
             )}
           </Card>
 
-          <UplinkIpCard interfaces={interfaces} addresses={ipAddresses} routes={routes} />
+          <UplinkIpCard interfaces={interfaces} addresses={ipAddresses} />
 
           <Card className={styles.networkCard}>
             <div className={styles.networkCardHeader}>

--- a/frontend/src/routes/internet/buildTopology.ts
+++ b/frontend/src/routes/internet/buildTopology.ts
@@ -1,11 +1,4 @@
-import {
-  fetchInterfaces,
-  fetchRoutes,
-  listVPNClients,
-  type InterfaceResponse,
-  type RouteResponse,
-  type VPNClientResponse,
-} from '../../api';
+import { fetchForeignGateway, fetchInterfaces, type InterfaceResponse } from '../../api';
 import type {
   RoutingHop,
   RoutingNode,
@@ -62,18 +55,9 @@ function classifyWan(iface: InterfaceResponse): { kind: RoutingWanKind; label: s
   return { kind: 'ether', label: iface.name.toUpperCase() };
 }
 
-function pickWanInterfaces(
-  ifaces: InterfaceResponse[],
-  routes: RouteResponse[],
-): InterfaceResponse[] {
-  const routeIfaces = new Set(
-    routes
-      .filter((r) => r.dstAddress === '0.0.0.0/0' && r.interface)
-      .map((r) => r.interface as string),
-  );
+function pickWanInterfaces(ifaces: InterfaceResponse[]): InterfaceResponse[] {
   const candidates = ifaces.filter((i) => {
     if (i.disabled) return false;
-    if (routeIfaces.has(i.name)) return true;
     if (i.type !== 'ether') return false;
     const comment = (i.comment ?? '').toLowerCase();
     return (
@@ -93,36 +77,14 @@ function pickWanInterfaces(
   return ifaces.filter((i) => i.type === 'ether' && !i.disabled);
 }
 
-function findWanForVpn(
-  vpnIfaceName: string,
-  routes: RouteResponse[],
-  wanByName: Map<string, InterfaceResponse>,
-): InterfaceResponse | undefined {
-  const vpnRoute = routes.find((r) => r.interface === vpnIfaceName);
-  if (vpnRoute?.gateway) {
-    const gwRoute = routes.find(
-      (r) => r.interface && r.interface !== vpnIfaceName && r.dstAddress === '0.0.0.0/0',
-    );
-    if (gwRoute?.interface && wanByName.has(gwRoute.interface)) {
-      return wanByName.get(gwRoute.interface);
-    }
-  }
-  const defaultRoute = routes.find(
-    (r) => r.dstAddress === '0.0.0.0/0' && r.active && r.interface && wanByName.has(r.interface),
-  );
-  if (defaultRoute?.interface) return wanByName.get(defaultRoute.interface);
-  return undefined;
-}
-
 export async function buildTopology(
   routerId: string,
   creds: Creds,
   signal?: AbortSignal,
 ): Promise<RoutingTopology> {
-  const [ifaces, vpnClients, routes] = await Promise.all([
+  const [ifaces, foreignGateway] = await Promise.all([
     fetchInterfaces(creds, signal),
-    listVPNClients(creds, signal),
-    fetchRoutes(creds, signal).catch(() => [] as RouteResponse[]),
+    fetchForeignGateway(creds, signal).catch(() => null),
   ]);
 
   const nodes: RoutingNode[] = [];
@@ -137,26 +99,28 @@ export async function buildTopology(
   const INTERNET_ID = 'internet';
   const domesticWans: InterfaceResponse[] = [];
 
-  const wans = pickWanInterfaces(ifaces, routes);
-  const wanByName = new Map<string, InterfaceResponse>();
+  const wans = pickWanInterfaces(ifaces);
   wans.forEach((wan) => {
-    wanByName.set(wan.name, wan);
     const id = `wan_${wan.name}`;
     const { kind, label } = classifyWan(wan);
+    const isDomestic = matchesWanCategory(wan.comment, 'domestic');
     nodes.push({ id, kind: 'wan', label, wanKind: kind });
     hops.push({
       id: `h_${ROUTER_ID}_${wan.name}`,
       fromId: ROUTER_ID,
       toId: id,
-      isActive: !!wan.running,
+      isActive: isDomestic || !!wan.running,
     });
-    if (matchesWanCategory(wan.comment, 'domestic')) domesticWans.push(wan);
+    if (isDomestic) domesticWans.push(wan);
   });
 
   const fallbackWan = wans.find((w) => w.running) ?? wans[0];
-  const vpnTunnels = vpnClients.filter(
-    (c: VPNClientResponse) => VPN_INTERFACE_TYPES.has(c.type) && !c.type.endsWith('-in'),
-  );
+  const vpnTunnels = ifaces.filter((i) => {
+    if (!VPN_INTERFACE_TYPES.has(i.type) || i.type.endsWith('-in')) return false;
+    const name = i.name.toLowerCase();
+    return name.includes('wg-client') || name.includes('l2tp-client');
+  });
+  const isRouted = (name: string) => foreignGateway === name;
   vpnTunnels.forEach((vpn) => {
     const id = `vpn_${vpn.name}`;
     nodes.push({
@@ -165,13 +129,12 @@ export async function buildTopology(
       label: vpn.comment?.trim() ? vpn.comment : vpn.name,
       protocol: TYPE_TO_PROTOCOL[vpn.type],
     });
-    const upstream = findWanForVpn(vpn.name, routes, wanByName) ?? fallbackWan;
-    if (upstream) {
+    if (fallbackWan) {
       hops.push({
         id: `h_vpn_${vpn.name}`,
-        fromId: `wan_${upstream.name}`,
+        fromId: `wan_${fallbackWan.name}`,
         toId: id,
-        isActive: !!vpn.running,
+        isActive: !!vpn.running && isRouted(vpn.name),
       });
     }
   });
@@ -183,7 +146,7 @@ export async function buildTopology(
         id: `h_internet_vpn_${vpn.name}`,
         fromId: `vpn_${vpn.name}`,
         toId: INTERNET_ID,
-        isActive: !!vpn.running,
+        isActive: !!vpn.running && isRouted(vpn.name),
       });
     });
     domesticWans.forEach((wan) => {
@@ -191,7 +154,7 @@ export async function buildTopology(
         id: `h_internet_wan_${wan.name}`,
         fromId: `wan_${wan.name}`,
         toId: INTERNET_ID,
-        isActive: !!wan.running,
+        isActive: true,
       });
     });
   }

--- a/frontend/src/routes/overview-panel/UplinkIpCard.tsx
+++ b/frontend/src/routes/overview-panel/UplinkIpCard.tsx
@@ -1,14 +1,13 @@
 import React, { useMemo } from 'react';
 import { Globe } from 'lucide-react';
 import { Badge, Card, StatusDot } from '@nasnet/ui';
-import type { InterfaceResponse, IpAddressResponse, RouteResponse } from '../../api';
+import type { InterfaceResponse, IpAddressResponse } from '../../api';
 import { buildUplinks, type UplinkKind } from './uplinks';
 import styles from './OverviewPanel.module.scss';
 
 export interface UplinkIpCardProps {
   interfaces: InterfaceResponse[];
   addresses: IpAddressResponse[];
-  routes: RouteResponse[];
 }
 
 const KIND_TONE: Record<UplinkKind, 'info' | 'warning' | 'success' | 'neutral'> = {
@@ -21,12 +20,8 @@ const KIND_TONE: Record<UplinkKind, 'info' | 'warning' | 'success' | 'neutral'> 
 export const UplinkIpCard: React.FC<UplinkIpCardProps> = React.memo(function UplinkIpCard({
   interfaces,
   addresses,
-  routes,
 }) {
-  const rows = useMemo(
-    () => buildUplinks(interfaces, addresses, routes),
-    [interfaces, addresses, routes],
-  );
+  const rows = useMemo(() => buildUplinks(interfaces, addresses), [interfaces, addresses]);
 
   return (
     <Card className={styles.panelCard} data-testid="uplink-card">
@@ -62,11 +57,6 @@ export const UplinkIpCard: React.FC<UplinkIpCardProps> = React.memo(function Upl
                 {row.label}
               </span>
               <Badge tone={KIND_TONE[row.kind]}>{row.kind}</Badge>
-              {row.isDefaultRoute ? (
-                <Badge tone="success" data-testid="uplink-default-route">
-                  Default route
-                </Badge>
-              ) : null}
               <span className={styles.uplinkIps}>
                 {row.ipAddresses.length > 0 ? (
                   row.ipAddresses.map((ip) => (

--- a/frontend/src/routes/overview-panel/uplinks.ts
+++ b/frontend/src/routes/overview-panel/uplinks.ts
@@ -1,4 +1,4 @@
-import type { InterfaceResponse, IpAddressResponse, RouteResponse } from '../../api';
+import type { InterfaceResponse, IpAddressResponse } from '../../api';
 
 export type UplinkKind = 'starlink' | 'mobile' | 'fiber' | 'ether';
 
@@ -9,7 +9,6 @@ export interface UplinkRow {
   ipAddresses: string[];
   running: boolean;
   disabled: boolean;
-  isDefaultRoute: boolean;
 }
 
 interface UplinkMatch {
@@ -58,35 +57,13 @@ export function wanInterfaces(interfaces: InterfaceResponse[]): InterfaceRespons
   return hinted.length > 0 ? hinted : ether;
 }
 
-function prefixOf(cidr: string): string {
-  const ip = cidr.split('/')[0];
-  return `${ip.split('.').slice(0, 3).join('.')}.`;
-}
-
-function defaultRouteInterface(
-  routes: RouteResponse[],
-  addresses: IpAddressResponse[],
-): string | undefined {
-  const def = routes.find((r) => r.dstAddress === '0.0.0.0/0' && r.active);
-  if (!def) return undefined;
-  if (def.interface) return def.interface.toLowerCase();
-  const gw = def.gateway?.split('%')[0];
-  if (!gw) return undefined;
-  const match = addresses.find(
-    (a) => a.address.split('/')[0] && gw.startsWith(prefixOf(a.address)),
-  );
-  return match?.interface.toLowerCase();
-}
-
 export function buildUplinks(
   interfaces: InterfaceResponse[],
   addresses: IpAddressResponse[],
-  routes: RouteResponse[],
 ): UplinkRow[] {
   const ether = interfaces.filter((i) => i.type === 'ether' && !i.disabled);
   const hinted = ether.filter((i) => matchUplink(i) !== null);
   const pool = hinted.length > 0 ? hinted : ether;
-  const defIface = defaultRouteInterface(routes, addresses);
   return pool.map((iface) => {
     const { kind, label } = classify(iface);
     const ipAddresses = addresses
@@ -99,7 +76,6 @@ export function buildUplinks(
       ipAddresses,
       running: iface.running,
       disabled: !!iface.disabled,
-      isDefaultRoute: defIface === iface.name.toLowerCase(),
     };
   });
 }

--- a/frontend/src/routes/vpn/sections/ClientsSection.tsx
+++ b/frontend/src/routes/vpn/sections/ClientsSection.tsx
@@ -193,6 +193,7 @@ export function ClientsSection({ creds, clients, onChanged, onDialogOpenChange }
         <div style={{ marginTop: 16 }}>
           <ClientsTable
             rows={paged.pagedRows}
+            allRows={clients}
             totalRows={clients.length}
             creds={creds}
             onToggled={onChanged}

--- a/frontend/src/routes/vpn/sections/ClientsTable.tsx
+++ b/frontend/src/routes/vpn/sections/ClientsTable.tsx
@@ -1,12 +1,19 @@
 import { useState } from 'react';
 import { Badge, Button, DataTable, Switch, useToast } from '@nasnet/ui';
 import { ArrowDown, ArrowUp, Cable, Pencil, Trash2 } from 'lucide-react';
-import { ApiError, updateVPNClient, type VPNClient, type VPNCredentials } from '../../../api';
+import {
+  ApiError,
+  updateForeignGateway,
+  updateVPNClient,
+  type VPNClient,
+  type VPNCredentials,
+} from '../../../api';
 import { formatBytes } from '../../../utils/format';
 import { useThemeColors } from '../../../utils/theme-colors';
 
 interface Props {
   rows: VPNClient[];
+  allRows: VPNClient[];
   totalRows: number;
   creds: VPNCredentials | null;
   onToggled: () => void;
@@ -14,7 +21,15 @@ interface Props {
   onDelete: (client: VPNClient) => void;
 }
 
-export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDelete }: Props) {
+export function ClientsTable({
+  rows,
+  allRows,
+  totalRows,
+  creds,
+  onToggled,
+  onEdit,
+  onDelete,
+}: Props) {
   const toast = useToast();
   const colors = useThemeColors();
   const [pending, setPending] = useState<Set<string>>(() => new Set());
@@ -23,11 +38,10 @@ export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDele
   const isPending = (id: string) => pending.has(id);
   const checkedFor = (c: VPNClient) => optimistic[c.id] ?? c.enabled;
 
-  const setRowPending = (id: string, on: boolean) => {
+  const setRowsPending = (ids: string[], on: boolean) => {
     setPending((prev) => {
       const next = new Set(prev);
-      if (on) next.add(id);
-      else next.delete(id);
+      ids.forEach((id) => (on ? next.add(id) : next.delete(id)));
       return next;
     });
   };
@@ -100,14 +114,28 @@ export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDele
                 disabled={!creds || busy}
                 onChange={async () => {
                   if (!creds) return;
-                  setOptimistic((m) => ({ ...m, [c.id]: next }));
-                  setRowPending(c.id, true);
+                  const others = next ? allRows.filter((o) => o.id !== c.id && checkedFor(o)) : [];
+                  const ids = [c.id, ...others.map((o) => o.id)];
+                  setOptimistic((m) => {
+                    const updated = { ...m, [c.id]: next };
+                    others.forEach((o) => {
+                      updated[o.id] = false;
+                    });
+                    return updated;
+                  });
+                  setRowsPending(ids, true);
                   try {
                     await updateVPNClient(creds, c.name, { disabled: !next });
+                    if (next) {
+                      await updateForeignGateway(creds, c.name);
+                      await Promise.all(
+                        others.map((o) => updateVPNClient(creds, o.name, { disabled: true })),
+                      );
+                    }
                   } catch (err) {
                     setOptimistic((m) => {
                       const reverted = { ...m };
-                      delete reverted[c.id];
+                      ids.forEach((rid) => delete reverted[rid]);
                       return reverted;
                     });
                     const message =
@@ -122,7 +150,7 @@ export function ClientsTable({ rows, totalRows, creds, onToggled, onEdit, onDele
                       tone: 'danger',
                     });
                   } finally {
-                    setRowPending(c.id, false);
+                    setRowsPending(ids, false);
                     onToggled();
                   }
                 }}

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -80,6 +80,20 @@ test.describe('WAN VPN clients section', () => {
       await route.fallback();
     });
 
+    let gatewayPutBody: { gateway?: string } | null = null;
+    await context.route('**/api/route/foreign-gateway', async (route) => {
+      if (route.request().method() === 'PUT') {
+        gatewayPutBody = route.request().postDataJSON() as typeof gatewayPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ gateway: 'home-l2tp', routesUpdated: 2 }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
     const row = page.getByRole('row', { name: /home-l2tp/ });
@@ -88,6 +102,116 @@ test.describe('WAN VPN clients section', () => {
 
     await row.getByRole('switch', { name: /enabled/i }).click();
     await expect.poll(() => lastPutBody?.disabled).toBe(false);
+    await expect.poll(() => gatewayPutBody?.gateway).toBe('home-l2tp');
+  });
+
+  test('activating a client deactivates the others and points routes at it', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'VPN Router', host: '10.0.0.10' });
+
+    await context.addInitScript((routerId) => {
+      try {
+        const key = 'nasnet-panel.session-credentials.v1';
+        const raw = window.sessionStorage.getItem(key);
+        const map = (raw ? JSON.parse(raw) : {}) as Record<
+          string,
+          { username: string; password: string }
+        >;
+        map[routerId] = { username: 'admin', password: 'test' };
+        window.sessionStorage.setItem(key, JSON.stringify(map));
+      } catch {
+        /* ignore */
+      }
+    }, ROUTER_ID);
+
+    const otherClient = {
+      ...baseClient,
+      id: '*2',
+      name: 'office-wg',
+      type: 'wg',
+      running: true,
+      disabled: false,
+    };
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope([baseClient, otherClient]),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+    await context.route('**/api/interface/interfaces', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([]),
+      });
+    });
+
+    let targetPutBody: { disabled?: boolean } | null = null;
+    await context.route('**/api/vpn/clients/home-l2tp', async (route) => {
+      if (route.request().method() === 'PUT') {
+        targetPutBody = route.request().postDataJSON() as typeof targetPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ ...baseClient, disabled: false }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    let otherPutBody: { disabled?: boolean } | null = null;
+    await context.route('**/api/vpn/clients/office-wg', async (route) => {
+      if (route.request().method() === 'PUT') {
+        otherPutBody = route.request().postDataJSON() as typeof otherPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ ...otherClient, disabled: true }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    let gatewayPutBody: { gateway?: string } | null = null;
+    await context.route('**/api/route/foreign-gateway', async (route) => {
+      if (route.request().method() === 'PUT') {
+        gatewayPutBody = route.request().postDataJSON() as typeof gatewayPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ gateway: 'home-l2tp', routesUpdated: 2 }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    const targetRow = page.getByRole('row', { name: /home-l2tp/ });
+    await expect(targetRow).toBeVisible();
+    await expect(
+      page.getByRole('row', { name: /office-wg/ }).getByRole('switch', { name: /enabled/i }),
+    ).toBeChecked();
+
+    await targetRow.getByRole('switch', { name: /enabled/i }).click();
+
+    await expect.poll(() => targetPutBody?.disabled).toBe(false);
+    await expect.poll(() => gatewayPutBody?.gateway).toBe('home-l2tp');
+    await expect.poll(() => otherPutBody?.disabled).toBe(true);
   });
 
   test('validates name and host inputs in add dialog and limits selectable types', async ({

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -22,81 +22,63 @@ async function seedCredentials(context: BrowserContext, routerId: string) {
   }, routerId);
 }
 
-async function mockTopologyApi(context: BrowserContext) {
+const wgMaskIface = {
+  id: '*5',
+  name: 'wg-client-mask',
+  type: 'wg',
+  running: true,
+  disabled: false,
+  comment: 'wg-mask',
+};
+
+const defaultInterfaces = [
+  {
+    id: '*1',
+    name: 'ether1',
+    type: 'ether',
+    running: true,
+    disabled: false,
+    comment: 'Starlink uplink',
+  },
+  {
+    id: '*2',
+    name: 'ether2',
+    type: 'ether',
+    running: false,
+    disabled: false,
+    comment: 'Irancell mobile',
+  },
+  {
+    id: '*3',
+    name: 'ether3',
+    type: 'ether',
+    running: true,
+    disabled: false,
+    comment: 'WAN - Domestic Link(Domestic)',
+  },
+  { id: '*4', name: 'bridge1', type: 'bridge', running: true, disabled: false },
+  wgMaskIface,
+];
+
+interface TopologyMockOptions {
+  interfaces?: Array<(typeof defaultInterfaces)[number]>;
+  gateway?: string | null;
+}
+
+async function mockTopologyApi(context: BrowserContext, opts: TopologyMockOptions = {}) {
   await context.route('**/api/interface/interfaces', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: envelope([
-        {
-          id: '*1',
-          name: 'ether1',
-          type: 'ether',
-          running: true,
-          disabled: false,
-          comment: 'Starlink uplink',
-        },
-        {
-          id: '*2',
-          name: 'ether2',
-          type: 'ether',
-          running: false,
-          disabled: false,
-          comment: 'Irancell mobile',
-        },
-        {
-          id: '*3',
-          name: 'ether3',
-          type: 'ether',
-          running: true,
-          disabled: false,
-          comment: 'WAN - Domestic Link(Domestic)',
-        },
-        { id: '*4', name: 'bridge1', type: 'bridge', running: true, disabled: false },
-      ]),
+      body: envelope(opts.interfaces ?? defaultInterfaces),
     });
   });
 
-  await context.route('**/api/routes', async (route) => {
+  await context.route('**/api/route/foreign-gateway', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: envelope([
-        {
-          id: '*1',
-          dstAddress: '0.0.0.0/0',
-          gateway: '100.64.0.1',
-          interface: 'ether1',
-          active: true,
-          distance: 1,
-        },
-      ]),
-    });
-  });
-
-  await context.route('**/api/vpn/clients', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: envelope([
-        {
-          id: '*1',
-          name: 'wg-mask',
-          type: 'wg',
-          running: true,
-          disabled: false,
-          mtu: 1420,
-          macAddress: '',
-          rxByte: 0,
-          txByte: 0,
-          rxPacket: 0,
-          txPacket: 0,
-          lastLinkUp: '',
-          lastLinkDown: '',
-          linkDowns: 0,
-          comment: 'wg-mask',
-        },
-      ]),
+      body: envelope({ gateway: opts.gateway === undefined ? 'wg-client-mask' : opts.gateway }),
     });
   });
 }
@@ -126,10 +108,10 @@ test.describe('Internet routing page', () => {
 
     await expect(svg.locator('path#edge-h_rtr_ether1')).toHaveCount(1);
     await expect(svg.locator('path#edge-h_rtr_ether2')).toHaveCount(1);
-    await expect(svg.locator('path#edge-h_vpn_wg-mask')).toHaveCount(1);
+    await expect(svg.locator('path#edge-h_vpn_wg-client-mask')).toHaveCount(1);
 
     await expect(page.getByText('Internet', { exact: true }).first()).toBeVisible();
-    await expect(svg.locator('path#edge-h_internet_vpn_wg-mask')).toHaveCount(1);
+    await expect(svg.locator('path#edge-h_internet_vpn_wg-client-mask')).toHaveCount(1);
     await expect(svg.locator('path#edge-h_internet_wan_ether3')).toHaveCount(1);
 
     const dots = svg.locator('circle animateMotion');
@@ -177,6 +159,166 @@ test.describe('Internet routing page', () => {
 
     const d = await svg.locator('path#edge-h_internet_wan_ether3').getAttribute('d');
     expect(d).toMatch(/^M -?[\d.]+ -?[\d.]+(?: L -?[\d.]+ -?[\d.]+)+$/);
+  });
+
+  test('marks only the routed VPN path as active', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      interfaces: [
+        ...defaultInterfaces,
+        { ...wgMaskIface, id: '*6', name: 'wg-client-alt', comment: 'wg-alt' },
+      ],
+      gateway: 'wg-client-mask',
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
+    );
+    await expect(svg.locator('path#edge-h_vpn_wg-client-alt')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+    await expect(svg.locator('path#edge-h_internet_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
+    );
+    await expect(svg.locator('path#edge-h_internet_vpn_wg-client-alt')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+  });
+
+  test('keeps the domestic WAN path always active', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      interfaces: defaultInterfaces.map((i) =>
+        i.name === 'ether3' ? { ...i, running: false } : i,
+      ),
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_rtr_ether3')).toHaveAttribute('marker-end', /arr-active/);
+    await expect(svg.locator('path#edge-h_internet_wan_ether3')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
+    );
+  });
+
+  test('activating a tunnel from the hop dialog points routes at it and disables others', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      interfaces: [
+        ...defaultInterfaces.filter((i) => i.name !== 'wg-client-mask'),
+        { ...wgMaskIface, running: false, disabled: true },
+        { ...wgMaskIface, id: '*6', name: 'wg-client-alt', comment: 'wg-alt' },
+      ],
+      gateway: 'wg-client-alt',
+    });
+
+    let targetPutBody: { disabled?: boolean } | null = null;
+    await context.route('**/api/vpn/clients/wg-client-mask', async (route) => {
+      targetPutBody = route.request().postDataJSON() as typeof targetPutBody;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ ...wgMaskIface, disabled: false }),
+      });
+    });
+
+    let otherPutBody: { disabled?: boolean } | null = null;
+    await context.route('**/api/vpn/clients/wg-client-alt', async (route) => {
+      otherPutBody = route.request().postDataJSON() as typeof otherPutBody;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ ...wgMaskIface, id: '*6', name: 'wg-client-alt', disabled: true }),
+      });
+    });
+
+    let gatewayPutBody: { gateway?: string } | null = null;
+    await context.route('**/api/route/foreign-gateway', async (route) => {
+      if (route.request().method() === 'PUT') {
+        gatewayPutBody = route.request().postDataJSON() as typeof gatewayPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ gateway: 'wg-client-mask', routesUpdated: 2 }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ gateway: 'wg-client-alt' }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    await page.getByRole('button', { name: 'Configure wg-mask' }).click();
+    await page.getByRole('switch', { name: /active/i }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect.poll(() => targetPutBody?.disabled).toBe(false);
+    await expect.poll(() => gatewayPutBody?.gateway).toBe('wg-client-mask');
+    await expect.poll(() => otherPutBody?.disabled).toBe(true);
+  });
+
+  test('marks no VPN path as active when no gateway route exists', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, { gateway: null });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+    await expect(svg.locator('path#edge-h_internet_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
   });
 
   test('topology stays scrollable on mobile viewports', async ({

--- a/frontend/tests/e2e/24-overview-port-diagram.spec.ts
+++ b/frontend/tests/e2e/24-overview-port-diagram.spec.ts
@@ -86,7 +86,7 @@ test.describe('Overview tab — router port diagram + uplink IP', () => {
     await expect(page.getByTestId('port-ether1')).toBeVisible();
   });
 
-  test('uplink card lists WAN interface, IP, and the active default route', async ({
+  test('uplink card lists WAN interface and IP', async ({
     page,
     resetMocks,
     seedRouter,
@@ -102,11 +102,9 @@ test.describe('Overview tab — router port diagram + uplink IP', () => {
     const row = page.getByTestId('uplink-ether1');
     await expect(row).toBeVisible();
     await expect(row).toContainText('100.64.0.2/24');
-    await expect(row.getByTestId('uplink-default-route')).toBeVisible();
-    await expect(page.getByTestId('uplink-default-route')).toHaveCount(1);
   });
 
-  test('degrades gracefully when ip/route endpoints return nothing', async ({
+  test('degrades gracefully when ip endpoints return nothing', async ({
     page,
     resetMocks,
     seedRouter,
@@ -118,7 +116,6 @@ test.describe('Overview tab — router port diagram + uplink IP', () => {
       id: 'rtr_deg',
       model: 'hAP ax3',
       addresses: [],
-      routes: [],
     });
 
     await page.goto('/router/rtr_deg');
@@ -126,6 +123,5 @@ test.describe('Overview tab — router port diagram + uplink IP', () => {
 
     await expect(page.getByTestId('port-diagram')).toBeVisible();
     await expect(page.getByTestId('uplink-card')).toBeVisible();
-    await expect(page.getByTestId('uplink-default-route')).toHaveCount(0);
   });
 });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -34,22 +34,12 @@ export interface OverviewBackendIpAddress {
   disabled?: boolean;
 }
 
-export interface OverviewBackendRoute {
-  id?: string;
-  dstAddress: string;
-  gateway: string;
-  interface?: string;
-  active?: boolean;
-  distance?: number;
-}
-
 export interface OverviewBackendRouter {
   id?: string;
   model?: string;
   version?: string;
   interfaces?: OverviewBackendInterface[];
   addresses?: OverviewBackendIpAddress[];
-  routes?: OverviewBackendRoute[];
 }
 
 export interface WifiBackendInterface {
@@ -294,17 +284,6 @@ export const test = base.extend<TestFixtures>({
           disabled: false,
         },
       ];
-      const routes = router.routes ?? [
-        {
-          id: '*1',
-          dstAddress: '0.0.0.0/0',
-          gateway: '100.64.0.1',
-          interface: 'ether1',
-          active: true,
-          distance: 1,
-        },
-      ];
-
       await context.route('**/api/system/info', async (route) => {
         await route.fulfill({
           status: 200,
@@ -382,14 +361,6 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope(dhcpClients),
-        });
-      });
-
-      await context.route('**/api/routes', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: envelope(routes),
         });
       });
 


### PR DESCRIPTION
## Summary
- enabling a VPN client now points foreign routes at it and disables the other clients, from both the WAN page and the topology hop dialog
- the internet topology marks only the routed tunnel as active, keeps the domestic path always active, and lists only client tunnels
- remove the dead routes fetch that returned 404 on every page load
Closes #252 