### PR TITLE
fix(fe): load saved routers after frontend rebuild

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { store } from './api';
-import type { Router } from '@nasnet/mocks';
+import { MOCK_STORE_KEY, type Router } from '@nasnet/mocks';
 
 declare global {
   interface Window {
@@ -17,7 +17,7 @@ if (typeof window !== 'undefined') {
   }
   const persisted = (() => {
     try {
-      return Boolean(window.localStorage?.getItem('nasnet-panel.mock-store.v3'));
+      return Boolean(window.localStorage?.getItem(MOCK_STORE_KEY));
     } catch {
       return false;
     }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { mockStore } from './handlers/store';
+import { mockStore, MOCK_STORE_KEY } from './handlers/store';
 import { routers } from './handlers/routers';
 import { system } from './handlers/system';
 import { vpn, getProtocolOptions } from './handlers/vpn';
@@ -7,7 +7,7 @@ import { updates } from './handlers/updates';
 import { logs } from './handlers/logs';
 import { batch } from './handlers/batch';
 
-export { mockStore, getProtocolOptions };
+export { mockStore, MOCK_STORE_KEY, getProtocolOptions };
 
 export const mockApi = {
   routers,

--- a/frontend/src/mocks/handlers/store.ts
+++ b/frontend/src/mocks/handlers/store.ts
@@ -31,14 +31,8 @@ export interface Store {
   idCounter: number;
 }
 
-const STORAGE_KEY = 'nasnet-panel.mock-store.v13';
-const LEGACY_KEYS = [
-  'nasnet-panel.mock-store.v12',
-  'nasnet-panel.mock-store.v11',
-  'nasnet-panel.mock-store.v10',
-  'nasnet-panel.mock-store.v9',
-  'nasnet-panel.mock-store.v8',
-];
+export const MOCK_STORE_KEY = 'nasnet-panel.mock-store.v13';
+const LEGACY_KEYS = ['nasnet-panel.mock-store.v12'];
 
 const createStore = (): Store => ({
   routers: [],
@@ -57,23 +51,27 @@ const createStore = (): Store => ({
 const loadStore = (): Store => {
   if (typeof window === 'undefined') return createStore();
   try {
-    let raw = window.localStorage?.getItem(STORAGE_KEY);
+    let raw = window.localStorage?.getItem(MOCK_STORE_KEY);
+    let migrated = false;
     if (!raw) {
       for (const legacy of LEGACY_KEYS) {
         const legacyRaw = window.localStorage?.getItem(legacy);
         if (legacyRaw) {
           raw = legacyRaw;
+          migrated = true;
           window.localStorage?.removeItem(legacy);
           break;
         }
       }
     }
     if (!raw) return createStore();
-    const parsed = JSON.parse(raw) as Store;
-    if (!parsed.routingTopologies) {
-      parsed.routingTopologies = {};
+    const parsed = JSON.parse(raw) as Partial<Store> | null;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.routers)) {
+      return createStore();
     }
-    return parsed;
+    const store = { ...createStore(), ...parsed };
+    if (migrated) persistStore(store);
+    return store;
   } catch {
     return createStore();
   }
@@ -82,7 +80,7 @@ const loadStore = (): Store => {
 const persistStore = (next: Store): void => {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(next));
+    window.localStorage?.setItem(MOCK_STORE_KEY, JSON.stringify(next));
   } catch {
     /* ignore quota errors */
   }

--- a/frontend/src/mocks/index.ts
+++ b/frontend/src/mocks/index.ts
@@ -1,3 +1,3 @@
 export * from './types';
-export { mockApi, mockStore, getProtocolOptions } from './handlers';
+export { mockApi, mockStore, MOCK_STORE_KEY, getProtocolOptions } from './handlers';
 export type { MockApi, MockStore } from './handlers';

--- a/frontend/src/routes/RouterListPage.tsx
+++ b/frontend/src/routes/RouterListPage.tsx
@@ -54,9 +54,10 @@ export function RouterListPage() {
 
   useEffect(() => {
     let cancelled = false;
-    void api.routers.list().then(() => {
+    const done = () => {
       if (!cancelled) setInitialLoad(false);
-    });
+    };
+    void api.routers.list().then(done, done);
     return () => {
       cancelled = true;
     };

--- a/frontend/src/state/RouterStoreContext.tsx
+++ b/frontend/src/state/RouterStoreContext.tsx
@@ -33,6 +33,17 @@ const initial: State = {
   lastConnectedRouterId: null,
 };
 
+const isPersistedRouter = (value: unknown): value is Router => {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Partial<Router>;
+  return (
+    typeof r.id === 'string' &&
+    r.id.length > 0 &&
+    typeof r.name === 'string' &&
+    typeof r.host === 'string'
+  );
+};
+
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'hydrate':
@@ -53,6 +64,7 @@ function reducer(state: State, action: Action): State {
       return { ...state, routers: action.routers };
     case 'mergeFromRemote': {
       const existingById = new Map(state.routers.map((r) => [r.id, r]));
+      const remoteIds = new Set(action.remote.map((r) => r.id));
       const merged = action.remote.map((incoming) => {
         const existing = existingById.get(incoming.id);
         if (!existing) return incoming;
@@ -63,7 +75,8 @@ function reducer(state: State, action: Action): State {
           hostname: incoming.hostname ?? existing.hostname,
         };
       });
-      return { ...state, routers: merged };
+      const localOnly = state.routers.filter((r) => !remoteIds.has(r.id));
+      return { ...state, routers: [...merged, ...localOnly] };
     }
     case 'select':
       return { ...state, selectedRouterId: action.id };
@@ -97,16 +110,35 @@ export const RouterStoreProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const [state, dispatch] = useReducer(reducer, initial);
 
   useEffect(() => {
+    let reset = false;
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as State;
-        if (parsed && Array.isArray(parsed.routers)) {
-          dispatch({ type: 'hydrate', state: parsed });
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<State> | null;
+      if (!parsed || !Array.isArray(parsed.routers)) {
+        reset = true;
+        return;
+      }
+      dispatch({
+        type: 'hydrate',
+        state: {
+          routers: parsed.routers.filter(isPersistedRouter),
+          selectedRouterId:
+            typeof parsed.selectedRouterId === 'string' ? parsed.selectedRouterId : null,
+          lastConnectedRouterId:
+            typeof parsed.lastConnectedRouterId === 'string' ? parsed.lastConnectedRouterId : null,
+        },
+      });
+    } catch {
+      reset = true;
+    } finally {
+      if (reset) {
+        try {
+          window.localStorage.removeItem(STORAGE_KEY);
+        } catch {
+          /* ignore */
         }
       }
-    } catch {
-      /* ignore malformed storage */
     }
   }, []);
 


### PR DESCRIPTION
Closes #298

## Summary
- keep locally saved routers when the persisted store resets after a rebuild
- always resolve the router list loading state and validate saved state on load, resetting corrupt data
- persist migrated legacy store immediately so a plain reload does not drop it