### PR TITLE
feat(fe): show loading indicator while scanning for wireless networks in wizard

### DIFF
--- a/frontend/src/routes/easy-config/steps/wan/WirelessScanDialog.tsx
+++ b/frontend/src/routes/easy-config/steps/wan/WirelessScanDialog.tsx
@@ -156,6 +156,12 @@ export function WirelessScanDialog({ open, interfaceName, onClose, onConnected }
             disabled={scanning}
           />
         </Label>
+        {scanning ? (
+          <div className={styles.scanning} role="status">
+            <span className={styles.spinner} aria-hidden />
+            <span>Scanning for nearby networks…</span>
+          </div>
+        ) : null}
         {selected ? (
           <Label>
             <span>Password (optional)</span>


### PR DESCRIPTION
Closes #399

## Summary
- show a spinner with status text while the wizard scans for nearby wireless networks
- announced to screen readers via role=status