### PR TITLE
feat(fe): show VPN profile comments in user add modal

### DIFF
--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
@@ -97,9 +97,9 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
   const markTouched = (key: string) => setTouched((t) => (t[key] ? t : { ...t, [key]: true }));
 
   const profileOptions = useMemo(() => {
-    const options = profiles.map((p) => ({ value: p.name, label: p.name }));
+    const options = profiles.map((p) => ({ value: p.name, label: p.name, description: p.comment }));
     if (user?.profile && !profiles.some((p) => p.name === user.profile)) {
-      options.unshift({ value: user.profile, label: user.profile });
+      options.unshift({ value: user.profile, label: user.profile, description: undefined });
     }
     return options;
   }, [profiles, user?.profile]);

--- a/frontend/src/ui/primitives/Select.module.scss
+++ b/frontend/src/ui/primitives/Select.module.scss
@@ -131,6 +131,19 @@
   user-select: none;
 }
 
+.optionText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.optionDescription {
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-regular);
+}
+
 .optionActive {
   background: var(--color-surface-alt);
 }

--- a/frontend/src/ui/primitives/Select.tsx
+++ b/frontend/src/ui/primitives/Select.tsx
@@ -13,6 +13,7 @@ import styles from './Select.module.scss';
 export interface SelectOption {
   value: string;
   label: string;
+  description?: string;
   disabled?: boolean;
 }
 
@@ -337,7 +338,12 @@ export const Select: React.FC<SelectProps> = (props) => {
                           selectAt(idx);
                         }}
                       >
-                        <span>{opt.label}</span>
+                        <span className={styles.optionText}>
+                          <span>{opt.label}</span>
+                          {opt.description ? (
+                            <span className={styles.optionDescription}>{opt.description}</span>
+                          ) : null}
+                        </span>
                         {selectedOpt ? (
                           <svg
                             className={styles.check}


### PR DESCRIPTION
Closes #404

- Show each profile's comment as muted text under its name in the profile dropdown of the VPN user modal
- Add optional description support to Select options to render it