### PR TITLE
feat(fe): fold router nav into mobile header menu

### DIFF
--- a/frontend/src/layout/AppHeader.tsx
+++ b/frontend/src/layout/AppHeader.tsx
@@ -1,5 +1,6 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { HeaderActions } from './HeaderActions';
+import { ROUTER_SECTIONS, activeRouterSectionId } from './routerSections';
 import { useSession } from '../state/SessionContext';
 import { useRouter, useRouterStore } from '../state/RouterStoreContext';
 import styles from './AppHeader.module.scss';
@@ -7,6 +8,7 @@ import styles from './AppHeader.module.scss';
 export function AppHeader() {
   const { activeRouterId } = useSession();
   const { lastConnectedRouterId, selectedRouterId } = useRouterStore();
+  const location = useLocation();
   const targetId = activeRouterId ?? lastConnectedRouterId ?? selectedRouterId ?? null;
   const router = useRouter(targetId ?? undefined);
   const logoTarget = targetId ? `/router/${targetId}` : '/';
@@ -20,7 +22,14 @@ export function AppHeader() {
           </div>
         </Link>
         <div className={styles.actionsRight}>
-          <HeaderActions routerName={router?.name} />
+          <HeaderActions
+            routerName={router?.name}
+            routerId={targetId ?? undefined}
+            sections={targetId ? ROUTER_SECTIONS : undefined}
+            activeSectionId={
+              targetId ? activeRouterSectionId(location.pathname, targetId) : undefined
+            }
+          />
         </div>
       </div>
     </header>

--- a/frontend/src/layout/HeaderActions.module.scss
+++ b/frontend/src/layout/HeaderActions.module.scss
@@ -77,11 +77,64 @@
   }
 }
 
