### PR TITLE
feat(fe): hide New button for WAN uplink interfaces

### DIFF
--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -44,7 +44,7 @@ export function DomesticUplinkSection({
     return { host, ...creds };
   };
 
-  const openAdd = () => setDialogOpen(true);
+  // const openAdd = () => setDialogOpen(true);
   const closeDialog = () => setDialogOpen(false);
 
   const onSubmit = async (interfaceName: string) => {
@@ -114,7 +114,7 @@ export function DomesticUplinkSection({
         <SectionHeader
           title="Domestic"
           description="Interfaces tagged as the domestic uplink."
-          action={{ label: 'New', onClick: openAdd }}
+          // action={{ label: 'New', onClick: openAdd }}
         />
         <WanTable
           rows={items}

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -44,7 +44,7 @@ export function StarlinkSection({
     return { host, ...creds };
   };
 
-  const openAdd = () => setDialogOpen(true);
+  // const openAdd = () => setDialogOpen(true);
   const closeDialog = () => setDialogOpen(false);
 
   const onSubmit = async (interfaceName: string) => {
@@ -114,7 +114,7 @@ export function StarlinkSection({
         <SectionHeader
           title="Foreign / Starlink"
           description="Interfaces tagged as the foreign (Starlink) uplink."
-          action={{ label: 'New', onClick: openAdd }}
+          // action={{ label: 'New', onClick: openAdd }}
         />
         <WanTable
           rows={items}

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -255,7 +255,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(2).click();
+    await page.getByRole('button', { name: 'New' }).nth(0).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
@@ -350,7 +350,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(2).click();
+    await page.getByRole('button', { name: 'New' }).nth(0).click();
     const dialog = page.getByRole('dialog');
     await dialog.getByLabel('Name').fill('home-l2tp');
     await dialog.getByLabel('Connect to').fill('vpn.example.com');

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -3,7 +3,9 @@ import type { BrowserContext, Page } from '@playwright/test';
 
 const ROUTER_ID = 'rtr_wan';
 
-// "New" button order in WanPage: 0 Starlink, 1 Domestic, 2 Starlink Masking VPN Client.
+// "New" button order in WanPage: 0 Starlink Masking VPN Client.
+// The Starlink and Domestic add buttons are hidden for this release; when they come back
+// the order becomes 0 Starlink, 1 Domestic, 2 Starlink Masking VPN Client.
 const newButton = (page: Page, index: number) =>
   page.getByRole('button', { name: 'New' }).nth(index);
 
@@ -221,7 +223,8 @@ test.describe('WAN tab', () => {
     await expect(page.getByText('No VPN clients yet.')).toBeVisible();
   });
 
-  test('add a Starlink uplink via real BE and move it to Domestic', async ({
+  // Skipped while the WAN uplink "New" buttons are hidden.
+  test.skip('add a Starlink uplink via real BE and move it to Domestic', async ({
     page,
     context,
     resetMocks,
@@ -258,7 +261,8 @@ test.describe('WAN tab', () => {
     expect(state.wanPuts[1]).toMatchObject({ name: 'ether1', body: { type: 'domestic' } });
   });
 
-  test('already-tagged interface is excluded from the add picker', async ({
+  // Skipped while the WAN uplink "New" buttons are hidden.
+  test.skip('already-tagged interface is excluded from the add picker', async ({
     page,
     context,
     resetMocks,
@@ -294,7 +298,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 2).click();
+    await newButton(page, 0).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 


### PR DESCRIPTION
Closes #356

- hides the [+ New] button on the foreign and domestic WAN uplink sections, since this release only supports changing those interfaces
- commented out rather than deleted, as the add flow is expected back in a later release
- the two e2e tests that drive the add dialogs are skipped for now, and the VPN client test reindexed since it is the only New button left
