### PR TITLE
fix(fe): make router password optional when connecting

### DIFF
--- a/frontend/src/routes/add-router/TargetStep.tsx
+++ b/frontend/src/routes/add-router/TargetStep.tsx
@@ -21,11 +21,7 @@ interface Props {
 }
 
 export function TargetStep({ state, dispatch, onBack, onConnect }: Props) {
-  const valid =
-    isRequired(state.name) &&
-    isIPv4(state.host) &&
-    isRequired(state.username) &&
-    isRequired(state.password);
+  const valid = isRequired(state.name) && isIPv4(state.host) && isRequired(state.username);
   return (
     <Card>
       <CardHeader>

--- a/frontend/src/routes/add-router/useAddRouter.ts
+++ b/frontend/src/routes/add-router/useAddRouter.ts
@@ -53,8 +53,8 @@ export function useAddRouter(
   );
 
   const onConnect = useCallback(async () => {
-    if (!isRequired(state.username) || !isRequired(state.password)) {
-      dispatch({ type: 'error', message: 'Username and password are required.' });
+    if (!isRequired(state.username)) {
+      dispatch({ type: 'error', message: 'Username is required.' });
       return;
     }
     const duplicate = routers.find((r) => r.host === state.host);


### PR DESCRIPTION
## Summary

- Allow connecting to a router that has no password
- Only username stays required in the add-router flow