### PR TITLE
feat(fe): mobile responsiveness improvement

### DIFF
--- a/frontend/src/layout/AppHeader.module.scss
+++ b/frontend/src/layout/AppHeader.module.scss
@@ -15,6 +15,12 @@
   gap: var(--space-md);
 }
 
+@media (max-width: 640px) {
+  .wrap {
+    padding: var(--space-md) var(--space-lg);
+  }
+}
+
 .brand {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/routes/DHCPPage.module.scss
+++ b/frontend/src/routes/DHCPPage.module.scss
@@ -64,4 +64,13 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  min-width: 0;
+  max-width: 100%;
+}
+
+@media (max-width: 640px) {
+  .lanPortsDiagram {
+    align-items: flex-start;
+    width: 100%;
+  }
 }

--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -363,7 +363,7 @@ export function DHCPPage() {
                 disabledIfaceNames={wanNames}
               />
             ) : (
-              <Skeleton width={320} height={56} />
+              <Skeleton width="min(320px, 100%)" height={56} />
             )}
           </div>
         </div>

--- a/frontend/src/routes/OverviewTab.module.scss
+++ b/frontend/src/routes/OverviewTab.module.scss
@@ -19,6 +19,8 @@
   flex-direction: column;
   align-items: flex-end;
   gap: var(--space-sm);
+  min-width: 0;
+  max-width: 100%;
 }
 
 .bannerLeft {
@@ -163,6 +165,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-sm);
+  flex-wrap: wrap;
 }
 
 .networkCardTitle {
@@ -281,8 +284,9 @@
 }
 
 .ifaceSelect {
-  width: 220px;
-  flex: 0 0 auto;
+  width: min(220px, 100%);
+  flex: 0 1 auto;
+  min-width: 0;
 
   button {
     padding: 4px 10px;

--- a/frontend/src/routes/RouterDashboard.module.scss
+++ b/frontend/src/routes/RouterDashboard.module.scss
@@ -25,6 +25,12 @@
   gap: var(--space-xl);
 }
 
+@media (max-width: 640px) {
+  .contentShell {
+    padding: var(--space-lg);
+  }
+}
+
 .notFound {
   padding: var(--space-2xl);
   text-align: center;

--- a/frontend/src/routes/UpdatesPage.module.scss
+++ b/frontend/src/routes/UpdatesPage.module.scss
@@ -60,7 +60,7 @@
 
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr));
   gap: var(--space-lg);
 }
 

