### PR TITLE
fix(fe): show real port statuses on the LAN page diagram

### DIFF
--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Cable, Inbox, Pin, Trash2 } from 'lucide-react';
 import {
@@ -31,7 +31,6 @@ import {
 import { useSession } from '../state/SessionContext';
 import { useRouter } from '../state/RouterStoreContext';
 import { RouterPortDiagramCard } from './overview-panel/RouterPortDiagramCard';
-import { wanInterfaceNames } from './overview-panel/uplinks';
 
 interface SectionState<T> {
   data: T[];
@@ -192,8 +191,6 @@ export function DHCPPage() {
       setBusyMac(null);
     }
   }, [id, router?.host, getCredentials, leaseToRemove, reload, toast]);
-
-  const wanNames = useMemo(() => wanInterfaceNames(interfaces), [interfaces]);
 
   const leaseColumns: DataTableColumn<DhcpLease>[] = [
     {
@@ -360,7 +357,6 @@ export function DHCPPage() {
                 interfaces={interfaces}
                 ifaceRates={ethernetRates}
                 showPowerControls={false}
-                disabledIfaceNames={wanNames}
               />
             ) : (
               <Skeleton width="min(320px, 100%)" height={56} />

--- a/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
+++ b/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
@@ -11,7 +11,6 @@ export interface RouterPortDiagramCardProps {
   interfaces: InterfaceResponse[];
   onPower?: (action: PowerAction) => void;
   showPowerControls?: boolean;
-  disabledIfaceNames?: readonly string[];
   ifaceRates?: Readonly<Record<string, string>>;
 }
 
@@ -21,19 +20,15 @@ export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React
     interfaces,
     onPower,
     showPowerControls = true,
-    disabledIfaceNames,
     ifaceRates,
   }) {
     const { descriptor, slots } = useMemo(() => {
       const resolved = resolveModelStrict(model);
-      const disabled = disabledIfaceNames
-        ? new Set(disabledIfaceNames.map((n) => n.toLowerCase()))
-        : undefined;
       const baseSlots = showPowerControls
         ? resolved.slots
         : resolved.slots.filter((s) => s.kind !== 'power' && s.kind !== 'reset');
-      return { descriptor: resolved, slots: mapPorts(baseSlots, interfaces, disabled, ifaceRates) };
-    }, [model, interfaces, disabledIfaceNames, showPowerControls, ifaceRates]);
+      return { descriptor: resolved, slots: mapPorts(baseSlots, interfaces, ifaceRates) };
+    }, [model, interfaces, showPowerControls, ifaceRates]);
 
     const Panel = PANEL_REGISTRY[descriptor.key];
 

--- a/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
+++ b/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
@@ -15,7 +15,7 @@ export interface RouterPortDiagramCardProps {
 }
 
 export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React.memo(
-  function RouterPortDiagramCard({
+  function RouterPortDiagramCardInner({
     model,
     interfaces,
     onPower,

--- a/frontend/src/routes/overview-panel/mapPorts.ts
+++ b/frontend/src/routes/overview-panel/mapPorts.ts
@@ -60,7 +60,6 @@ const deriveStatus = (iface: InterfaceResponse | undefined): PortStatus => {
 export function mapPorts(
   slots: PortSlot[],
   interfaces: InterfaceResponse[],
-  disabledIfaceNames?: ReadonlySet<string>,
   ifaceRates?: Readonly<Record<string, string>>,
 ): ResolvedSlot[] {
   return slots.map((slot) => {
@@ -75,9 +74,7 @@ export function mapPorts(
       };
     }
     const iface = findIface(interfaces, slot.ifaceName);
-    const forcedDisabled =
-      !!slot.ifaceName && !!disabledIfaceNames?.has(slot.ifaceName.toLowerCase());
-    const status = forcedDisabled ? 'disabled' : deriveStatus(iface);
+    const status = deriveStatus(iface);
     const name = slot.ifaceName ?? slot.id;
     const rxLabel = iface?.rx;
     const txLabel = iface?.tx;
@@ -98,7 +95,7 @@ export function mapPorts(
     return {
       ...slot,
       status,
-      interactive: !forcedDisabled,
+      interactive: true,
       tooltip,
       rxLabel,
       txLabel,

--- a/frontend/src/routes/overview-panel/uplinks.ts
+++ b/frontend/src/routes/overview-panel/uplinks.ts
@@ -47,10 +47,6 @@ function classify(iface: InterfaceResponse): UplinkMatch {
   return matchUplink(iface) ?? { kind: 'ether', label: iface.name.toUpperCase() };
 }
 
-export function wanInterfaceNames(interfaces: InterfaceResponse[]): string[] {
-  return interfaces.filter((i) => i.type === 'ether' && matchUplink(i) !== null).map((i) => i.name);
-}
-
 export function wanInterfaces(interfaces: InterfaceResponse[]): InterfaceResponse[] {
   const ether = interfaces.filter((i) => i.type === 'ether' && !i.disabled);
   const hinted = ether.filter((i) => matchUplink(i) !== null);

--- a/frontend/tests/e2e/19-dhcp-page.spec.ts
+++ b/frontend/tests/e2e/19-dhcp-page.spec.ts
@@ -28,7 +28,7 @@ test.describe('LAN page (DHCP + port diagram)', () => {
     await expect(clients).toContainText('10.0.0.42');
   });
 
-  test('shows the port diagram with WAN ports greyed and LAN port info', async ({
+  test('shows the port diagram with live port statuses', async ({
     page,
     resetMocks,
     seedRouter,
@@ -45,8 +45,10 @@ test.describe('LAN page (DHCP + port diagram)', () => {
     await expect(page.getByTestId('port-diagram')).toBeVisible();
     await expect(page.getByTestId('panel-model')).toHaveText('MikroTik hAP ax3');
 
-    // ether1 has comment "WAN uplink" -> greyed + disabled.
-    await expect(page.getByTestId('port-ether1')).toHaveAttribute('data-status', 'disabled');
+    // ether1 has comment "WAN uplink" but is running -> shows its real status, like Overview.
+    await expect(page.getByTestId('port-ether1')).toHaveAttribute('data-status', 'up');
+    // ether3 is administratively disabled -> greyed.
+    await expect(page.getByTestId('port-ether3')).toHaveAttribute('data-status', 'disabled');
     // ether2 is a LAN port -> live, with info exposed via the hover-card tooltip.
     await expect(page.getByTestId('port-ether2')).toHaveAttribute('data-status', 'up');
     await expect(page.getByTestId('port-ether2')).toHaveAttribute('aria-label', /ether2.*up/i);


### PR DESCRIPTION
Closes #405

## Summary
- LAN page greyed out any port whose comment looked WAN-ish, hiding its real link state
- ports now show live status, rate, and tooltip exactly like the overview diagram
- power and reset slots stay hidden on the LAN page as before