### PR TITLE
feat(fe): color overview ports by ethernet link rate

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -22,6 +22,7 @@ export {
   fetchDynamicOverview,
   fetchInterfaceGraph,
   fetchInterfaces,
+  fetchEthernetInterfaces,
   updateWanInterface,
   type WanInterfaceType,
   fetchForeignGateway,
@@ -40,6 +41,7 @@ export {
   type InterfaceGraphResponse,
   type InterfaceGraphSample,
   type InterfaceResponse,
+  type EthernetInterfaceResponse,
   type IpAddressResponse,
 } from './system';
 export {

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -142,6 +142,29 @@ export async function fetchInterfaces(
   return list ?? [];
 }
 
+export interface EthernetInterfaceResponse {
+  id?: string;
+  name?: string;
+  defaultName?: string;
+  running?: boolean;
+  disabled?: boolean;
+  status?: string;
+  rate?: string;
+}
+
+export async function fetchEthernetInterfaces(
+  creds: SystemCredentials,
+  signal?: AbortSignal,
+): Promise<EthernetInterfaceResponse[]> {
+  const list = await apiRequest<EthernetInterfaceResponse[] | null>('/api/interface/ethernets', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+  return list ?? [];
+}
+
 export type WanInterfaceType = 'foreign' | 'domestic';
 
 export async function updateWanInterface(

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -33,6 +33,7 @@ import {
   fetchDHCPLeases,
   fetchDhcpClients,
   fetchDynamicOverview,
+  fetchEthernetInterfaces,
   fetchInterfaceGraph,
   fetchInterfaces,
   fetchSystemOverview,
@@ -42,6 +43,7 @@ import {
   shutdownSystem,
   type DhcpClient,
   type DHCPLeaseResponse,
+  type EthernetInterfaceResponse,
   type InterfaceGraphSample,
   type InterfaceResponse,
   type IpAddressResponse,
@@ -113,6 +115,7 @@ export function OverviewTab() {
   const [vpnClients, setVpnClients] = useState<VPNActiveClient[]>([]);
   const [dhcpLeaseList, setDhcpLeaseList] = useState<DHCPLeaseResponse[]>([]);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
+  const [ethernetRates, setEthernetRates] = useState<Record<string, string>>({});
   const [dhcpClients, setDhcpClients] = useState<DhcpClient[]>([]);
   const [selectedIface, setSelectedIface] = useState<string>(DEFAULT_TRAFFIC_INTERFACE);
   const [graphLoading, setGraphLoading] = useState(false);
@@ -189,15 +192,25 @@ export function OverviewTab() {
 
     const loadInitial = async () => {
       try {
-        const [ov, list, clients] = await Promise.all([
+        const [ov, list, clients, ethernets] = await Promise.all([
           fetchSystemOverview(id, { host, ...creds }),
           fetchInterfaces({ host, ...creds }).catch(() => [] as InterfaceResponse[]),
           fetchDhcpClients({ host, ...creds }).catch(() => [] as DhcpClient[]),
+          fetchEthernetInterfaces({ host, ...creds }).catch(
+            () => [] as EthernetInterfaceResponse[],
+          ),
         ]);
         if (cancelled) return;
         setOverview(ov);
         setInterfaces(list);
         setDhcpClients(clients);
+        setEthernetRates(
+          Object.fromEntries(
+            ethernets.flatMap((e) =>
+              e.name && e.rate ? [[e.name.toLowerCase(), e.rate] as const] : [],
+            ),
+          ),
+        );
         if (list.length > 0) {
           setSelectedIface((prev) => {
             if (list.some((i) => i.name === prev)) return prev;
@@ -352,6 +365,7 @@ export function OverviewTab() {
             <RouterPortDiagramCard
               model={overview.model}
               interfaces={interfaces}
+              ifaceRates={ethernetRates}
               onPower={setPowerAction}
             />
           </div>

--- a/frontend/src/routes/overview-panel/OverviewPanel.module.scss
+++ b/frontend/src/routes/overview-panel/OverviewPanel.module.scss
@@ -163,6 +163,28 @@
   border-color: color-mix(in srgb, var(--color-success) 55%, var(--color-border));
 }
 
+.rateDegraded {
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning) 55%, var(--color-border));
+}
+
+.rateBad {
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 55%, var(--color-border));
+}
+
+.interactive:hover .rateDegraded,
+.interactive:focus-visible .rateDegraded {
+  color: color-mix(in srgb, var(--color-warning) 55%, #000);
+  border-color: color-mix(in srgb, var(--color-warning) 55%, #000);
+}
+
+.interactive:hover .rateBad,
+.interactive:focus-visible .rateBad {
+  color: color-mix(in srgb, var(--color-danger) 55%, #000);
+  border-color: color-mix(in srgb, var(--color-danger) 55%, #000);
+}
+
 .down,
 .disabled {
   color: var(--color-text-muted);

--- a/frontend/src/routes/overview-panel/PortSlot.tsx
+++ b/frontend/src/routes/overview-panel/PortSlot.tsx
@@ -37,6 +37,10 @@ const STATUS_PORT_CLASS = {
 
 const statusClass = (slot: ResolvedSlot): string | undefined => {
   if (slot.kind !== 'ethernet' && slot.kind !== 'sfp') return undefined;
+  if (slot.status === 'up') {
+    if (slot.rateTone === 'degraded') return styles.rateDegraded;
+    if (slot.rateTone === 'bad') return styles.rateBad;
+  }
   return STATUS_PORT_CLASS[slot.status];
 };
 

--- a/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
+++ b/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
@@ -12,6 +12,7 @@ export interface RouterPortDiagramCardProps {
   onPower?: (action: PowerAction) => void;
   showPowerControls?: boolean;
   disabledIfaceNames?: readonly string[];
+  ifaceRates?: Readonly<Record<string, string>>;
 }
 
 export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React.memo(
@@ -21,6 +22,7 @@ export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React
     onPower,
     showPowerControls = true,
     disabledIfaceNames,
+    ifaceRates,
   }) {
     const { descriptor, slots } = useMemo(() => {
       const resolved = resolveModelStrict(model);
@@ -30,8 +32,8 @@ export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React
       const baseSlots = showPowerControls
         ? resolved.slots
         : resolved.slots.filter((s) => s.kind !== 'power' && s.kind !== 'reset');
-      return { descriptor: resolved, slots: mapPorts(baseSlots, interfaces, disabled) };
-    }, [model, interfaces, disabledIfaceNames, showPowerControls]);
+      return { descriptor: resolved, slots: mapPorts(baseSlots, interfaces, disabled, ifaceRates) };
+    }, [model, interfaces, disabledIfaceNames, showPowerControls, ifaceRates]);
 
     const Panel = PANEL_REGISTRY[descriptor.key];
 

--- a/frontend/src/routes/overview-panel/mapPorts.ts
+++ b/frontend/src/routes/overview-panel/mapPorts.ts
@@ -1,5 +1,5 @@
 import type { InterfaceResponse } from '../../api';
-import type { PortSlot, PortStatus, ResolvedSlot, SlotKind } from './types';
+import type { PortSlot, PortStatus, RateTone, ResolvedSlot, SlotKind } from './types';
 
 const PORT_KINDS: SlotKind[] = ['ethernet', 'sfp'];
 
@@ -31,6 +31,26 @@ const findIface = (
   return interfaces.find((i) => i.name.toLowerCase() === lower);
 };
 
+const speedToMbps = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const match = /^([\d.]+)\s*(m|g)/i.exec(value.trim());
+  if (!match) return undefined;
+  const num = Number.parseFloat(match[1]);
+  if (Number.isNaN(num)) return undefined;
+  return match[2].toLowerCase() === 'g' ? num * 1000 : num;
+};
+
+const deriveRateTone = (
+  rate: string | undefined,
+  nominalSpeed: string | undefined,
+): RateTone | undefined => {
+  const actual = speedToMbps(rate);
+  const nominal = speedToMbps(nominalSpeed);
+  if (actual === undefined || nominal === undefined) return undefined;
+  if (actual >= nominal) return 'ok';
+  return actual >= nominal / 10 ? 'degraded' : 'bad';
+};
+
 const deriveStatus = (iface: InterfaceResponse | undefined): PortStatus => {
   if (!iface) return 'absent';
   if (iface.disabled) return 'disabled';
@@ -41,6 +61,7 @@ export function mapPorts(
   slots: PortSlot[],
   interfaces: InterfaceResponse[],
   disabledIfaceNames?: ReadonlySet<string>,
+  ifaceRates?: Readonly<Record<string, string>>,
 ): ResolvedSlot[] {
   return slots.map((slot) => {
     if (!PORT_KINDS.includes(slot.kind)) {
@@ -61,11 +82,14 @@ export function mapPorts(
     const rxLabel = iface?.rx;
     const txLabel = iface?.tx;
     const mtu = iface?.actualMtu;
+    const rate = status === 'up' ? ifaceRates?.[name.toLowerCase()] : undefined;
+    const rateTone = deriveRateTone(rate, slot.nominalSpeed);
     let tooltip: string;
     if (status === 'absent') {
       tooltip = `${name} · not detected`;
     } else {
       const parts = [name, STATUS_LABEL[status]];
+      if (rate) parts.push(rate);
       if (rxLabel) parts.push(`↓ ${rxLabel}`);
       if (txLabel) parts.push(`↑ ${txLabel}`);
       if (mtu) parts.push(`${mtu} MTU`);
@@ -79,6 +103,8 @@ export function mapPorts(
       rxLabel,
       txLabel,
       mtu,
+      rate,
+      rateTone,
     };
   });
 }

--- a/frontend/src/routes/overview-panel/types.ts
+++ b/frontend/src/routes/overview-panel/types.ts
@@ -2,6 +2,8 @@ export type SlotKind = 'ethernet' | 'sfp' | 'usb' | 'power' | 'reset' | 'sim' | 
 
 export type PortStatus = 'up' | 'down' | 'disabled' | 'absent';
 
+export type RateTone = 'ok' | 'degraded' | 'bad';
+
 export interface PortSlot {
   id: string;
   kind: SlotKind;
@@ -32,6 +34,8 @@ export interface ResolvedSlot extends PortSlot {
   rxLabel?: string;
   txLabel?: string;
   mtu?: number;
+  rate?: string;
+  rateTone?: RateTone;
 }
 
 export interface PanelProps {


### PR DESCRIPTION
Closes #250

## Summary
- fetch each ethernet interface's negotiated link rate on the overview page
- color each port in the diagram green, orange, or red by comparing the rate to the port's nominal speed