### PR TITLE
feat(fe): disable wizard WiFi step on routers without WiFi hardware

### DIFF
--- a/frontend/src/routes/EasyConfigWizard.tsx
+++ b/frontend/src/routes/EasyConfigWizard.tsx
@@ -20,6 +20,7 @@ export function EasyConfigWizard() {
     interfaces,
     interfacesLoading,
     wifiInterfaces,
+    wifiSupported,
     onApply,
     goNext,
     goPrev,
@@ -107,6 +108,7 @@ export function EasyConfigWizard() {
             state={state}
             dispatch={dispatch}
             wifiInterfaces={wifiInterfaces}
+            wifiSupported={wifiSupported}
             footer={footer}
           />
         );

--- a/frontend/src/routes/easy-config/steps/WifiStep.tsx
+++ b/frontend/src/routes/easy-config/steps/WifiStep.tsx
@@ -24,6 +24,7 @@ interface Props {
   state: State;
   dispatch: React.Dispatch<Action>;
   wifiInterfaces: WifiInterfaceResponse[];
+  wifiSupported: boolean;
   footer?: React.ReactNode;
 }
 
@@ -49,7 +50,7 @@ function bandKeyFor(wi: WifiInterfaceResponse): BandKey | null {
   return null;
 }
 
-export function WifiStep({ state, dispatch, wifiInterfaces, footer }: Props) {
+export function WifiStep({ state, dispatch, wifiInterfaces, wifiSupported, footer }: Props) {
   const setText = (field: keyof State) => (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch({ type: 'setField', field, value: e.target.value });
 
@@ -76,16 +77,27 @@ export function WifiStep({ state, dispatch, wifiInterfaces, footer }: Props) {
       <CardHeader>
         <CardTitle>Wireless settings</CardTitle>
         <CardDescription>
-          One network name and password for the router&apos;s Wi-Fi. Avoid words like
-          &quot;starlink&quot;, &quot;VPN&quot;, or &quot;Iran&quot; in the SSID.
+          {wifiSupported ? (
+            <>
+              One network name and password for the router&apos;s Wi-Fi. Avoid words like
+              &quot;starlink&quot;, &quot;VPN&quot;, or &quot;Iran&quot; in the SSID.
+            </>
+          ) : (
+            'This router has no Wi-Fi hardware, so wireless options are unavailable.'
+          )}
         </CardDescription>
       </CardHeader>
       <div className={wizardStyles.modeLayout}>
         <Stack>
           <Inline>
             <Switch
-              label={`Wi-Fi ${state.wifiEnabled ? 'enabled' : 'disabled'}`}
+              label={
+                wifiSupported
+                  ? `Wi-Fi ${state.wifiEnabled ? 'enabled' : 'disabled'}`
+                  : 'Wi-Fi not available'
+              }
               checked={state.wifiEnabled}
+              disabled={!wifiSupported}
               onChange={(e) =>
                 dispatch({ type: 'setField', field: 'wifiEnabled', value: e.target.checked })
               }

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -154,6 +154,7 @@ export function useEasyConfig(routerId: string | undefined) {
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState<boolean>(false);
   const [wifiInterfaces, setWifiInterfaces] = useState<WifiInterfaceResponse[]>([]);
+  const [wifiSupported, setWifiSupported] = useState<boolean>(true);
 
   useEffect(() => {
     if (!routerId) return;
@@ -164,6 +165,7 @@ export function useEasyConfig(routerId: string | undefined) {
     if (!creds || !host) {
       setInterfaces([]);
       setWifiInterfaces([]);
+      setWifiSupported(true);
       setInterfacesLoading(false);
       return;
     }
@@ -189,6 +191,10 @@ export function useEasyConfig(routerId: string | undefined) {
         const list = await fetchWifiInterfaces({ host, ...creds }, controller.signal);
         if (controller.signal.aborted) return;
         setWifiInterfaces(list);
+        setWifiSupported(list.length > 0);
+        if (list.length === 0) {
+          dispatch({ type: 'setField', field: 'wifiEnabled', value: false });
+        }
       } catch {
         if (controller.signal.aborted) return;
         setWifiInterfaces([]);
@@ -298,6 +304,7 @@ export function useEasyConfig(routerId: string | undefined) {
     interfaces,
     interfacesLoading,
     wifiInterfaces,
+    wifiSupported,
     script,
     onApply,
     goNext,

--- a/frontend/src/ui/primitives/Checkbox.module.scss
+++ b/frontend/src/ui/primitives/Checkbox.module.scss
@@ -75,6 +75,11 @@
     transform: translateX(14px);
   }
 
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   &:focus-visible {
     outline: 2px solid var(--color-success);
     outline-offset: 2px;

--- a/frontend/tests/e2e/32-easy-config-no-wifi-hardware.spec.ts
+++ b/frontend/tests/e2e/32-easy-config-no-wifi-hardware.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from './fixtures';
+
+test.describe('Easy-Mode wizard — router without WiFi hardware', () => {
+  test('disables the WiFi step and applies without wireless settings', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockEasyConfigBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_nowifi', name: 'Wired-only Router' });
+    await mockEasyConfigBackend({
+      id: 'rtr_nowifi',
+      interfaces: [
+        { id: '*1', name: 'ether1', type: 'ether', running: true, disabled: false },
+        { id: '*2', name: 'ether2', type: 'ether', running: true, disabled: false },
+      ],
+      wifiInterfaces: [],
+    });
+    await page.goto('/router/rtr_nowifi/config');
+
+    await page.getByRole('radio', { name: /starlink-only/i }).check();
+    await page.getByRole('button', { name: /^next$/i }).click();
+
+    await page.getByLabel(/starlink wan/i).click();
+    await page.getByRole('option', { name: 'ether1' }).click();
+    await page.getByRole('button', { name: /^next$/i }).click();
+
+    await page.getByLabel(/wireguard configuration/i).fill(`[Interface]
+PrivateKey = 4AjT3jhk6L8h3GVe7Mw3lP3xQK4n5cL2yR6f8tWvX1c=
+Address = 10.0.0.2/32
+
+[Peer]
+PublicKey = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+Endpoint = mask.example.com:51820
+AllowedIPs = 0.0.0.0/0`);
+    await page.getByRole('button', { name: /^next$/i }).click();
+
+    const wifiToggle = page.getByRole('switch', { name: /wi-fi not available/i });
+    await expect(wifiToggle).toBeVisible();
+    await expect(wifiToggle).toBeDisabled();
+    await expect(wifiToggle).not.toBeChecked();
+    await expect(page.getByText(/no wi-fi hardware/i)).toBeVisible();
+    await expect(page.getByLabel('Network name (SSID)', { exact: true })).not.toBeVisible();
+
+    await expect(page.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    await page.getByRole('button', { name: /^next$/i }).click();
+
+    await page.getByRole('button', { name: /^apply$/i }).click();
+    await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #398

## Summary
- gray out and force off the wizard WiFi toggle when the router reports no WiFi interfaces
- keep the toggle usable if the interface lookup fails so a transient error cannot lock it
- add an e2e test covering a wired-only router completing the wizard