### PR TITLE
feat(fe): unified VPN user management

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -129,6 +129,11 @@ export {
   deleteWireguardPeer,
   createWireguardClient,
   importWireguardConfig,
+  listVPNUsers,
+  createVPNUser,
+  updateVPNUser,
+  deleteVPNUser,
+  listVPNProfiles,
   fetchNasnetVpnCredentials,
   finalizeWizard,
   fetchWizardStatus,
@@ -173,6 +178,10 @@ export {
   type CreateWireguardClientResponse,
   type ImportWireguardConfigRequest,
   type ImportWireguardConfigResponse,
+  type VPNUserResponse,
+  type CreateVPNUserRequest,
+  type UpdateVPNUserRequest,
+  type VPNProfileResponse,
 } from './vpn';
 export { ApiError } from './http';
 export { isAbortError } from './abort';

--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -875,3 +875,117 @@ function parseFilename(disposition: string | null): string | null {
   const match = disposition.match(/filename\s*=\s*"?([^";]+)"?/i);
   return match ? match[1] : null;
 }
+
+export interface VPNUserResponse {
+  id: string;
+  name: string;
+  service: string;
+  profile: string;
+  password: string;
+  disabled: boolean;
+  limitBytesIn: number;
+  limitBytesOut: number;
+  callerId?: string;
+  routes?: string;
+  comment?: string;
+}
+
+export interface CreateVPNUserRequest {
+  name: string;
+  password: string;
+  profile: string;
+  disabled?: boolean;
+  limitBytesIn?: number;
+  limitBytesOut?: number;
+  comment?: string;
+}
+
+export interface UpdateVPNUserRequest {
+  name?: string;
+  password?: string;
+  profile?: string;
+  disabled?: boolean;
+  limitBytesIn?: number;
+  limitBytesOut?: number;
+  comment?: string;
+}
+
+export interface VPNProfileResponse {
+  id: string;
+  name: string;
+  default: boolean;
+  localAddress?: string;
+  remoteAddress?: string;
+  remoteAddressRange?: string[];
+  dnsServer?: string;
+  rateLimit?: string;
+  sessionTimeout?: string;
+  idleTimeout?: string;
+  comment?: string;
+}
+
+export async function listVPNUsers(
+  creds: VPNCredentials,
+  signal?: AbortSignal,
+): Promise<VPNUserResponse[]> {
+  const data = await apiRequest<VPNUserResponse[] | null>('/api/vpn/users', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+  return data ?? [];
+}
+
+export async function createVPNUser(
+  creds: VPNCredentials,
+  body: CreateVPNUserRequest,
+  signal?: AbortSignal,
+): Promise<VPNUserResponse> {
+  return apiRequest<VPNUserResponse>('/api/vpn/users', {
+    method: 'POST',
+    headers: authHeaders(creds),
+    body: JSON.stringify(body),
+    signal,
+  });
+}
+
+export async function updateVPNUser(
+  creds: VPNCredentials,
+  nameOrID: string,
+  body: UpdateVPNUserRequest,
+  signal?: AbortSignal,
+): Promise<VPNUserResponse> {
+  return apiRequest<VPNUserResponse>(`/api/vpn/users/${encodeURIComponent(nameOrID)}`, {
+    method: 'PUT',
+    headers: authHeaders(creds),
+    body: JSON.stringify(body),
+    signal,
+  });
+}
+
+export async function deleteVPNUser(
+  creds: VPNCredentials,
+  nameOrID: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiRequest<void>(`/api/vpn/users/${encodeURIComponent(nameOrID)}`, {
+    method: 'DELETE',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}
+
+export async function listVPNProfiles(
+  creds: VPNCredentials,
+  signal?: AbortSignal,
+): Promise<VPNProfileResponse[]> {
+  const data = await apiRequest<VPNProfileResponse[] | null>('/api/vpn/profiles', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+  return data ?? [];
+}

--- a/frontend/src/routes/VPNPage.tsx
+++ b/frontend/src/routes/VPNPage.tsx
@@ -5,11 +5,13 @@ import {
   ApiError,
   fetchVPNServersStatus,
   listVPNClients,
+  listVPNUsers,
   type VPNClient,
   type VPNCredentials,
   type VPNPeer,
   type VPNProtocol,
   type VPNServer,
+  type VPNUserResponse,
 } from '../api';
 import { useRouter } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
@@ -17,6 +19,7 @@ import { usePolling } from '../utils/usePolling';
 import { mapClientFromBE, mapServersStatusToList } from './vpn/adapters';
 import { StatsStrip } from './vpn/StatsStrip';
 import { ServersSection } from './vpn/sections/ServersSection';
+import { UsersSection } from './vpn/sections/UsersSection';
 // import { PeersSection } from './vpn/sections/PeersSection';
 // TODO: re-enable PeersSection when /api/vpn/peers exists on the backend.
 
@@ -28,6 +31,7 @@ export function VPNPage() {
 
   const [clients, setClients] = useState<VPNClient[]>([]);
   const [servers, setServers] = useState<VPNServer[]>([]);
+  const [users, setUsers] = useState<VPNUserResponse[]>([]);
   const [loaded, setLoaded] = useState(false);
   const peers: VPNPeer[] = [];
 
@@ -42,12 +46,14 @@ export function VPNPage() {
   const reload = useCallback(async () => {
     if (!id || !creds) return;
     try {
-      const [rawClients, serversStatus] = await Promise.all([
+      const [rawClients, serversStatus, rawUsers] = await Promise.all([
         listVPNClients(creds),
         fetchVPNServersStatus(creds),
+        listVPNUsers(creds),
       ]);
       setClients(rawClients.map((c) => mapClientFromBE(c, id)));
       setServers(mapServersStatusToList(serversStatus, id));
+      setUsers(rawUsers);
       setLoaded(true);
     } catch (err) {
       const message =
@@ -81,6 +87,7 @@ export function VPNPage() {
         loading={!loaded}
       />
       <ServersSection creds={creds} servers={servers} onChanged={reload} />
+      <UsersSection creds={creds} users={users} onChanged={reload} />
       {/* <PeersSection routerId={id} peers={peers} servers={servers} onChanged={reload} /> */}
     </Stack>
   );

--- a/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Plus, Trash2 } from 'lucide-react';
 import {
   Button,
   Dialog,
@@ -22,7 +21,6 @@ import {
   type CreateWireguardServerRequest,
   type OvpnServerTaskStatus,
   type VPNCredentials,
-  type VpnUser,
 } from '../../../api';
 import { isCIDR, isPort, validateIdentifier } from '../../../utils/validators';
 
@@ -34,11 +32,6 @@ const TYPE_OPTIONS: Array<{ value: AddVpnServerType; label: string }> = [
 ];
 
 const POLL_INTERVAL_MS = 1000;
-
-interface OvpnUserDraft {
-  username: string;
-  password: string;
-}
 
 interface Props {
   creds: VPNCredentials | null;
@@ -82,7 +75,6 @@ interface FormProps {
 
 function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
   const [certPassphrase, setCertPassphrase] = useState('');
-  const [users, setUsers] = useState<OvpnUserDraft[]>([{ username: '', password: '' }]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [taskId, setTaskId] = useState<string | null>(null);
@@ -135,40 +127,14 @@ function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
     };
   }, [taskId]);
 
-  const setUserField = (idx: number, field: keyof OvpnUserDraft, value: string) => {
-    setUsers((prev) => prev.map((u, i) => (i === idx ? { ...u, [field]: value } : u)));
-  };
-
-  const addUser = () => setUsers((prev) => [...prev, { username: '', password: '' }]);
-  const removeUser = (idx: number) =>
-    setUsers((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
-
-  const errors = useMemo(() => {
-    const dupUsernames = new Set<string>();
-    const seen = new Set<string>();
-    users.forEach((u) => {
-      const v = u.username.trim();
-      if (!v) return;
-      if (seen.has(v)) dupUsernames.add(v);
-      else seen.add(v);
-    });
-    return {
+  const errors = useMemo(
+    () => ({
       certPassphrase: certPassphrase ? null : 'Certificate passphrase is required.',
-      users: users.map((u) => ({
-        username:
-          u.username.trim() === ''
-            ? 'Username is required.'
-            : dupUsernames.has(u.username.trim())
-              ? 'Duplicate username.'
-              : null,
-        password: u.password === '' ? 'Password is required.' : null,
-      })),
-    };
-  }, [certPassphrase, users]);
+    }),
+    [certPassphrase],
+  );
 
-  const hasErrors =
-    errors.certPassphrase !== null ||
-    errors.users.some((e) => e.username !== null || e.password !== null);
+  const hasErrors = errors.certPassphrase !== null;
 
   const canSubmit = !!creds && !submitting;
 
@@ -179,7 +145,7 @@ function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
     setSubmitting(true);
     const body: CreateOvpnServerRequest = {
       clientCertificatePassword: certPassphrase,
-      users: users.map<VpnUser>((u) => ({ username: u.username.trim(), password: u.password })),
+      users: [],
     };
     try {
       const res = await createOvpnServer(creds, body);
@@ -225,70 +191,13 @@ function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
             onChange={(e) => setCertPassphrase(e.target.value)}
             aria-label="Client certificate passphrase"
             autoComplete="new-password"
+            aria-invalid={submitAttempted && !!errors.certPassphrase}
           />
+          {submitAttempted && errors.certPassphrase ? (
+            <FormError>{errors.certPassphrase}</FormError>
+          ) : null}
         </Label>
       </FieldRow>
-      {users.map((u, idx) => (
-        <div
-          key={idx}
-          style={{
-            display: 'flex',
-            gap: 'var(--space-lg)',
-            alignItems: 'flex-start',
-          }}
-        >
-          <Label style={{ flex: 1, minWidth: 0 }}>
-            <span>Username</span>
-            <Input
-              value={u.username}
-              onChange={(e) => setUserField(idx, 'username', e.target.value)}
-              aria-label={`Username ${idx + 1}`}
-              autoComplete="off"
-            />
-            {submitAttempted && errors.users[idx].username ? (
-              <FormError>{errors.users[idx].username}</FormError>
-            ) : null}
-          </Label>
-          <Label style={{ flex: 1, minWidth: 0 }}>
-            <span>Password</span>
-            <PasswordInput
-              value={u.password}
-              onChange={(e) => setUserField(idx, 'password', e.target.value)}
-              aria-label={`Password ${idx + 1}`}
-              autoComplete="new-password"
-            />
-            {submitAttempted && errors.users[idx].password ? (
-              <FormError>{errors.users[idx].password}</FormError>
-            ) : null}
-          </Label>
-          <div
-            style={{
-              flex: '0 0 auto',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 'var(--space-xs)',
-            }}
-          >
-            <span aria-hidden style={{ fontSize: 'var(--font-sm)', visibility: 'hidden' }}>
-              .
-            </span>
-            <Button
-              variant="danger"
-              onClick={() => removeUser(idx)}
-              disabled={users.length <= 1}
-              title={`Remove user ${idx + 1}`}
-              aria-label={`Remove user ${idx + 1}`}
-            >
-              <Trash2 size={16} aria-hidden />
-            </Button>
-          </div>
-        </div>
-      ))}
-      <div>
-        <Button variant="primary" onClick={addUser}>
-          <Plus size={14} aria-hidden /> Add user
-        </Button>
-      </div>
       {error ? <FormError role="alert">{error}</FormError> : null}
       <FieldRow>
         <Button variant="ghost" onClick={onCancel} disabled={submitting}>

--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  FieldRow,
+  FieldStack,
+  FormError,
+  Input,
+  Label,
+  PasswordInput,
+  Select,
+  Switch,
+} from '@nasnet/ui';
+import {
+  ApiError,
+  createVPNUser,
+  isAbortError,
+  listVPNProfiles,
+  updateVPNUser,
+  type UpdateVPNUserRequest,
+  type VPNCredentials,
+  type VPNProfileResponse,
+  type VPNUserResponse,
+} from '../../../api';
+
+const PREFERRED_PROFILE = 'VPN-VPN';
+
+interface Draft {
+  name: string;
+  password: string;
+  profile: string;
+  disabled: boolean;
+}
+
+interface Props {
+  creds: VPNCredentials | null;
+  user: VPNUserResponse | null;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
+  const [profiles, setProfiles] = useState<VPNProfileResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<Draft>({
+    name: user?.name ?? '',
+    password: user?.password ?? '',
+    profile: user?.profile ?? '',
+    disabled: user?.disabled ?? false,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!creds) {
+      setLoading(false);
+      setLoadError('Not connected to router.');
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setLoadError(null);
+
+    (async () => {
+      try {
+        const data = await listVPNProfiles(creds, controller.signal);
+        const selectable = data.filter((p) => !p.default);
+        setProfiles(selectable);
+        setDraft((d) => {
+          if (d.profile) return d;
+          const preferred = selectable.find((p) => p.name === PREFERRED_PROFILE);
+          const fallback = preferred ?? selectable[0];
+          return fallback ? { ...d, profile: fallback.name } : d;
+        });
+      } catch (err) {
+        if (isAbortError(err)) return;
+        const message =
+          err instanceof ApiError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : 'Failed to load VPN profiles.';
+        setLoadError(message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [creds]);
+
+  const set = <K extends keyof Draft>(key: K, value: Draft[K]) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  const markTouched = (key: string) => setTouched((t) => (t[key] ? t : { ...t, [key]: true }));
+
+  const profileOptions = useMemo(() => {
+    const options = profiles.map((p) => ({ value: p.name, label: p.name }));
+    if (user?.profile && !profiles.some((p) => p.name === user.profile)) {
+      options.unshift({ value: user.profile, label: user.profile });
+    }
+    return options;
+  }, [profiles, user?.profile]);
+
+  const errors = useMemo(
+    () => ({
+      name: draft.name.trim() === '' ? 'Name is required.' : null,
+      password: draft.password === '' ? 'Password is required.' : null,
+      profile: draft.profile === '' ? 'Profile is required.' : null,
+    }),
+    [draft],
+  );
+
+  const hasErrors = Object.values(errors).some(Boolean);
+  const canSubmit = !!creds && !submitting && !loading && !loadError && !hasErrors;
+
+  const handleSubmit = async () => {
+    if (!creds) return;
+    setTouched({ name: true, password: true, profile: true });
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      if (user) {
+        const body: UpdateVPNUserRequest = {};
+        const name = draft.name.trim();
+        if (name !== user.name) body.name = name;
+        if (draft.password !== user.password) body.password = draft.password;
+        if (draft.profile !== user.profile) body.profile = draft.profile;
+        if (draft.disabled !== user.disabled) body.disabled = draft.disabled;
+        if (Object.keys(body).length > 0) {
+          await updateVPNUser(creds, user.id, body);
+        }
+      } else {
+        await createVPNUser(creds, {
+          name: draft.name.trim(),
+          password: draft.password,
+          profile: draft.profile,
+          disabled: draft.disabled,
+        });
+      }
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : user
+              ? 'Failed to update VPN user.'
+              : 'Failed to create VPN user.';
+      setError(message);
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+    onSaved();
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={submitting ? () => undefined : onCancel}
+      title={user ? `Edit VPN user - ${user.name}` : 'New VPN user'}
+      size="md"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button variant="success" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? 'Saving…' : user ? 'Save changes' : 'Create user'}
+          </Button>
+        </>
+      }
+    >
+      {loading ? (
+        <p>Loading…</p>
+      ) : loadError ? (
+        <FormError role="alert">{loadError}</FormError>
+      ) : (
+        <FieldStack>
+          <FieldRow>
+            <Label>
+              <span>Name</span>
+              <Input
+                value={draft.name}
+                onChange={(e) => set('name', e.target.value)}
+                onBlur={() => markTouched('name')}
+                autoComplete="off"
+                aria-label="Name"
+                aria-invalid={touched.name && !!errors.name}
+              />
+              {touched.name && errors.name ? <FormError>{errors.name}</FormError> : null}
+            </Label>
+            <Label>
+              <span>Password</span>
+              <PasswordInput
+                value={draft.password}
+                onChange={(e) => set('password', e.target.value)}
+                onBlur={() => markTouched('password')}
+                aria-label="Password"
+                aria-invalid={touched.password && !!errors.password}
+                autoComplete="new-password"
+              />
+              {touched.password && errors.password ? (
+                <FormError>{errors.password}</FormError>
+              ) : null}
+            </Label>
+          </FieldRow>
+          <FieldRow>
+            <Label>
+              <span>Profile</span>
+              <Select
+                aria-label="Profile"
+                value={draft.profile}
+                onChange={(v) => set('profile', v)}
+                options={profileOptions}
+                placeholder={profileOptions.length ? 'Select a profile' : 'No profiles available'}
+              />
+              {touched.profile && errors.profile ? <FormError>{errors.profile}</FormError> : null}
+            </Label>
+            <Label as="div">
+              <Switch
+                label="Enabled"
+                checked={!draft.disabled}
+                onChange={(e) => set('disabled', !e.target.checked)}
+              />
+            </Label>
+          </FieldRow>
+          {error ? <FormError role="alert">{error}</FormError> : null}
+        </FieldStack>
+      )}
+    </Dialog>
+  );
+}

--- a/frontend/src/routes/vpn/sections/ServersTable.tsx
+++ b/frontend/src/routes/vpn/sections/ServersTable.tsx
@@ -52,15 +52,6 @@ export function ServersTable({
           },
         },
         {
-          key: 'remoteIp',
-          header: 'Remote IP',
-          render: (s: VPNServer) => {
-            if (!s.remoteIp && !s.ipPool) return '–';
-            if (s.remoteIp && s.ipPool) return `${s.remoteIp} (${s.ipPool})`;
-            return s.remoteIp || s.ipPool;
-          },
-        },
-        {
           key: 'actions',
           header: 'Actions',
           render: (s: VPNServer) => {

--- a/frontend/src/routes/vpn/sections/UsersSection.tsx
+++ b/frontend/src/routes/vpn/sections/UsersSection.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { Card, ConfirmDialog, Stack, useToast } from '@nasnet/ui';
+import { ApiError, deleteVPNUser, type VPNCredentials, type VPNUserResponse } from '../../../api';
+import { UserFormDialog } from '../dialogs/UserFormDialog';
+import { PaginationControls } from '../PaginationControls';
+import { usePagedFilter } from '../hooks/usePagedFilter';
+import { PAGE_SIZE } from '../utils';
+import { UsersTable } from './UsersTable';
+import { SectionHeader } from './SectionHeader';
+
+const matches = (u: VPNUserResponse, q: string) =>
+  u.name.toLowerCase().includes(q) ||
+  u.profile.toLowerCase().includes(q) ||
+  (u.comment ?? '').toLowerCase().includes(q);
+
+interface Props {
+  creds: VPNCredentials | null;
+  users: VPNUserResponse[];
+  onChanged: () => void;
+}
+
+export function UsersSection({ creds, users, onChanged }: Props) {
+  const paged = usePagedFilter(users, matches);
+  const toast = useToast();
+  const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<VPNUserResponse | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<VPNUserResponse | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  const onConfirmDelete = async () => {
+    if (!creds || !pendingDelete) return;
+    const target = pendingDelete;
+    setDeleteSubmitting(true);
+    try {
+      await deleteVPNUser(creds, target.id);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to delete VPN user.';
+      toast.notify({
+        title: 'Failed to delete user',
+        description: message,
+        tone: 'danger',
+      });
+      setDeleteSubmitting(false);
+      return;
+    }
+    setDeleteSubmitting(false);
+    setPendingDelete(null);
+    toast.notify({ title: `User "${target.name}" deleted`, tone: 'info' });
+    onChanged();
+  };
+
+  return (
+    <Stack>
+      <Card>
+        <SectionHeader
+          title="VPN Users"
+          count={users.length}
+          description="Manage credentials shared across all VPN servers."
+          search={{
+            value: paged.search,
+            placeholder: 'Search users…',
+            ariaLabel: 'Search users',
+            onChange: paged.setSearch,
+          }}
+          action={{
+            label: 'Add user',
+            disabled: !creds,
+            onClick: () => setAdding(true),
+          }}
+        />
+        <div style={{ marginTop: 16 }}>
+          <UsersTable
+            rows={paged.pagedRows}
+            totalRows={users.length}
+            onEdit={setEditing}
+            onDelete={setPendingDelete}
+            canMutate={!!creds}
+          />
+          <PaginationControls
+            page={paged.page}
+            totalPages={paged.totalPages}
+            total={paged.filteredCount}
+            pageSize={PAGE_SIZE}
+            onPrev={paged.onPrev}
+            onNext={paged.onNext}
+          />
+        </div>
+      </Card>
+      {adding ? (
+        <UserFormDialog
+          creds={creds}
+          user={null}
+          onCancel={() => setAdding(false)}
+          onSaved={() => {
+            setAdding(false);
+            toast.notify({ title: 'VPN user created', tone: 'success' });
+            onChanged();
+          }}
+        />
+      ) : null}
+      {editing ? (
+        <UserFormDialog
+          creds={creds}
+          user={editing}
+          onCancel={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            toast.notify({ title: 'VPN user updated', tone: 'success' });
+            onChanged();
+          }}
+        />
+      ) : null}
+      <ConfirmDialog
+        open={!!pendingDelete}
+        title="Delete VPN user"
+        description={
+          pendingDelete
+            ? `Remove "${pendingDelete.name}" from this router? This cannot be undone.`
+            : undefined
+        }
+        confirmLabel={deleteSubmitting ? 'Deleting…' : 'Delete'}
+        destructive
+        onConfirm={onConfirmDelete}
+        onCancel={() => (deleteSubmitting ? undefined : setPendingDelete(null))}
+      />
+    </Stack>
+  );
+}

--- a/frontend/src/routes/vpn/sections/UsersTable.tsx
+++ b/frontend/src/routes/vpn/sections/UsersTable.tsx
@@ -1,0 +1,77 @@
+import { Badge, Button, DataTable } from '@nasnet/ui';
+import { Pencil, Trash2, Users as UsersIcon } from 'lucide-react';
+import type { VPNUserResponse } from '../../../api';
+
+interface Props {
+  rows: VPNUserResponse[];
+  totalRows: number;
+  onEdit?: (user: VPNUserResponse) => void;
+  onDelete?: (user: VPNUserResponse) => void;
+  canMutate?: boolean;
+}
+
+export function UsersTable({ rows, totalRows, onEdit, onDelete, canMutate = false }: Props) {
+  return (
+    <DataTable
+      columns={[
+        { key: 'name', header: 'Name', render: (u: VPNUserResponse) => u.name },
+        {
+          key: 'profile',
+          header: 'Profile',
+          render: (u: VPNUserResponse) => <Badge tone="info">{u.profile}</Badge>,
+        },
+        {
+          key: 'status',
+          header: 'Status',
+          render: (u: VPNUserResponse) => (
+            <Badge tone={u.disabled ? 'neutral' : 'success'}>
+              {u.disabled ? 'Disabled' : 'Enabled'}
+            </Badge>
+          ),
+        },
+        {
+          key: 'comment',
+          header: 'Comment',
+          render: (u: VPNUserResponse) => u.comment || '–',
+        },
+        {
+          key: 'actions',
+          header: 'Actions',
+          render: (u: VPNUserResponse) => (
+            <span style={{ display: 'inline-flex', gap: 8 }}>
+              {onEdit ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={!canMutate}
+                  title={`Edit ${u.name}`}
+                  aria-label={`Edit ${u.name}`}
+                  onClick={() => onEdit(u)}
+                >
+                  <Pencil size={14} aria-hidden />
+                </Button>
+              ) : null}
+              {onDelete ? (
+                <Button
+                  size="sm"
+                  variant="danger"
+                  disabled={!canMutate}
+                  title={`Delete ${u.name}`}
+                  aria-label={`Delete ${u.name}`}
+                  onClick={() => onDelete(u)}
+                >
+                  <Trash2 size={14} aria-hidden />
+                </Button>
+              ) : null}
+            </span>
+          ),
+          width: '120px',
+        },
+      ]}
+      rows={rows}
+      rowKey={(u) => u.id}
+      emptyMessage={totalRows ? 'No users match the current filters.' : 'No VPN users configured.'}
+      emptyIcon={<UsersIcon size={32} aria-hidden />}
+    />
+  );
+}

--- a/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
+++ b/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
@@ -37,6 +37,14 @@ test.describe('VPN servers tab', () => {
       });
     });
 
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([]),
+      });
+    });
+
     await context.route('**/api/vpn/servers', async (route) => {
       await route.fulfill({
         status: 200,
@@ -83,7 +91,7 @@ test.describe('VPN servers tab', () => {
     const row = page.getByRole('row', { name: /PPTP/ }).first();
     await expect(row).toBeVisible();
     await expect(row).toContainText('1723');
-    await expect(row).toContainText('10.10.10.2-10.10.10.50 (vpn-remote-pool)');
+    await expect(page.getByRole('columnheader', { name: 'Remote IP' })).toHaveCount(0);
 
     await row.click();
 
@@ -101,5 +109,96 @@ test.describe('VPN servers tab', () => {
     await expect(dialog.getByText('1.1.1.1')).toBeVisible();
     await expect(dialog.getByText('alice', { exact: true })).toBeVisible();
     await expect(dialog.getByText('alice123')).toBeVisible();
+  });
+
+  test('creates an OpenVPN server without inline user fields', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Server Router', host: '10.0.0.20' });
+
+    await context.addInitScript((routerId) => {
+      try {
+        const key = 'nasnet-panel.session-credentials.v1';
+        const raw = window.sessionStorage.getItem(key);
+        const map = (raw ? JSON.parse(raw) : {}) as Record<
+          string,
+          { username: string; password: string }
+        >;
+        map[routerId] = { username: 'admin', password: 'test' };
+        window.sessionStorage.setItem(key, JSON.stringify(map));
+      } catch {
+        /* ignore */
+      }
+    }, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ ovpnServers: [], wireguards: [], pptp: null, l2tp: null, sstp: null }),
+      });
+    });
+
+    let lastPostBody: { clientCertificatePassword?: string; users?: unknown[] } | null = null;
+    await context.route('**/api/vpn/ovpn/server', async (route) => {
+      if (route.request().method() === 'POST') {
+        lastPostBody = route.request().postDataJSON() as typeof lastPostBody;
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: envelope({ taskId: 'task-1', status: 'running' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await context.route('**/api/vpn/ovpn/server/status/task-1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          taskId: 'task-1',
+          status: 'completed',
+          progress: 100,
+          currentStep: 'Done',
+          startTime: 0,
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Add server' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('combobox', { name: 'VPN type' })).toContainText('OpenVPN');
+    await expect(dialog.getByLabel(/Username/)).toHaveCount(0);
+    await expect(dialog.getByRole('button', { name: 'Add user' })).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: 'Create OpenVPN server' }).click();
+    await expect(dialog.getByText('Certificate passphrase is required.')).toBeVisible();
+    expect(lastPostBody).toBeNull();
+
+    await dialog.getByLabel('Client certificate passphrase', { exact: true }).fill('certpass123');
+    await dialog.getByRole('button', { name: 'Create OpenVPN server' }).click();
+
+    await expect
+      .poll(() => lastPostBody)
+      .toEqual({ clientCertificatePassword: 'certpass123', users: [] });
+    await expect(dialog).toBeHidden();
   });
 });

--- a/frontend/tests/e2e/30-vpn-users-crud.spec.ts
+++ b/frontend/tests/e2e/30-vpn-users-crud.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect } from './fixtures';
+
+const ROUTER_ID = 'rtr_vusers';
+
+const envelope = <T>(data: T) => JSON.stringify({ status: 200, message: 'OK', data });
+
+const baseUsers = [
+  {
+    id: '*1',
+    name: 'alice',
+    service: 'any',
+    profile: 'VPN-VPN',
+    password: 'alice123',
+    disabled: false,
+    limitBytesIn: 0,
+    limitBytesOut: 0,
+  },
+  {
+    id: '*2',
+    name: 'bob',
+    service: 'any',
+    profile: 'branch-office',
+    password: 'bob123',
+    disabled: true,
+    limitBytesIn: 0,
+    limitBytesOut: 0,
+    comment: 'suspended',
+  },
+];
+
+const profiles = [
+  { id: '*0', name: 'default', default: true },
+  { id: '*1', name: 'VPN-VPN', default: false },
+  { id: '*2', name: 'branch-office', default: false },
+];
+
+async function setup(
+  context: import('@playwright/test').BrowserContext,
+  resetMocks: () => Promise<void>,
+  seedRouter: (input: { id: string; name: string; host: string }) => Promise<void>,
+) {
+  await resetMocks();
+  await seedRouter({ id: ROUTER_ID, name: 'Users Router', host: '10.0.0.30' });
+
+  await context.addInitScript((routerId) => {
+    try {
+      const key = 'nasnet-panel.session-credentials.v1';
+      const raw = window.sessionStorage.getItem(key);
+      const map = (raw ? JSON.parse(raw) : {}) as Record<
+        string,
+        { username: string; password: string }
+      >;
+      map[routerId] = { username: 'admin', password: 'test' };
+      window.sessionStorage.setItem(key, JSON.stringify(map));
+    } catch {
+      /* ignore */
+    }
+  }, ROUTER_ID);
+
+  await context.route('**/api/vpn/clients', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+  });
+
+  await context.route('**/api/vpn/servers', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: envelope({ ovpnServers: [], wireguards: [], pptp: null, l2tp: null, sstp: null }),
+    });
+  });
+
+  await context.route('**/api/vpn/profiles', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: envelope(profiles) });
+  });
+}
+
+test.describe('VPN users section', () => {
+  test('lists users and creates one with VPN-VPN preselected', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await setup(context, resetMocks, seedRouter);
+
+    let lastPostBody: {
+      name?: string;
+      password?: string;
+      profile?: string;
+      disabled?: boolean;
+    } | null = null;
+    await context.route('**/api/vpn/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        lastPostBody = route.request().postDataJSON() as typeof lastPostBody;
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: envelope({
+            id: '*3',
+            name: lastPostBody?.name,
+            service: 'any',
+            profile: lastPostBody?.profile,
+            password: lastPostBody?.password,
+            disabled: false,
+            limitBytesIn: 0,
+            limitBytesOut: 0,
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(baseUsers),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    const aliceRow = page.getByRole('row', { name: /alice/ });
+    await expect(aliceRow).toBeVisible();
+    await expect(aliceRow.getByText('VPN-VPN')).toBeVisible();
+    await expect(aliceRow.getByText('Enabled')).toBeVisible();
+
+    const bobRow = page.getByRole('row', { name: /bob/ });
+    await expect(bobRow.getByText('Disabled')).toBeVisible();
+    await expect(bobRow.getByText('suspended')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Add user' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('combobox', { name: 'Profile' })).toContainText('VPN-VPN');
+
+    await dialog.getByRole('combobox', { name: 'Profile' }).click();
+    await expect(page.getByRole('option', { name: 'default' })).toHaveCount(0);
+    await page.getByRole('option', { name: 'branch-office' }).click();
+
+    await dialog.getByLabel('Name').fill('carol');
+    await dialog.getByLabel('Password', { exact: true }).fill('carol123');
+    await dialog.getByRole('button', { name: 'Create user' }).click();
+
+    await expect
+      .poll(() => lastPostBody)
+      .toEqual({
+        name: 'carol',
+        password: 'carol123',
+        profile: 'branch-office',
+        disabled: false,
+      });
+    await expect(dialog).toBeHidden();
+  });
+
+  test('edits and deletes a user', async ({ page, context, resetMocks, seedRouter }) => {
+    await setup(context, resetMocks, seedRouter);
+
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(baseUsers),
+      });
+    });
+
+    let lastPutBody: {
+      name?: string;
+      password?: string;
+      profile?: string;
+      disabled?: boolean;
+    } | null = null;
+    let deletedUrl: string | null = null;
+    await context.route('**/api/vpn/users/*', async (route) => {
+      if (route.request().method() === 'PUT') {
+        lastPutBody = route.request().postDataJSON() as typeof lastPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ ...baseUsers[1], disabled: false, password: 'bob456' }),
+        });
+        return;
+      }
+      if (route.request().method() === 'DELETE') {
+        deletedUrl = route.request().url();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(null),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Edit bob' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByLabel('Name')).toHaveValue('bob');
+
+    await dialog.getByLabel('Password', { exact: true }).fill('bob456');
+    await dialog.getByRole('switch', { name: /enabled/i }).click();
+    await dialog.getByRole('button', { name: 'Save changes' }).click();
+
+    await expect.poll(() => lastPutBody).toEqual({ password: 'bob456', disabled: false });
+    await expect(dialog).toBeHidden();
+
+    await page.getByRole('button', { name: 'Delete alice' }).click();
+    await expect(page.getByText('Delete VPN user')).toBeVisible();
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await expect.poll(() => deletedUrl).toContain('/api/vpn/users/*1');
+  });
+});


### PR DESCRIPTION

<img width="1245" height="716" alt="Screenshot 2026-07-21 at 01 01 27" src="https://github.com/user-attachments/assets/b80c573f-bc68-4db9-b3a9-8c5fda901451" />


Closes #360

## Summary
- new VPN Users section on the VPN page with create, edit and delete, forms pick a non-default profile with VPN-VPN preselected
- OpenVPN server modal no longer collects inline users and the servers table drops the Remote IP column
- creating an OpenVPN server now sends an empty user list, needs the backend to stop requiring one user
- e2e coverage for the users section and the slimmed modal