### PR TITLE
feat(fe): reflect net connectivity in internet routing graph

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -102,6 +102,7 @@ export {
   DIAG_REPORT_FILENAME,
   type DiagStatusResponse,
 } from './diag';
+export { fetchNetStatus, type NetStatusEntry, type NetHostType } from './net';
 export {
   listVPNClients,
   updateVPNClient,

--- a/frontend/src/api/net.ts
+++ b/frontend/src/api/net.ts
@@ -1,0 +1,30 @@
+import { apiRequest } from './http';
+import type { SystemCredentials } from './system';
+
+export type NetHostType = 'foreign' | 'vpn' | 'domestic' | '';
+
+export interface NetStatusEntry {
+  host: string;
+  status: string;
+  since: string;
+  type: NetHostType;
+}
+
+function authHeaders({ host, username, password }: SystemCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function fetchNetStatus(
+  creds: SystemCredentials,
+  signal?: AbortSignal,
+): Promise<NetStatusEntry[]> {
+  return apiRequest<NetStatusEntry[]>('/api/net/status', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}

--- a/frontend/src/routes/internet/buildTopology.ts
+++ b/frontend/src/routes/internet/buildTopology.ts
@@ -1,4 +1,10 @@
-import { fetchForeignGateway, fetchInterfaces, type InterfaceResponse } from '../../api';
+import {
+  fetchForeignGateway,
+  fetchInterfaces,
+  fetchNetStatus,
+  type InterfaceResponse,
+  type NetStatusEntry,
+} from '../../api';
 import type {
   RoutingHop,
   RoutingNode,
@@ -82,10 +88,17 @@ export async function buildTopology(
   creds: Creds,
   signal?: AbortSignal,
 ): Promise<RoutingTopology> {
-  const [ifaces, foreignGateway] = await Promise.all([
+  const [ifaces, foreignGateway, netStatus] = await Promise.all([
     fetchInterfaces(creds, signal),
     fetchForeignGateway(creds, signal).catch(() => null),
+    fetchNetStatus(creds, signal).catch((): NetStatusEntry[] => []),
   ]);
+
+  const isNetDown = (type: NetStatusEntry['type']) =>
+    netStatus.some((e) => e.type === type && e.status === 'down');
+  const domesticDown = isNetDown('domestic');
+  const vpnDown = isNetDown('vpn');
+  const foreignDown = isNetDown('foreign');
 
   const nodes: RoutingNode[] = [];
   const hops: RoutingHop[] = [];
@@ -109,7 +122,7 @@ export async function buildTopology(
       id: `h_${ROUTER_ID}_${wan.name}`,
       fromId: ROUTER_ID,
       toId: id,
-      isActive: isDomestic || !!wan.running,
+      isActive: (isDomestic || !!wan.running) && !(isDomestic ? domesticDown : foreignDown),
     });
     if (isDomestic) domesticWans.push(wan);
   });
@@ -134,7 +147,7 @@ export async function buildTopology(
         id: `h_vpn_${vpn.name}`,
         fromId: `wan_${fallbackWan.name}`,
         toId: id,
-        isActive: !!vpn.running && isRouted(vpn.name),
+        isActive: !!vpn.running && isRouted(vpn.name) && !vpnDown,
       });
     }
   });
@@ -146,7 +159,7 @@ export async function buildTopology(
         id: `h_internet_vpn_${vpn.name}`,
         fromId: `vpn_${vpn.name}`,
         toId: INTERNET_ID,
-        isActive: !!vpn.running && isRouted(vpn.name),
+        isActive: !!vpn.running && isRouted(vpn.name) && !vpnDown,
       });
     });
     domesticWans.forEach((wan) => {
@@ -154,7 +167,7 @@ export async function buildTopology(
         id: `h_internet_wan_${wan.name}`,
         fromId: `wan_${wan.name}`,
         toId: INTERNET_ID,
-        isActive: true,
+        isActive: !domesticDown,
       });
     });
   }

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -60,12 +60,35 @@ const defaultInterfaces = [
   wgMaskIface,
 ];
 
+interface NetStatusEntry {
+  host: string;
+  status: string;
+  since: string;
+  type: 'foreign' | 'vpn' | 'domestic' | '';
+}
+
 interface TopologyMockOptions {
   interfaces?: Array<(typeof defaultInterfaces)[number]>;
   gateway?: string | null;
+  netStatus?: NetStatusEntry[];
 }
 
+const netProbe = (type: NetStatusEntry['type'], status: string): NetStatusEntry => ({
+  host: type === 'foreign' ? '4.2.2.1' : type === 'vpn' ? '4.2.2.2' : '217.218.127.127',
+  status,
+  since: '2026-07-22 10:00:00',
+  type,
+});
+
 async function mockTopologyApi(context: BrowserContext, opts: TopologyMockOptions = {}) {
+  await context.route('**/api/net/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: envelope(opts.netStatus ?? []),
+    });
+  });
+
   await context.route('**/api/interface/interfaces', async (route) => {
     await route.fulfill({
       status: 200,
@@ -318,6 +341,97 @@ test.describe('Internet routing page', () => {
     await expect(svg.locator('path#edge-h_internet_vpn_wg-client-mask')).toHaveAttribute(
       'marker-end',
       /arr-idle/,
+    );
+  });
+
+  test('grays the routed VPN path when the vpn probe is down', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      gateway: 'wg-client-mask',
+      netStatus: [netProbe('vpn', 'down'), netProbe('foreign', 'up'), netProbe('domestic', 'up')],
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+    await expect(svg.locator('path#edge-h_internet_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+    await expect(svg.locator('path#edge-h_rtr_ether1')).toHaveAttribute('marker-end', /arr-active/);
+    await expect(svg.locator('path#edge-h_internet_wan_ether3')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
+    );
+  });
+
+  test('grays the domestic path when the domestic probe is down', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      gateway: 'wg-client-mask',
+      netStatus: [netProbe('domestic', 'down'), netProbe('vpn', 'up')],
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_rtr_ether3')).toHaveAttribute('marker-end', /arr-idle/);
+    await expect(svg.locator('path#edge-h_internet_wan_ether3')).toHaveAttribute(
+      'marker-end',
+      /arr-idle/,
+    );
+    await expect(svg.locator('path#edge-h_vpn_wg-client-mask')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
+    );
+  });
+
+  test('grays the foreign WAN link when the foreign probe is down', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Net Router', host: '10.0.0.10' });
+    await seedCredentials(context, ROUTER_ID);
+    await mockTopologyApi(context, {
+      gateway: 'wg-client-mask',
+      netStatus: [netProbe('foreign', 'down'), netProbe('domestic', 'up')],
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/internet`);
+
+    const svg = page.getByRole('img', { name: 'Routing topology' });
+    await expect(svg).toBeVisible();
+
+    await expect(svg.locator('path#edge-h_rtr_ether1')).toHaveAttribute('marker-end', /arr-idle/);
+    await expect(svg.locator('path#edge-h_rtr_ether3')).toHaveAttribute('marker-end', /arr-active/);
+    await expect(svg.locator('path#edge-h_internet_wan_ether3')).toHaveAttribute(
+      'marker-end',
+      /arr-active/,
     );
   });
 


### PR DESCRIPTION
Closes #364

- fetch net connectivity status with each topology poll
- force a network's arrows to idle gray when its probe reports down
- e2e cases for foreign, vpn and domestic probe down states