### PR TITLE
fix(fe): wifi wizard scan search filtering and optional password

### DIFF
--- a/frontend/src/routes/easy-config/steps/wan/WirelessScanDialog.tsx
+++ b/frontend/src/routes/easy-config/steps/wan/WirelessScanDialog.tsx
@@ -68,7 +68,13 @@ export function WirelessScanDialog({ open, interfaceName, onClose, onConnected }
       .then((list) => {
         if (controller.signal.aborted) return;
         const sorted = [...list].sort((a, b) => signalNumber(b.signal) - signalNumber(a.signal));
-        setNetworks(sorted);
+        const seen = new Set<string>();
+        const unique = sorted.filter((n) => {
+          if (!n.ssid || seen.has(n.ssid)) return false;
+          seen.add(n.ssid);
+          return true;
+        });
+        setNetworks(unique);
         setScanning(false);
       })
       .catch((err: Error) => {
@@ -97,8 +103,7 @@ export function WirelessScanDialog({ open, interfaceName, onClose, onConnected }
   );
 
   const selected = networks.find((n) => n.ssid === ssid) ?? null;
-  const isOpenNetwork = isOpenSecurity(selected?.security);
-  const canVerify = Boolean(selected) && (isOpenNetwork || password.length >= 8);
+  const canVerify = Boolean(selected);
 
   const onVerify = async () => {
     if (!selected || !selected.ssid) return;
@@ -120,7 +125,7 @@ export function WirelessScanDialog({ open, interfaceName, onClose, onConnected }
       onClose={verifying ? () => undefined : onClose}
       size="md"
       title="Choose a wireless network"
-      description="Pick a network within range and enter its password."
+      description="Pick a network within range. Enter its password if it requires one."
       labelledBy="wireless-scan-title"
       footer={
         <>
@@ -151,9 +156,9 @@ export function WirelessScanDialog({ open, interfaceName, onClose, onConnected }
             disabled={scanning}
           />
         </Label>
-        {selected && !isOpenNetwork ? (
+        {selected ? (
           <Label>
-            <span>Password</span>
+            <span>Password (optional)</span>
             <PasswordInput
               value={password}
               onChange={(e) => setPassword(e.target.value)}

--- a/frontend/src/routes/easy-config/steps/wan/wirelessScanMock.ts
+++ b/frontend/src/routes/easy-config/steps/wan/wirelessScanMock.ts
@@ -21,11 +21,8 @@ export async function scanWirelessNetworks(): Promise<WirelessNetwork[]> {
 
 export async function verifyWirelessPassword(
   _ssid: string,
-  password: string,
+  _password: string,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   await new Promise((r) => setTimeout(r, 600));
-  if (password.length < 8) {
-    return { ok: false, reason: 'Password must be at least 8 characters.' };
-  }
   return { ok: true };
 }

--- a/frontend/tests/e2e/22-easy-config-wireless-scan.spec.ts
+++ b/frontend/tests/e2e/22-easy-config-wireless-scan.spec.ts
@@ -61,4 +61,48 @@ AllowedIPs = 0.0.0.0/0`);
     await page.getByRole('button', { name: /^apply$/i }).click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });
+
+  test('scan dedupes SSIDs, search filters the list, and password is optional', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockEasyConfigBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_wsearch', name: 'Wireless Search Router' });
+    await mockEasyConfigBackend({
+      id: 'rtr_wsearch',
+      scanNetworks: [
+        { ssid: 'NasNet-Home', security: 'wpa2-psk', signal: '-45' },
+        { ssid: 'NasNet-Home', security: 'wpa2-psk', signal: '-52' },
+        { ssid: 'Neighbor-WiFi', security: 'wpa2-psk', signal: '-70' },
+        { ssid: 'Coffee-Guest', security: '', signal: '-60' },
+      ],
+    });
+    await page.goto('/router/rtr_wsearch/config');
+
+    await page.getByRole('radio', { name: /starlink-only/i }).check();
+    await page.getByRole('button', { name: /^next$/i }).click();
+    await page.getByRole('radio', { name: 'Wireless' }).first().click();
+    await page.getByLabel(/starlink wan/i).click();
+    await page.getByRole('option', { name: 'Wifi2.4' }).click();
+
+    await page.getByRole('button', { name: /choose wireless network/i }).click();
+    await page.getByRole('combobox', { name: 'Wireless network' }).click();
+
+    // Duplicate SSIDs from the scan collapse to a single entry
+    await expect(page.getByRole('option', { name: /NasNet-Home/ })).toHaveCount(1);
+
+    // Typing in the search box narrows the list
+    await page.getByLabel('Search options').fill('coffee');
+    await expect(page.getByRole('option', { name: /Coffee-Guest/ })).toBeVisible();
+    await expect(page.getByRole('option', { name: /NasNet-Home/ })).toHaveCount(0);
+    await expect(page.getByRole('option', { name: /Neighbor-WiFi/ })).toHaveCount(0);
+    await page.getByRole('option', { name: /Coffee-Guest/ }).click();
+
+    // Connect without entering a password
+    await expect(page.getByLabel('Wireless password')).toBeVisible();
+    await page.getByRole('button', { name: /verify and connect/i }).click();
+    await expect(page.getByText('Coffee-Guest', { exact: true })).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #380

- dedupe scanned networks by SSID keeping the strongest signal, duplicate entries were breaking the search filter
- password field is now always shown and optional, no 8-char minimum
- e2e test covering dedupe, search filtering and empty-password connect