### PR TITLE
feat(fe): show emergency access note during wizard apply

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -134,6 +134,7 @@ export {
   fetchWizardStatus,
   type NasnetVpnCredentialsResponse,
   type FinalizeWizardRequest,
+  type FinalizeWizardResponse,
   type FinalizeWizardInterface,
   type FinalizeWizardL2tpClient,
   type FinalizeWizardWireGuardClient,

--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -413,7 +413,7 @@ export async function fetchNasnetVpnCredentials(
 }
 
 export interface FinalizeWizardInterface {
-  type: 'ethernet' | 'wifi';
+  type: 'ether' | 'wifi';
   interface: string;
   ssid?: string;
   password?: string;
@@ -454,12 +454,17 @@ export interface FinalizeWizardRequest {
   ovpnServer?: FinalizeWizardOvpnServer;
 }
 
+export interface FinalizeWizardResponse {
+  managementWiFiSSID?: string;
+  managementWiFiPassword?: string;
+}
+
 export async function finalizeWizard(
   creds: VPNCredentials,
   body: FinalizeWizardRequest,
   signal?: AbortSignal,
-): Promise<void> {
-  await apiRequest('/api/wizard/finalize', {
+): Promise<FinalizeWizardResponse> {
+  return apiRequest<FinalizeWizardResponse>('/api/wizard/finalize', {
     method: 'POST',
     headers: authHeaders(creds),
     body: JSON.stringify(body),

--- a/frontend/src/routes/EasyConfigWizard.module.scss
+++ b/frontend/src/routes/EasyConfigWizard.module.scss
@@ -152,6 +152,67 @@
   text-align: left;
 }
 
+.emergencyAlert {
+  display: flex;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+}
+
+.emergencyAlertIcon {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-warning);
+  color: #1a1a1a;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-bold);
+  line-height: 1;
+}
+
+.emergencyAlertBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.emergencyAlertText {
+  margin: 0;
+  font-size: var(--font-sm);
+  line-height: 1.5;
+}
+
+.emergencyWifi {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px var(--space-md);
+  margin: 0;
+
+  div {
+    display: contents;
+  }
+
+  dt {
+    color: var(--color-text-muted);
+    font-size: var(--font-sm);
+  }
+
+  dd {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: var(--font-sm);
+    word-break: break-all;
+  }
+}
+
 .spinner {
   width: 72px;
   height: 72px;

--- a/frontend/src/routes/EasyConfigWizard.tsx
+++ b/frontend/src/routes/EasyConfigWizard.tsx
@@ -135,6 +135,8 @@ export function EasyConfigWizard() {
         applied={state.applied}
         progress={state.progress}
         error={state.error}
+        managementWifiSsid={state.managementWifiSsid}
+        managementWifiPassword={state.managementWifiPassword}
         onClose={closeDialog}
         onRetry={() => onApply()}
         onDone={goToOverview}

--- a/frontend/src/routes/easy-config/state.ts
+++ b/frontend/src/routes/easy-config/state.ts
@@ -57,6 +57,8 @@ export interface State {
   applying: boolean;
   applied: boolean;
   progress: number;
+  managementWifiSsid: string;
+  managementWifiPassword: string;
 }
 
 export const initial: State = {
@@ -113,6 +115,8 @@ export const initial: State = {
   applying: false,
   applied: false,
   progress: 0,
+  managementWifiSsid: '',
+  managementWifiPassword: '',
 };
 
 export type Action =
@@ -123,6 +127,7 @@ export type Action =
   | { type: 'error'; message: string | null }
   | { type: 'applying'; value: boolean }
   | { type: 'progress'; value: number }
+  | { type: 'managementWifi'; ssid: string; password: string }
   | { type: 'applied' };
 
 export function reducer(state: State, action: Action): State {
@@ -143,6 +148,8 @@ export function reducer(state: State, action: Action): State {
         : { ...state, applying: false };
     case 'progress':
       return { ...state, progress: Math.max(state.progress, action.value) };
+    case 'managementWifi':
+      return { ...state, managementWifiSsid: action.ssid, managementWifiPassword: action.password };
     case 'applied':
       return { ...state, applied: true, applying: false, progress: 100 };
     default:

--- a/frontend/src/routes/easy-config/steps/ShowStep.tsx
+++ b/frontend/src/routes/easy-config/steps/ShowStep.tsx
@@ -70,6 +70,8 @@ export function ShowStep({ script, state, onApply, onBack }: Props) {
         applied={state.applied}
         progress={state.progress}
         error={state.error}
+        managementWifiSsid={state.managementWifiSsid}
+        managementWifiPassword={state.managementWifiPassword}
         onClose={closeDialog}
         onRetry={() => onApply(currentScript)}
         onDone={goToOverview}

--- a/frontend/src/routes/easy-config/steps/show/ApplyDialog.tsx
+++ b/frontend/src/routes/easy-config/steps/show/ApplyDialog.tsx
@@ -9,6 +9,8 @@ interface Props {
   applied: boolean;
   progress: number;
   error: string | null;
+  managementWifiSsid: string;
+  managementWifiPassword: string;
   onClose: () => void;
   onRetry: () => void;
   onDone: () => void;
@@ -20,6 +22,8 @@ export function ApplyDialog({
   applied,
   progress,
   error,
+  managementWifiSsid,
+  managementWifiPassword,
   onClose,
   onRetry,
   onDone,
@@ -39,6 +43,37 @@ export function ApplyDialog({
             </p>
             <div className={styles.applyProgress}>
               <Progress value={progress} label="Progress" tone="success" />
+            </div>
+            <div className={styles.emergencyAlert} role="alert">
+              <span aria-hidden="true" className={styles.emergencyAlertIcon}>
+                !
+              </span>
+              <div className={styles.emergencyAlertBody}>
+                <p className={styles.emergencyAlertText}>
+                  If the connection drops or setup runs into an error, you can still reach the
+                  router through the emergency interfaces: plug into the last Ethernet port and open{' '}
+                  <strong>192.168.200.1</strong>
+                  {managementWifiSsid ? (
+                    <>
+                      , or join the management WiFi below and open <strong>192.168.210.1</strong>
+                    </>
+                  ) : (
+                    '.'
+                  )}
+                </p>
+                {managementWifiSsid ? (
+                  <dl className={styles.emergencyWifi}>
+                    <div>
+                      <dt>WiFi name</dt>
+                      <dd>{managementWifiSsid}</dd>
+                    </div>
+                    <div>
+                      <dt>Password</dt>
+                      <dd>{managementWifiPassword}</dd>
+                    </div>
+                  </dl>
+                ) : null}
+              </div>
             </div>
           </>
         ) : applied ? (

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -28,7 +28,7 @@ function wanInterface(
   if (type === 'wireless') {
     return { type: 'wifi', interface: name, ssid, password };
   }
-  return { type: 'ethernet', interface: name };
+  return { type: 'ether', interface: name };
 }
 
 function buildFinalizePayload(state: State): FinalizeWizardRequest {
@@ -256,7 +256,12 @@ export function useEasyConfig(routerId: string | undefined) {
     dispatch({ type: 'applying', value: true });
     dispatch({ type: 'error', message: null });
     try {
-      await finalizeWizard({ host, ...creds }, buildFinalizePayload(state));
+      const result = await finalizeWizard({ host, ...creds }, buildFinalizePayload(state));
+      dispatch({
+        type: 'managementWifi',
+        ssid: result.managementWiFiSSID ?? '',
+        password: result.managementWiFiPassword ?? '',
+      });
     } catch (err) {
       dispatch({ type: 'error', message: (err as Error).message ?? 'Apply failed' });
       dispatch({ type: 'applying', value: false });

--- a/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
+++ b/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
@@ -41,7 +41,12 @@ test.describe('Easy-Mode wizard — apply progress', () => {
     });
     await page.goto('/router/rtr_progress/config');
 
+    const finalizeRequest = page.waitForRequest('**/api/wizard/finalize');
     await stepToApply(page);
+
+    // the finalize payload uses the RouterOS interface type ("ether"), not the UI label
+    const body = (await finalizeRequest).postDataJSON();
+    expect(body.foreign).toMatchObject({ type: 'ether', interface: 'ether1' });
 
     const bar = page.getByRole('progressbar', { name: /progress/i });
     await expect(bar).toBeVisible();
@@ -51,6 +56,57 @@ test.describe('Easy-Mode wizard — apply progress', () => {
 
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
     await expect(page.getByRole('progressbar')).toHaveCount(0);
+  });
+
+  test('shows emergency access details while applying', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockEasyConfigBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_rescue', name: 'Rescue Router' });
+    await mockEasyConfigBackend({
+      id: 'rtr_rescue',
+      wifiInterfaces: [{ id: '*100', name: 'wifi1', band: '2ghz-ax' }],
+      wizardProgress: [5, 45, 100],
+      managementWifi: { ssid: 'NNC-Rescue-42', password: 'rescue-pass-4242' },
+    });
+    await page.goto('/router/rtr_rescue/config');
+
+    await stepToApply(page);
+
+    const alert = page.getByRole('alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText('192.168.200.1');
+    await expect(alert).toContainText('192.168.210.1');
+    await expect(alert).toContainText('NNC-Rescue-42');
+    await expect(alert).toContainText('rescue-pass-4242');
+  });
+
+  test('omits the management WiFi details when the router has no WiFi radio', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockEasyConfigBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_nowifi', name: 'No-WiFi Router' });
+    await mockEasyConfigBackend({
+      id: 'rtr_nowifi',
+      wifiInterfaces: [{ id: '*100', name: 'wifi1', band: '2ghz-ax' }],
+      wizardProgress: [5, 45, 100],
+      managementWifi: null,
+    });
+    await page.goto('/router/rtr_nowifi/config');
+
+    await stepToApply(page);
+
+    const alert = page.getByRole('alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText('192.168.200.1');
+    await expect(alert).not.toContainText('192.168.210.1');
+    await expect(alert).not.toContainText(/WiFi name/i);
   });
 
   test('keeps polling when the router drops off mid-apply', async ({

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -102,6 +102,8 @@ export interface EasyConfigBackendOptions {
   scanNetworks?: EasyConfigBackendScanNetwork[];
   // progress returned by successive wizard status polls; the last value repeats
   wizardProgress?: number[];
+  // management WiFi credentials returned by finalize; pass null to omit them (no WiFi radio)
+  managementWifi?: { ssid: string; password: string } | null;
 }
 
 export interface TestFixtures {
@@ -572,7 +574,9 @@ export const test = base.extend<TestFixtures>({
     });
   },
   mockEasyConfigBackend: async ({ context }, use) => {
-    await use(async ({ id, interfaces, wifiInterfaces, scanNetworks, wizardProgress }) => {
+    await use(async (options) => {
+      const { id, interfaces, wifiInterfaces, scanNetworks, wizardProgress, managementWifi } =
+        options;
       await context.addInitScript((routerId) => {
         try {
           const key = 'nasnet-panel.session-credentials.v1';
@@ -656,11 +660,18 @@ export const test = base.extend<TestFixtures>({
         });
       });
 
+      const mgmtWifi =
+        managementWifi === undefined
+          ? { ssid: 'NNC-Rescue-42', password: 'rescue-pass-4242' }
+          : managementWifi;
       await context.route('**/api/wizard/finalize', async (route) => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: envelope(null),
+          body: envelope({
+            managementWiFiSSID: mgmtWifi?.ssid ?? '',
+            managementWiFiPassword: mgmtWifi?.password ?? '',
+          }),
         });
       });
 


### PR DESCRIPTION
Closes #342
Closes #331

- Warn during wizard apply that the router stays reachable via the emergency Ethernet port and management WiFi if the connection drops or setup errors
- Surface the management WiFi name and password returned by finalize
- Send the RouterOS `ether` interface type on finalize so ethernet WAN config applies
