### PR TITLE
feat(fe): hide top menu until wizard has run on the router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { GlobalStyle, ToastProvider } from '@nasnet/ui';
 import { AppThemeProvider } from './state/ThemeContext';
 import { RouterStoreProvider } from './state/RouterStoreContext';
 import { SessionProvider } from './state/SessionContext';
+import { WizardGateProvider } from './state/WizardGateContext';
 import { AppShell } from './layout/AppShell';
 import { RouterListPage } from './routes/RouterListPage';
 import { AddRouterWizard } from './routes/AddRouterWizard';
@@ -34,52 +35,54 @@ export function App() {
       <GlobalStyle />
       <RouterStoreProvider>
         <SessionProvider>
-          <ToastProvider>
-            <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-              <Routes>
-                <Route path="/" element={<RouterListPage />} />
-                <Route
-                  path="/routers/new"
-                  element={
-                    <AppShell>
-                      <AddRouterEntry />
-                    </AppShell>
-                  }
-                />
-                <Route
-                  path="/router/:id"
-                  element={
-                    <AppShell>
-                      <RouterDashboard />
-                    </AppShell>
-                  }
-                >
-                  <Route index element={<OverviewTab />} />
-                  <Route path="config" element={<EasyConfigWizard />} />
-                  <Route path="internet" element={<InternetPage />} />
-                  <Route path="wan" element={<WanPage />} />
-                  <Route path="vpn" element={<VPNPage />} />
-                  <Route path="wireless" element={<WirelessPage />} />
-                  <Route path="logs" element={<LogsPage />} />
-                  <Route path="lan" element={<DHCPPage />} />
-                  <Route path="dns" element={<DNSPage />} />
-                  <Route path="firewall" element={<FirewallPage />} />
-                  <Route path="plugins" element={<PluginsPage />} />
-                  <Route path="diagnostics" element={<DiagnosticsPage />} />
-                  <Route path="help" element={<HelpPage />} />
-                </Route>
-                <Route
-                  path="/updates"
-                  element={
-                    <AppShell>
-                      <UpdatesPage />
-                    </AppShell>
-                  }
-                />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
-            </BrowserRouter>
-          </ToastProvider>
+          <WizardGateProvider>
+            <ToastProvider>
+              <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+                <Routes>
+                  <Route path="/" element={<RouterListPage />} />
+                  <Route
+                    path="/routers/new"
+                    element={
+                      <AppShell>
+                        <AddRouterEntry />
+                      </AppShell>
+                    }
+                  />
+                  <Route
+                    path="/router/:id"
+                    element={
+                      <AppShell>
+                        <RouterDashboard />
+                      </AppShell>
+                    }
+                  >
+                    <Route index element={<OverviewTab />} />
+                    <Route path="config" element={<EasyConfigWizard />} />
+                    <Route path="internet" element={<InternetPage />} />
+                    <Route path="wan" element={<WanPage />} />
+                    <Route path="vpn" element={<VPNPage />} />
+                    <Route path="wireless" element={<WirelessPage />} />
+                    <Route path="logs" element={<LogsPage />} />
+                    <Route path="lan" element={<DHCPPage />} />
+                    <Route path="dns" element={<DNSPage />} />
+                    <Route path="firewall" element={<FirewallPage />} />
+                    <Route path="plugins" element={<PluginsPage />} />
+                    <Route path="diagnostics" element={<DiagnosticsPage />} />
+                    <Route path="help" element={<HelpPage />} />
+                  </Route>
+                  <Route
+                    path="/updates"
+                    element={
+                      <AppShell>
+                        <UpdatesPage />
+                      </AppShell>
+                    }
+                  />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </BrowserRouter>
+            </ToastProvider>
+          </WizardGateProvider>
         </SessionProvider>
       </RouterStoreProvider>
     </AppThemeProvider>

--- a/frontend/src/layout/AppHeader.tsx
+++ b/frontend/src/layout/AppHeader.tsx
@@ -3,11 +3,13 @@ import { HeaderActions } from './HeaderActions';
 import { ROUTER_SECTIONS, activeRouterSectionId } from './routerSections';
 import { useSession } from '../state/SessionContext';
 import { useRouter, useRouterStore } from '../state/RouterStoreContext';
+import { useWizardGate } from '../state/WizardGateContext';
 import styles from './AppHeader.module.scss';
 
 export function AppHeader() {
   const { activeRouterId } = useSession();
   const { lastConnectedRouterId, selectedRouterId } = useRouterStore();
+  const { statusFor } = useWizardGate();
   const location = useLocation();
   const targetId = activeRouterId ?? lastConnectedRouterId ?? selectedRouterId ?? null;
   const router = useRouter(targetId ?? undefined);
@@ -25,7 +27,7 @@ export function AppHeader() {
           <HeaderActions
             routerName={router?.name}
             routerId={targetId ?? undefined}
-            sections={targetId ? ROUTER_SECTIONS : undefined}
+            sections={targetId && statusFor(targetId) === 'completed' ? ROUTER_SECTIONS : undefined}
             activeSectionId={
               targetId ? activeRouterSectionId(location.pathname, targetId) : undefined
             }

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Tabs } from '@nasnet/ui';
 import { useRouter } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
+import { useWizardGate } from '../state/WizardGateContext';
 import { ROUTER_SECTIONS as TABS } from '../layout/routerSections';
 import styles from './RouterDashboard.module.scss';
 
@@ -12,6 +13,7 @@ export function RouterDashboard() {
   const location = useLocation();
   const navigate = useNavigate();
   const { setActiveRouterId } = useSession();
+  const { statusFor } = useWizardGate();
 
   useEffect(() => {
     setActiveRouterId(id ?? null);
@@ -26,28 +28,36 @@ export function RouterDashboard() {
     );
   }
 
+  const wizardStatus = statusFor(router.id);
+
   const activeTab =
     TABS.find((t) => {
       const full = `/router/${router.id}${t.path ? `/${t.path}` : ''}`;
       return t.path === '' ? location.pathname === full : location.pathname.startsWith(full);
     })?.id ?? 'overview';
 
+  if (wizardStatus === 'fresh' && activeTab !== 'wizard') {
+    return <Navigate to={`/router/${router.id}/config`} replace />;
+  }
+
   return (
     <>
-      <div className={styles.tabBarBand}>
-        <div className={styles.tabBarInner}>
-          <Tabs
-            items={TABS}
-            activeId={activeTab}
-            onChange={(tabId) => {
-              const item = TABS.find((t) => t.id === tabId);
-              if (!item) return;
-              navigate(`/router/${router.id}${item.path ? `/${item.path}` : ''}`);
-            }}
-            ariaLabel="Router sections"
-          />
+      {wizardStatus === 'completed' ? (
+        <div className={styles.tabBarBand}>
+          <div className={styles.tabBarInner}>
+            <Tabs
+              items={TABS}
+              activeId={activeTab}
+              onChange={(tabId) => {
+                const item = TABS.find((t) => t.id === tabId);
+                if (!item) return;
+                navigate(`/router/${router.id}${item.path ? `/${item.path}` : ''}`);
+              }}
+              ariaLabel="Router sections"
+            />
+          </div>
         </div>
-      </div>
+      ) : null}
       <div className={styles.contentShell}>
         <Outlet />
       </div>

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -12,6 +12,7 @@ import {
 } from '../../api';
 import { useSession } from '../../state/SessionContext';
 import { useRouter } from '../../state/RouterStoreContext';
+import { useWizardGate } from '../../state/WizardGateContext';
 import { buildEasyConfigScript, type EasyConfigInput } from '../../utils/rsc-builder';
 import { canAdvance } from './validation';
 import { initial, reducer, stepOrder, type State } from './state';
@@ -148,6 +149,7 @@ function buildScript(state: State): string {
 export function useEasyConfig(routerId: string | undefined) {
   const { getCredentials } = useSession();
   const router = useRouter(routerId);
+  const { markCompleted } = useWizardGate();
   const [state, dispatch] = useReducer(reducer, initial);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState<boolean>(false);
@@ -213,37 +215,41 @@ export function useEasyConfig(routerId: string | undefined) {
     [],
   );
 
-  const trackProgress = useCallback((creds: VPNCredentials) => {
-    const ctl = poll.current;
-    ctl.cancelled = false;
-    const deadline = Date.now() + POLL_TIMEOUT_MS;
+  const trackProgress = useCallback(
+    (creds: VPNCredentials) => {
+      const ctl = poll.current;
+      ctl.cancelled = false;
+      const deadline = Date.now() + POLL_TIMEOUT_MS;
 
-    const tick = async () => {
-      if (ctl.cancelled) return;
-      try {
-        const status = await fetchWizardStatus(creds);
+      const tick = async () => {
         if (ctl.cancelled) return;
-        dispatch({ type: 'progress', value: status.progress });
-        if (status.progress >= 100) {
-          dispatch({ type: 'applied' });
+        try {
+          const status = await fetchWizardStatus(creds);
+          if (ctl.cancelled) return;
+          dispatch({ type: 'progress', value: status.progress });
+          if (status.progress >= 100) {
+            dispatch({ type: 'applied' });
+            if (routerId) markCompleted(routerId);
+            return;
+          }
+        } catch {
+          // router drops off while its addressing is rewritten; keep polling until the deadline
+        }
+        if (ctl.cancelled) return;
+        if (Date.now() > deadline) {
+          dispatch({ type: 'error', message: 'Timed out waiting for the router to finish.' });
+          dispatch({ type: 'applying', value: false });
           return;
         }
-      } catch {
-        // router drops off while its addressing is rewritten; keep polling until the deadline
-      }
-      if (ctl.cancelled) return;
-      if (Date.now() > deadline) {
-        dispatch({ type: 'error', message: 'Timed out waiting for the router to finish.' });
-        dispatch({ type: 'applying', value: false });
-        return;
-      }
-      ctl.timer = setTimeout(() => {
-        void tick();
-      }, POLL_INTERVAL_MS);
-    };
+        ctl.timer = setTimeout(() => {
+          void tick();
+        }, POLL_INTERVAL_MS);
+      };
 
-    void tick();
-  }, []);
+      void tick();
+    },
+    [routerId, markCompleted],
+  );
 
   const onApply = useCallback(async () => {
     const creds = routerId ? getCredentials(routerId) : undefined;

--- a/frontend/src/state/WizardGateContext.tsx
+++ b/frontend/src/state/WizardGateContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { fetchWizardStatus } from '../api';
+import { useSession } from './SessionContext';
+import { useRouter } from './RouterStoreContext';
+
+export type WizardGateStatus = 'unknown' | 'fresh' | 'completed';
+
+interface WizardGateContextValue {
+  statusFor: (routerId: string | null | undefined) => WizardGateStatus;
+  markCompleted: (routerId: string) => void;
+}
+
+const Ctx = createContext<WizardGateContextValue | null>(null);
+
+export const WizardGateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { activeRouterId, getCredentials } = useSession();
+  const router = useRouter(activeRouterId ?? undefined);
+  const host = router?.host;
+  const [statuses, setStatuses] = useState<Record<string, WizardGateStatus>>({});
+
+  useEffect(() => {
+    if (!activeRouterId || !host) return;
+    const creds = getCredentials(activeRouterId);
+    if (!creds) return;
+    const controller = new AbortController();
+    void (async () => {
+      let next: WizardGateStatus;
+      try {
+        const status = await fetchWizardStatus({ host, ...creds }, controller.signal);
+        next = status.completed ? 'completed' : 'fresh';
+      } catch {
+        next = 'fresh';
+      }
+      if (controller.signal.aborted) return;
+      setStatuses((prev) => ({ ...prev, [activeRouterId]: next }));
+    })();
+    return () => controller.abort();
+  }, [activeRouterId, host, getCredentials]);
+
+  const statusFor = useCallback(
+    (routerId: string | null | undefined): WizardGateStatus =>
+      routerId ? (statuses[routerId] ?? 'unknown') : 'unknown',
+    [statuses],
+  );
+
+  const markCompleted = useCallback((routerId: string) => {
+    setStatuses((prev) => ({ ...prev, [routerId]: 'completed' }));
+  }, []);
+
+  const value = useMemo(() => ({ statusFor, markCompleted }), [statusFor, markCompleted]);
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+};
+
+export const useWizardGate = (): WizardGateContextValue => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useWizardGate must be used inside <WizardGateProvider>');
+  return ctx;
+};

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -456,9 +456,10 @@ test.describe('Internet routing page', () => {
     expect(box?.width ?? 0).toBeGreaterThan(375);
   });
 
-  test('Internet tab is enabled', async ({ page, resetMocks, seedRouter }) => {
+  test('Internet tab is enabled', async ({ page, resetMocks, seedRouter, mockOverviewBackend }) => {
     await resetMocks();
-    await seedRouter({ id: 'rtr_tabs', name: 'Tabs Router' });
+    await seedRouter({ id: 'rtr_tabs', name: 'Tabs Router', host: '10.0.0.9' });
+    await mockOverviewBackend({ id: 'rtr_tabs' });
     await page.goto('/router/rtr_tabs');
 
     const tab = page.getByRole('tab', { name: /internet/i });

--- a/frontend/tests/e2e/25-help-page.spec.ts
+++ b/frontend/tests/e2e/25-help-page.spec.ts
@@ -10,9 +10,11 @@ test.describe('Help page', () => {
     page,
     resetMocks,
     seedRouter,
+    mockOverviewBackend,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await mockOverviewBackend({ id: ROUTER.id });
     await page.goto(`/router/${ROUTER.id}`);
 
     const helpTab = page.getByRole('tab', { name: 'Help' });

--- a/frontend/tests/e2e/26-plugins-page.spec.ts
+++ b/frontend/tests/e2e/26-plugins-page.spec.ts
@@ -7,9 +7,11 @@ test.describe('Plugins page', () => {
     page,
     resetMocks,
     seedRouter,
+    mockOverviewBackend,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await mockOverviewBackend({ id: ROUTER.id });
     await page.goto(`/router/${ROUTER.id}`);
 
     const pluginsTab = page.getByRole('tab', { name: 'Plugins' });

--- a/frontend/tests/e2e/31-wizard-gated-menu.spec.ts
+++ b/frontend/tests/e2e/31-wizard-gated-menu.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from './fixtures';
+
+const freshStatus = JSON.stringify({
+  status: 200,
+  message: 'OK',
+  data: { completed: false, completedAt: null, progress: 0 },
+});
+
+test.describe('Wizard-gated navigation', () => {
+  test('hides the tab bar and redirects to the wizard on a fresh router', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    context,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_fresh', name: 'Fresh Router', host: '10.0.0.70' });
+    await mockOverviewBackend({ id: 'rtr_fresh' });
+    await context.route('**/api/wizard/status', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: freshStatus });
+    });
+
+    await page.goto('/router/rtr_fresh');
+    await expect(page).toHaveURL(/\/router\/rtr_fresh\/config$/);
+    await expect(page.locator('[role="tablist"][aria-label="Router sections"]')).toHaveCount(0);
+
+    await page.goto('/router/rtr_fresh/wan');
+    await expect(page).toHaveURL(/\/router\/rtr_fresh\/config$/);
+  });
+
+  test('treats a failing status check as a fresh router', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    context,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_err', name: 'Unreachable Router', host: '10.0.0.72' });
+    await mockOverviewBackend({ id: 'rtr_err' });
+    await context.route('**/api/wizard/status', async (route) => {
+      await route.abort('connectionrefused');
+    });
+
+    await page.goto('/router/rtr_err');
+    await expect(page).toHaveURL(/\/router\/rtr_err\/config$/);
+    await expect(page.locator('[role="tablist"][aria-label="Router sections"]')).toHaveCount(0);
+  });
+
+  test('shows the tab bar once the wizard has completed', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_done', name: 'Configured Router', host: '10.0.0.71' });
+    await mockOverviewBackend({ id: 'rtr_done' });
+
+    await page.goto('/router/rtr_done');
+    await expect(page).toHaveURL(/\/router\/rtr_done$/);
+    await expect(page.locator('[role="tablist"][aria-label="Router sections"]')).toBeVisible();
+  });
+
+  test.describe('mobile menu', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('hides the router sections on a fresh router', async ({
+      page,
+      resetMocks,
+      seedRouter,
+      mockOverviewBackend,
+      context,
+    }) => {
+      await resetMocks();
+      await seedRouter({ id: 'rtr_mfresh', name: 'Fresh Mobile', host: '10.0.0.73' });
+      await mockOverviewBackend({ id: 'rtr_mfresh' });
+      await context.route('**/api/wizard/status', async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: freshStatus });
+      });
+
+      await page.goto('/router/rtr_mfresh');
+      await expect(page).toHaveURL(/\/router\/rtr_mfresh\/config$/);
+
+      const trigger = page.locator('header button[aria-haspopup="menu"]');
+      await trigger.click();
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      await expect(page.getByRole('menuitem', { name: /logout/i })).toBeVisible();
+      await expect(page.getByRole('menuitem', { name: 'Overview' })).toHaveCount(0);
+      await expect(page.getByRole('menuitem', { name: 'Wizard' })).toHaveCount(0);
+    });
+  });
+});

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -138,6 +138,18 @@ export const test = base.extend<TestFixtures>({
     });
   },
   seedRouter: async ({ context }, use) => {
+    // seeded routers default to a completed wizard; gating specs override this route
+    await context.route('**/api/wizard/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 200,
+          message: 'OK',
+          data: { completed: true, completedAt: null, progress: 100 },
+        }),
+      });
+    });
     await use(async (input) => {
       await context.addInitScript((seed) => {
         window.__PENDING_SEEDS__ = window.__PENDING_SEEDS__ ?? [];

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -120,6 +120,18 @@ export interface TestFixtures {
 
 export const test = base.extend<TestFixtures>({
   resetMocks: async ({ context }, use) => {
+    // routers default to a completed wizard; gating specs override this route
+    await context.route('**/api/wizard/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 200,
+          message: 'OK',
+          data: { completed: true, completedAt: null, progress: 100 },
+        }),
+      });
+    });
     await use(async () => {
       await context.addInitScript(() => {
         try {
@@ -138,18 +150,6 @@ export const test = base.extend<TestFixtures>({
     });
   },
   seedRouter: async ({ context }, use) => {
-    // seeded routers default to a completed wizard; gating specs override this route
-    await context.route('**/api/wizard/status', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          status: 200,
-          message: 'OK',
-          data: { completed: true, completedAt: null, progress: 100 },
-        }),
-      });
-    });
     await use(async (input) => {
       await context.addInitScript((seed) => {
         window.__PENDING_SEEDS__ = window.__PENDING_SEEDS__ ?? [];


### PR DESCRIPTION
Closes #394

## Summary
- check wizard status when opening a router dashboard and hide the top tab row and mobile menu sections until the wizard has completed
- treat a failed or unknown status check as fresh and redirect non wizard pages to the wizard
- reveal the menu immediately once the wizard finishes applying