### PR TITLE
feat(fe): change default router scan range to 192.168.10.0/24

### DIFF
--- a/frontend/src/routes/add-router/ScanStep.tsx
+++ b/frontend/src/routes/add-router/ScanStep.tsx
@@ -35,7 +35,7 @@ const SCAN_COLUMNS = [
 ];
 
 export function ScanStep({ onSelect }: Props) {
-  const [subnet, setSubnet] = useState('192.168.88.0/24');
+  const [subnet, setSubnet] = useState('192.168.10.0/24');
   const [scanning, setScanning] = useState(false);
   const [percent, setPercent] = useState(0);
   const [displayPercent, setDisplayPercent] = useSmoothedPercent(percent);

--- a/frontend/src/routes/add-router/ScanToolbar.tsx
+++ b/frontend/src/routes/add-router/ScanToolbar.tsx
@@ -17,7 +17,7 @@ export function ScanToolbar({ subnet, scanning, onSubnetChange, onStart }: Props
         <Input
           value={subnet}
           onChange={(e) => onSubnetChange(e.target.value)}
-          placeholder="192.168.88.0/24"
+          placeholder="192.168.10.0/24"
           aria-label="Subnet"
         />
       </Label>

--- a/frontend/tests/e2e/02-add-router-scan.spec.ts
+++ b/frontend/tests/e2e/02-add-router-scan.spec.ts
@@ -21,7 +21,7 @@ test.describe('Add router — scan network', () => {
     await expect(page.getByRole('heading', { name: /add router/i })).toBeVisible();
 
     const subnet = page.getByLabel(/subnet/i);
-    await expect(subnet).toHaveValue('192.168.88.0/24');
+    await expect(subnet).toHaveValue('192.168.10.0/24');
 
     await page.getByRole('button', { name: /start scan/i }).click();
 


### PR DESCRIPTION
Closes #391

- change default scan subnet from 192.168.88.0/24 to 192.168.10.0/24
- update input placeholder and e2e assertion to match