+.triggerDesktop {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.triggerMobile {
+  display: none;
+}
+
 .routerName {
   max-width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .triggerDesktop {
+    display: none;
+  }
+
+  .triggerMobile {
+    display: inline-flex;
+  }
+
+  .menuTrigger {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    justify-content: center;
+    border: none;
+    background: transparent;
+
+    &[aria-expanded='true'] {
+      background: var(--color-surface-alt);
+      border-color: transparent;
+    }
+  }
+}
+
+.sectionsMobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .sectionsMobile {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+}
+
+.menuItemActive {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+  box-shadow: inset 2px 0 0 var(--color-success);
 }
 
 .onlineDot {

--- a/frontend/src/layout/HeaderActions.tsx
+++ b/frontend/src/layout/HeaderActions.tsx
@@ -1,17 +1,26 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Bell, ChevronDown, KeyRound, LogOut, Moon, Sun } from 'lucide-react';
+import { Bell, ChevronDown, KeyRound, LogOut, Menu, Moon, Sun } from 'lucide-react';
 import { useAppTheme } from '../state/ThemeContext';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
+import type { RouterSection } from './routerSections';
 import styles from './HeaderActions.module.scss';
 
 export interface HeaderActionsProps {
   routerName?: string;
+  routerId?: string;
+  sections?: RouterSection[];
+  activeSectionId?: string;
 }
 
 const cx = (...parts: Array<string | undefined | false>) => parts.filter(Boolean).join(' ');
 
-export function HeaderActions({ routerName }: HeaderActionsProps) {
+export function HeaderActions({
+  routerName,
+  routerId,
+  sections,
+  activeSectionId,
+}: HeaderActionsProps) {
   const { preference, resolved, setPreference } = useAppTheme();
   const navigate = useNavigate();
   const location = useLocation();
@@ -65,19 +74,40 @@ export function HeaderActions({ routerName }: HeaderActionsProps) {
         className={styles.menuTrigger}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={routerName ? undefined : 'Open menu'}
+        aria-label="Open menu"
         onClick={() => setOpen((v) => !v)}
       >
-        {routerName ? (
-          <>
-            <span className={styles.onlineDot} aria-label="Online" role="status" />
-            <span className={styles.routerName}>{routerName}</span>
-          </>
-        ) : null}
-        <ChevronDown size={14} aria-hidden className={open ? styles.chevronOpen : undefined} />
+        <span className={styles.triggerDesktop}>
+          {routerName ? (
+            <>
+              <span className={styles.onlineDot} aria-label="Online" role="status" />
+              <span className={styles.routerName}>{routerName}</span>
+            </>
+          ) : null}
+          <ChevronDown size={14} aria-hidden className={open ? styles.chevronOpen : undefined} />
+        </span>
+        <Menu size={20} aria-hidden className={styles.triggerMobile} />
       </button>
       {open ? (
         <div className={styles.menuPanel} role="menu">
+          {sections && routerId ? (
+            <div className={styles.sectionsMobile}>
+              {sections.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="menuitem"
+                  disabled={s.disabled}
+                  className={cx(styles.menuItem, s.id === activeSectionId && styles.menuItemActive)}
+                  onClick={goAndClose(`/router/${routerId}${s.path ? `/${s.path}` : ''}`)}
+                >
+                  {s.icon}
+                  <span>{s.label}</span>
+                </button>
+              ))}
+              <div className={styles.menuDivider} role="separator" />
+            </div>
+          ) : null}
           <div className={styles.themeRow}>
             <button
               type="button"

--- a/frontend/src/layout/RouterTabBar.module.scss
+++ b/frontend/src/layout/RouterTabBar.module.scss
@@ -2,6 +2,10 @@
   width: 100%;
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
+
+  @media (max-width: 768px) {
+    display: none;
+  }
 }
 
 .tabBarInner {

--- a/frontend/src/layout/routerSections.tsx
+++ b/frontend/src/layout/routerSections.tsx
@@ -1,0 +1,35 @@
+import {
+  Activity,
+  Blocks,
+  Cable,
+  CircleHelp,
+  Globe,
+  LayoutGrid,
+  Network,
+  Shield,
+  Wand2,
+  Wifi,
+} from 'lucide-react';
+import type { TabItem } from '@nasnet/ui';
+
+export type RouterSection = TabItem & { path: string };
+
+export const ROUTER_SECTIONS: RouterSection[] = [
+  { id: 'overview', label: 'Overview', path: '', icon: <LayoutGrid size={16} /> },
+  { id: 'internet', label: 'Internet', path: 'internet', icon: <Globe size={16} /> },
+  { id: 'wan', label: 'WAN', path: 'wan', icon: <Cable size={16} /> },
+  { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} /> },
+  { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
+  { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
+  { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },
+  { id: 'plugins', label: 'Plugins', path: 'plugins', icon: <Blocks size={16} /> },
+  { id: 'diagnostics', label: 'Diagnostics', path: 'diagnostics', icon: <Activity size={16} /> },
+  { id: 'help', label: 'Help', path: 'help', icon: <CircleHelp size={16} /> },
+];
+
+export function activeRouterSectionId(pathname: string, routerId: string): string | undefined {
+  return ROUTER_SECTIONS.find((t) => {
+    const full = `/router/${routerId}${t.path ? `/${t.path}` : ''}`;
+    return t.path === '' ? pathname === full : pathname.startsWith(full);
+  })?.id;
+}

--- a/frontend/src/routes/RouterDashboard.module.scss
+++ b/frontend/src/routes/RouterDashboard.module.scss
@@ -2,6 +2,10 @@
   width: 100%;
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
+
+  @media (max-width: 768px) {
+    display: none;
+  }
 }
 
 .tabBarInner {

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -1,48 +1,10 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
-import {
-  Activity,
-  Blocks,
-  Cable,
-  CircleHelp,
-  Globe,
-  LayoutGrid,
-  Network,
-  Shield,
-  Wand2,
-  Wifi,
-} from 'lucide-react';
-import { Tabs, type TabItem } from '@nasnet/ui';
+import { Tabs } from '@nasnet/ui';
 import { useRouter } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
+import { ROUTER_SECTIONS as TABS } from '../layout/routerSections';
 import styles from './RouterDashboard.module.scss';
-
-const TABS: Array<TabItem & { path: string }> = [
-  { id: 'overview', label: 'Overview', path: '', icon: <LayoutGrid size={16} /> },
-  {
-    id: 'internet',
-    label: 'Internet',
-    path: 'internet',
-    icon: <Globe size={16} />,
-  },
-  { id: 'wan', label: 'WAN', path: 'wan', icon: <Cable size={16} /> },
-  { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} /> },
-  { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
-  { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
-  { id: 'wizard', label: 'Wizard', path: 'config', icon: <Wand2 size={16} /> },
-  { id: 'plugins', label: 'Plugins', path: 'plugins', icon: <Blocks size={16} /> },
-  {
-    id: 'diagnostics',
-    label: 'Diagnostics',
-    path: 'diagnostics',
-    icon: <Activity size={16} />,
-  },
-  { id: 'help', label: 'Help', path: 'help', icon: <CircleHelp size={16} /> },
-  // { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },
-  // { id: 'dns', label: 'DNS', path: 'dns', icon: <Globe size={16} /> },
-  // { id: 'firewall', label: 'Firewall', path: 'firewall', icon: <Flame size={16} /> },
-  // { id: 'logs', label: 'Logs', path: 'logs', icon: <ScrollText size={16} /> },
-];
 
 export function RouterDashboard() {
   const { id } = useParams<{ id: string }>();

--- a/frontend/tests/e2e/29-mobile-nav-menu.spec.ts
+++ b/frontend/tests/e2e/29-mobile-nav-menu.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from './fixtures';
+
+test.describe('Mobile navigation menu', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('folds the section tab bar into the header hamburger menu', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({
+      id: 'rtr_mob',
+      name: 'Mobile Router',
+      host: '10.0.0.60',
+      model: 'hAP ax3',
+      version: '7.13.2',
+    });
+    await mockOverviewBackend({ id: 'rtr_mob', model: 'hAP ax3', version: '7.13.2' });
+    await page.goto('/router/rtr_mob');
+
+    // The section tab bar is folded away on mobile.
+    await expect(page.locator('[role="tablist"][aria-label="Router sections"]')).toBeHidden();
+
+    const trigger = page.locator('header button[aria-haspopup="menu"]');
+    await expect(trigger).toBeVisible();
+    await expect(trigger.locator('[role="status"]')).toBeHidden();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Opening the menu reveals both the router sections and the session actions.
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByRole('menuitem', { name: 'Overview' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Internet' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: /updates & notifications/i })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: /logout/i })).toBeVisible();
+
+    // Selecting a section navigates and folds the menu away.
+    await page.getByRole('menuitem', { name: 'Help' }).click();
+    await expect(page).toHaveURL(/\/router\/rtr_mob\/help$/);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('closes the menu on Escape', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_mob2', name: 'Mobile Router 2', host: '10.0.0.61' });
+    await mockOverviewBackend({ id: 'rtr_mob2' });
+    await page.goto('/router/rtr_mob2');
+
+    const trigger = page.locator('header button[aria-haspopup="menu"]');
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await page.keyboard.press('Escape');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION

<img width="361" height="511" alt="Screenshot 2026-07-16 at 02 03 17" src="https://github.com/user-attachments/assets/80eda5af-eed8-4313-8647-9929c3445eab" />
<img width="362" height="597" alt="Screenshot 2026-07-16 at 02 03 22" src="https://github.com/user-attachments/assets/813063d2-3d7b-4a34-97a7-d2f99410101d" />


Closes #333

- Collapse the top section nav into the header hamburger on mobile, removing the extra nav row
- Hamburger menu holds the router sections plus the existing theme, updates, password and logout actions
- Desktop tab bar unchanged
- Add e2e coverage for the mobile menu