### PR TITLE
feat(fe): match the new WAN update API

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ export {
   fetchEthernetInterfaces,
   updateWanInterface,
   type WanInterfaceType,
+  type UpdateWanInterfaceRequest,
   fetchForeignGateway,
   updateForeignGateway,
   type ForeignGatewayResponse,

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -167,18 +167,24 @@ export async function fetchEthernetInterfaces(
 
 export type WanInterfaceType = 'foreign' | 'domestic';
 
+export interface UpdateWanInterfaceRequest {
+  interface: string;
+  type: WanInterfaceType;
+  ssid?: string;
+  password?: string;
+}
+
 export async function updateWanInterface(
   creds: SystemCredentials,
-  name: string,
-  type: WanInterfaceType,
+  request: UpdateWanInterfaceRequest,
 ): Promise<void> {
-  await apiRequest<unknown>(`/api/interface/wan/${encodeURIComponent(name)}`, {
+  await apiRequest<unknown>('/api/interface/wan', {
     method: 'PUT',
     headers: {
       ...authHeaders(creds),
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ type }),
+    body: JSON.stringify(request),
   });
 }
 

--- a/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
+++ b/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
@@ -1,13 +1,20 @@
 import { useMemo, useReducer, useState } from 'react';
 import { Button, Dialog, FieldStack, FormError } from '@nasnet/ui';
 import type { InterfaceResponse } from '../../../api';
-import { initial, reducer } from '../../easy-config/state';
+import { initial, reducer, type State } from '../../easy-config/state';
 import {
   WanInterfaceSelect,
   availableInterfaceTypes,
+  classifyInterface,
 } from '../../easy-config/steps/wan/WanInterfaceSelect';
 
 type Variant = 'foreign' | 'domestic';
+
+export interface WanUplinkValues {
+  interfaceName: string;
+  ssid?: string;
+  password?: string;
+}
 
 interface Props {
   variant: Variant;
@@ -15,8 +22,9 @@ interface Props {
   interfaces: InterfaceResponse[];
   excludeNames?: string[];
   interfacesLoading?: boolean;
+  initialInterface?: InterfaceResponse;
   onCancel: () => void;
-  onSubmit: (interfaceName: string) => Promise<void>;
+  onSubmit: (values: WanUplinkValues) => Promise<void>;
 }
 
 const FIELD_MAP = {
@@ -46,11 +54,19 @@ export function WanUplinkDialog({
   interfaces,
   excludeNames,
   interfacesLoading,
+  initialInterface,
   onCancel,
   onSubmit,
 }: Props) {
   const fields = FIELD_MAP[variant];
-  const [state, dispatch] = useReducer(reducer, initial);
+  const [state, dispatch] = useReducer(reducer, initial, (base): State => {
+    if (!initialInterface) return base;
+    return {
+      ...base,
+      [fields.typeField]: classifyInterface(initialInterface) ?? 'ethernet',
+      [fields.nameField]: initialInterface.name,
+    };
+  });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const availableTypes = useMemo(() => availableInterfaceTypes(interfaces), [interfaces]);
@@ -59,14 +75,20 @@ export function WanUplinkDialog({
     return interfaces.filter((i) => !excluded.has(i.name));
   }, [interfaces, excludeNames]);
   const chosen = state[fields.nameField];
-  const canSubmit = chosen !== '' && !submitting;
+  const wireless = state[fields.typeField] === 'wireless';
+  const ssid = state[fields.ssidField];
+  const canSubmit = chosen !== '' && (!wireless || ssid !== '') && !submitting;
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setError(null);
     setSubmitting(true);
     try {
-      await onSubmit(chosen);
+      await onSubmit({
+        interfaceName: chosen,
+        ssid: wireless ? ssid : undefined,
+        password: wireless ? state[fields.passwordField] : undefined,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save uplink.');
       setSubmitting(false);
@@ -81,6 +103,7 @@ export function WanUplinkDialog({
       onClose={submitting ? () => undefined : onCancel}
       title={title}
       size="sm"
+      labelledBy="wan-uplink-title"
       footer={
         <>
           <Button variant="ghost" onClick={onCancel} disabled={submitting}>

--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -10,8 +10,9 @@ import {
 import { useSession } from '../../../state/SessionContext';
 import { useRouter } from '../../../state/RouterStoreContext';
 import { SectionHeader } from '../../vpn/sections/SectionHeader';
+import { classifyInterface } from '../../easy-config/steps/wan/WanInterfaceSelect';
 import { WanTable } from '../WanTable';
-import { WanUplinkDialog } from '../dialogs/WanUplinkDialog';
+import { WanUplinkDialog, type WanUplinkValues } from '../dialogs/WanUplinkDialog';
 
 interface Props {
   routerId: string;
@@ -44,10 +45,10 @@ export function DomesticUplinkSection({
     return { host, ...creds };
   };
 
-  // const openAdd = () => setDialogOpen(true);
+  const openAdd = () => setDialogOpen(true);
   const closeDialog = () => setDialogOpen(false);
 
-  const onSubmit = async (interfaceName: string) => {
+  const onSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
     const creds = resolveCreds();
     if (!creds) {
       toast.notify({
@@ -58,7 +59,12 @@ export function DomesticUplinkSection({
       return;
     }
     try {
-      await updateWanInterface(creds, interfaceName, 'domestic');
+      await updateWanInterface(creds, {
+        interface: interfaceName,
+        type: 'domestic',
+        ssid,
+        password,
+      });
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -92,7 +98,7 @@ export function DomesticUplinkSection({
     }
     setMoveSubmitting(true);
     try {
-      await updateWanInterface(creds, target.name, 'foreign');
+      await updateWanInterface(creds, { interface: target.name, type: 'foreign' });
     } catch (err) {
       toast.notify({
         title: 'Failed to move uplink',
@@ -108,13 +114,31 @@ export function DomesticUplinkSection({
     onChanged();
   };
 
+  const moveWireless = pendingMove ? classifyInterface(pendingMove) === 'wireless' : false;
+
+  const onMoveSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
+    const creds = resolveCreds();
+    if (!creds) {
+      toast.notify({
+        title: 'Missing router credentials',
+        description: 'Reconnect to the router and try again.',
+        tone: 'danger',
+      });
+      return;
+    }
+    await updateWanInterface(creds, { interface: interfaceName, type: 'foreign', ssid, password });
+    setPendingMove(null);
+    toast.notify({ title: `Moved "${interfaceName}" to Foreign`, tone: 'info' });
+    onChanged();
+  };
+
   return (
     <Stack>
       <Card>
         <SectionHeader
           title="Domestic"
           description="Interfaces tagged as the domestic uplink."
-          // action={{ label: 'New', onClick: openAdd }}
+          action={{ label: 'New', onClick: openAdd }}
         />
         <WanTable
           rows={items}
@@ -140,8 +164,18 @@ export function DomesticUplinkSection({
           onSubmit={onSubmit}
         />
       ) : null}
+      {pendingMove && moveWireless ? (
+        <WanUplinkDialog
+          variant="foreign"
+          title={`Move ${pendingMove.name} to Foreign`}
+          interfaces={[pendingMove]}
+          initialInterface={pendingMove}
+          onCancel={() => setPendingMove(null)}
+          onSubmit={onMoveSubmit}
+        />
+      ) : null}
       <ConfirmDialog
-        open={!!pendingMove}
+        open={!!pendingMove && !moveWireless}
         title="Move to Foreign"
         description={
           pendingMove

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -10,8 +10,9 @@ import {
 import { useSession } from '../../../state/SessionContext';
 import { useRouter } from '../../../state/RouterStoreContext';
 import { SectionHeader } from '../../vpn/sections/SectionHeader';
+import { classifyInterface } from '../../easy-config/steps/wan/WanInterfaceSelect';
 import { WanTable } from '../WanTable';
-import { WanUplinkDialog } from '../dialogs/WanUplinkDialog';
+import { WanUplinkDialog, type WanUplinkValues } from '../dialogs/WanUplinkDialog';
 
 interface Props {
   routerId: string;
@@ -44,10 +45,10 @@ export function StarlinkSection({
     return { host, ...creds };
   };
 
-  // const openAdd = () => setDialogOpen(true);
+  const openAdd = () => setDialogOpen(true);
   const closeDialog = () => setDialogOpen(false);
 
-  const onSubmit = async (interfaceName: string) => {
+  const onSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
     const creds = resolveCreds();
     if (!creds) {
       toast.notify({
@@ -58,7 +59,12 @@ export function StarlinkSection({
       return;
     }
     try {
-      await updateWanInterface(creds, interfaceName, 'foreign');
+      await updateWanInterface(creds, {
+        interface: interfaceName,
+        type: 'foreign',
+        ssid,
+        password,
+      });
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -92,7 +98,7 @@ export function StarlinkSection({
     }
     setMoveSubmitting(true);
     try {
-      await updateWanInterface(creds, target.name, 'domestic');
+      await updateWanInterface(creds, { interface: target.name, type: 'domestic' });
     } catch (err) {
       toast.notify({
         title: 'Failed to move uplink',
@@ -108,13 +114,31 @@ export function StarlinkSection({
     onChanged();
   };
 
+  const moveWireless = pendingMove ? classifyInterface(pendingMove) === 'wireless' : false;
+
+  const onMoveSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
+    const creds = resolveCreds();
+    if (!creds) {
+      toast.notify({
+        title: 'Missing router credentials',
+        description: 'Reconnect to the router and try again.',
+        tone: 'danger',
+      });
+      return;
+    }
+    await updateWanInterface(creds, { interface: interfaceName, type: 'domestic', ssid, password });
+    setPendingMove(null);
+    toast.notify({ title: `Moved "${interfaceName}" to Domestic`, tone: 'info' });
+    onChanged();
+  };
+
   return (
     <Stack>
       <Card>
         <SectionHeader
           title="Foreign / Starlink"
           description="Interfaces tagged as the foreign (Starlink) uplink."
-          // action={{ label: 'New', onClick: openAdd }}
+          action={{ label: 'New', onClick: openAdd }}
         />
         <WanTable
           rows={items}
@@ -140,8 +164,18 @@ export function StarlinkSection({
           onSubmit={onSubmit}
         />
       ) : null}
+      {pendingMove && moveWireless ? (
+        <WanUplinkDialog
+          variant="domestic"
+          title={`Move ${pendingMove.name} to Domestic`}
+          interfaces={[pendingMove]}
+          initialInterface={pendingMove}
+          onCancel={() => setPendingMove(null)}
+          onSubmit={onMoveSubmit}
+        />
+      ) : null}
       <ConfirmDialog
-        open={!!pendingMove}
+        open={!!pendingMove && !moveWireless}
         title="Move to Domestic"
         description={
           pendingMove

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -255,7 +255,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(0).click();
+    await page.getByRole('button', { name: 'New' }).nth(2).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
@@ -350,7 +350,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(0).click();
+    await page.getByRole('button', { name: 'New' }).nth(2).click();
     const dialog = page.getByRole('dialog');
     await dialog.getByLabel('Name').fill('home-l2tp');
     await dialog.getByLabel('Connect to').fill('vpn.example.com');

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -3,9 +3,7 @@ import type { BrowserContext, Page } from '@playwright/test';
 
 const ROUTER_ID = 'rtr_wan';
 
-// "New" button order in WanPage: 0 Starlink Masking VPN Client.
-// The Starlink and Domestic add buttons are hidden for this release; when they come back
-// the order becomes 0 Starlink, 1 Domestic, 2 Starlink Masking VPN Client.
+// "New" button order in WanPage: 0 Starlink, 1 Domestic, 2 Starlink Masking VPN Client.
 const newButton = (page: Page, index: number) =>
   page.getByRole('button', { name: 'New' }).nth(index);
 
@@ -37,7 +35,9 @@ interface WanRouteState {
     linkDowns: number;
     comment?: string;
   }>;
-  wanPuts: Array<{ name: string; body: { type: string } }>;
+  wanPuts: Array<{
+    body: { interface: string; type: string; ssid?: string; password?: string };
+  }>;
   vpnPuts: Array<{ name: string; body: Record<string, unknown> }>;
   l2tpPosts: Array<Record<string, unknown>>;
   wgImports: Array<Record<string, unknown>>;
@@ -66,19 +66,31 @@ const setupWanRoutes = async (context: BrowserContext, state: WanRouteState) => 
     });
   });
 
-  await context.route('**/api/interface/wan/*', async (route) => {
+  await context.route('**/api/interface/wan', async (route) => {
     if (route.request().method() !== 'PUT') return route.fallback();
-    const name = decodeURIComponent(route.request().url().split('/').pop() ?? '');
-    const body = route.request().postDataJSON() as { type: 'foreign' | 'domestic' };
-    state.wanPuts.push({ name, body });
+    const body = route.request().postDataJSON() as {
+      interface: string;
+      type: 'foreign' | 'domestic';
+      ssid?: string;
+      password?: string;
+    };
+    state.wanPuts.push({ body });
     const comment =
       body.type === 'foreign' ? 'WAN - Foreign Link(Foreign)' : 'WAN - Domestic Link(Domestic)';
-    const idx = state.interfaces.findIndex((i) => i.name === name);
+    const idx = state.interfaces.findIndex((i) => i.name === body.interface);
     if (idx >= 0) state.interfaces[idx] = { ...state.interfaces[idx], comment };
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: envelope({ name, type: body.type, comment }),
+      body: envelope({ interface: body.interface, type: body.type }),
+    });
+  });
+
+  await context.route('**/api/wifi/scan/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: envelope([{ ssid: 'CafeNet', security: 'wpa2', signal: '-48' }]),
     });
   });
 
@@ -223,8 +235,7 @@ test.describe('WAN tab', () => {
     await expect(page.getByText('No VPN clients yet.')).toBeVisible();
   });
 
-  // Skipped while the WAN uplink "New" buttons are hidden.
-  test.skip('add a Starlink uplink via real BE and move it to Domestic', async ({
+  test('add a Starlink uplink via real BE and move it to Domestic', async ({
     page,
     context,
     resetMocks,
@@ -246,7 +257,7 @@ test.describe('WAN tab', () => {
     await dialog.getByRole('button', { name: /^save$/i }).click();
 
     await expect.poll(() => state.wanPuts.length).toBe(1);
-    expect(state.wanPuts[0]).toMatchObject({ name: 'ether1', body: { type: 'foreign' } });
+    expect(state.wanPuts[0]).toMatchObject({ body: { interface: 'ether1', type: 'foreign' } });
 
     await expect(page.getByRole('cell', { name: 'ether1', exact: true })).toBeVisible();
 
@@ -258,11 +269,55 @@ test.describe('WAN tab', () => {
       .click();
 
     await expect.poll(() => state.wanPuts.length).toBe(2);
-    expect(state.wanPuts[1]).toMatchObject({ name: 'ether1', body: { type: 'domestic' } });
+    expect(state.wanPuts[1]).toMatchObject({ body: { interface: 'ether1', type: 'domestic' } });
   });
 
-  // Skipped while the WAN uplink "New" buttons are hidden.
-  test.skip('already-tagged interface is excluded from the add picker', async ({
+  test('add a wireless Starlink uplink sends ssid and password', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'WAN Router' });
+    await setSessionCreds(context, ROUTER_ID);
+    const state = blankState();
+    state.interfaces.push({
+      id: '*3',
+      name: 'wifi1',
+      type: 'wifi',
+      running: true,
+      disabled: false,
+    });
+    await setupWanRoutes(context, state);
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    await newButton(page, 0).click();
+    const dialog = page.getByRole('dialog', { name: 'Add Starlink uplink' });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('radio', { name: 'Wireless' }).click();
+    await dialog.getByLabel('Starlink WAN').click();
+    await page.getByRole('option', { name: 'wifi1' }).click();
+    await dialog.getByRole('button', { name: 'Choose wireless network' }).click();
+
+    const scanDialog = page.getByRole('dialog', { name: 'Choose a wireless network' });
+    await expect(scanDialog).toBeVisible();
+    await scanDialog.getByLabel('Wireless network').click();
+    await page.getByRole('option', { name: /CafeNet/ }).click();
+    await scanDialog.getByLabel('Wireless password').fill('secret-pass');
+    await scanDialog.getByRole('button', { name: 'Verify and connect' }).click();
+    await expect(scanDialog).toBeHidden();
+
+    await dialog.getByRole('button', { name: /^save$/i }).click();
+
+    await expect.poll(() => state.wanPuts.length).toBe(1);
+    expect(state.wanPuts[0]).toMatchObject({
+      body: { interface: 'wifi1', type: 'foreign', ssid: 'CafeNet', password: 'secret-pass' },
+    });
+  });
+
+  test('already-tagged interface is excluded from the add picker', async ({
     page,
     context,
     resetMocks,
@@ -298,7 +353,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 0).click();
+    await newButton(page, 2).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 


### PR DESCRIPTION
Closes #412

## Summary
- send WAN uplink changes in the new request format with the interface in the body
- include SSID and password when a wifi interface is selected, chosen via the wireless scan dialog
- bring back the New uplink buttons hidden in #361 and re-enable the skipped e2e tests