--- a/frontend/src/routes/overview-panel/OverviewPanel.module.scss
+++ b/frontend/src/routes/overview-panel/OverviewPanel.module.scss
@@ -29,6 +29,8 @@
 
 .chassisScroll {
   overflow: visible;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .chassis {
@@ -47,9 +49,23 @@
   display: flex;
   justify-content: flex-end;
   padding-top: var(--space-lg);
+  max-width: 100%;
+  min-width: 0;
 
   > div {
     margin-left: auto;
+    max-width: 100%;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .bannerPorts {
+    justify-content: flex-start;
+
+    > div {
+      margin-left: 0;
+    }
   }
 }
 
@@ -311,4 +327,10 @@
 
 .txRow svg {
   color: var(--color-danger);
+}
+
+@media (max-width: 640px) {
+  .row {
+    flex-wrap: wrap;
+  }
 }

--- a/frontend/src/routes/overview-panel/models.ts
+++ b/frontend/src/routes/overview-panel/models.ts
@@ -23,9 +23,8 @@ export const MODELS: RouterModelDescriptor[] = [
       eth(3, 2),
       eth(4, 3),
       eth(5, 4),
-      { id: 'usb', kind: 'usb', label: 'USB 3.0', row: 0, col: 5 },
-      { id: 'pwr', kind: 'power', label: 'DC', row: 0, col: 6 },
-      { id: 'rst', kind: 'reset', label: 'Reset', row: 0, col: 7 },
+      { id: 'pwr', kind: 'power', label: 'DC', row: 0, col: 5 },
+      { id: 'rst', kind: 'reset', label: 'Reset', row: 0, col: 6 },
     ],
   },
   {

--- a/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
@@ -396,61 +396,63 @@ function PeersSection({ peers, canMutate, onAdd, onEdit, onDelete }: PeersSectio
       {peers.length === 0 ? (
         <p style={{ color: 'var(--color-muted)' }}>No peers configured.</p>
       ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-          <thead>
-            <tr style={{ textAlign: 'left', borderBottom: '1px solid var(--color-border)' }}>
-              <th style={{ padding: '6px 8px' }}>Name</th>
-              <th style={{ padding: '6px 8px' }}>Allowed addresses</th>
-              <th style={{ padding: '6px 8px' }}>Endpoint</th>
-              <th style={{ padding: '6px 8px' }}>Last handshake</th>
-              <th style={{ padding: '6px 8px' }}>Status</th>
-              <th style={{ padding: '6px 8px', width: 120 }}>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {peers.map((p) => (
-              <tr key={p.id || p.name} style={{ borderBottom: '1px solid var(--color-border)' }}>
-                <td style={{ padding: '6px 8px' }}>{p.name}</td>
-                <td style={{ padding: '6px 8px' }}>{p.allowedAddresses || '–'}</td>
-                <td style={{ padding: '6px 8px' }}>
-                  {p.currentEndpointAddress
-                    ? `${p.currentEndpointAddress}:${p.currentEndpointPort}`
-                    : p.endpointAddress
-                      ? `${p.endpointAddress}:${p.endpointPort}`
-                      : '–'}
-                </td>
-                <td style={{ padding: '6px 8px' }}>{p.lastHandshake || '–'}</td>
-                <td style={{ padding: '6px 8px' }}>
-                  <BoolBadge value={!p.disabled} />
-                </td>
-                <td style={{ padding: '6px 8px' }}>
-                  <span style={{ display: 'inline-flex', gap: 8 }}>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      disabled={!canMutate}
-                      title={`Edit ${p.name}`}
-                      aria-label={`Edit peer ${p.name}`}
-                      onClick={() => onEdit(p)}
-                    >
-                      <Pencil size={14} aria-hidden />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      disabled={!canMutate}
-                      title={`Delete ${p.name}`}
-                      aria-label={`Delete peer ${p.name}`}
-                      onClick={() => onDelete(p)}
-                    >
-                      <Trash2 size={14} aria-hidden />
-                    </Button>
-                  </span>
-                </td>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', minWidth: 560, borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '1px solid var(--color-border)' }}>
+                <th style={{ padding: '6px 8px' }}>Name</th>
+                <th style={{ padding: '6px 8px' }}>Allowed addresses</th>
+                <th style={{ padding: '6px 8px' }}>Endpoint</th>
+                <th style={{ padding: '6px 8px' }}>Last handshake</th>
+                <th style={{ padding: '6px 8px' }}>Status</th>
+                <th style={{ padding: '6px 8px', width: 120 }}>Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {peers.map((p) => (
+                <tr key={p.id || p.name} style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <td style={{ padding: '6px 8px' }}>{p.name}</td>
+                  <td style={{ padding: '6px 8px' }}>{p.allowedAddresses || '–'}</td>
+                  <td style={{ padding: '6px 8px' }}>
+                    {p.currentEndpointAddress
+                      ? `${p.currentEndpointAddress}:${p.currentEndpointPort}`
+                      : p.endpointAddress
+                        ? `${p.endpointAddress}:${p.endpointPort}`
+                        : '–'}
+                  </td>
+                  <td style={{ padding: '6px 8px' }}>{p.lastHandshake || '–'}</td>
+                  <td style={{ padding: '6px 8px' }}>
+                    <BoolBadge value={!p.disabled} />
+                  </td>
+                  <td style={{ padding: '6px 8px' }}>
+                    <span style={{ display: 'inline-flex', gap: 8 }}>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={!canMutate}
+                        title={`Edit ${p.name}`}
+                        aria-label={`Edit peer ${p.name}`}
+                        onClick={() => onEdit(p)}
+                      >
+                        <Pencil size={14} aria-hidden />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        disabled={!canMutate}
+                        title={`Delete ${p.name}`}
+                        aria-label={`Delete peer ${p.name}`}
+                        onClick={() => onDelete(p)}
+                      >
+                        <Trash2 size={14} aria-hidden />
+                      </Button>
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #332

- Router pages reflow at mobile widths with no horizontal overflow
- LAN and Overview port strip wraps to a second line instead of scrolling sideways
- Drop a nonexistent USB port from the hAP ax2 diagram
