### PR TITLE
feat(be): Introduced plugin system

### DIFF
--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -28,7 +28,7 @@ const (
 )
 
 // pluginInstallPhase enumerates the stages of an async plugin installation,
-// tracked in-process so GET /api/plugin/status/{taskId} has something to
+// tracked in-process so GET /api/plugin/status/{pluginId} has something to
 // report while the background goroutine runs independently of the request
 // that started it.
 type pluginInstallPhase string
@@ -46,10 +46,10 @@ const (
 	pluginInstallPhaseError              pluginInstallPhase = "error"
 )
 
-// pluginInstallTask tracks one in-flight (or completed) async installation.
+// pluginInstallTask tracks one in-flight (or completed) async installation,
+// identified by the id of the plugin being installed.
 type pluginInstallTask struct {
 	mu          sync.RWMutex
-	taskID      string
 	pluginID    string
 	phase       pluginInstallPhase
 	message     string
@@ -84,7 +84,6 @@ func (t *pluginInstallTask) snapshot() PluginInstallStatusResponse {
 	defer t.mu.RUnlock()
 
 	return PluginInstallStatusResponse{
-		TaskID:      t.taskID,
 		PluginID:    t.pluginID,
 		Phase:       string(t.phase),
 		Message:     t.message,
@@ -94,9 +93,10 @@ func (t *pluginInstallTask) snapshot() PluginInstallStatusResponse {
 	}
 }
 
-// pluginInstallPool tracks every plugin installation task, keyed by task ID.
-// One plugin id may have at most one non-terminal task at a time; different
-// plugin ids may install concurrently.
+// pluginInstallPool tracks every plugin installation task, keyed by plugin id.
+// At most one install per plugin may be in flight, so a plugin id is enough to
+// identify its task. Different plugins may install concurrently, and
+// re-installing a plugin replaces its previous, finished task.
 type pluginInstallPool struct {
 	mu    sync.RWMutex
 	tasks map[string]*pluginInstallTask
@@ -107,15 +107,10 @@ var pluginInstalls = &pluginInstallPool{tasks: make(map[string]*pluginInstallTas
 // activeLocked reports whether pluginID has a non-terminal task in flight.
 // Callers must already hold p.mu, since sync.RWMutex is not reentrant.
 func (p *pluginInstallPool) activeLocked(pluginID string) bool {
-	for _, t := range p.tasks {
-		t.mu.RLock()
-		samePlugin := t.pluginID == pluginID
-		t.mu.RUnlock()
-		if samePlugin && !t.terminal() {
-			return true
-		}
-	}
-	return false
+	// A missing key yields a nil pointer, so the nil check doubles as the
+	// "no such task" check.
+	task := p.tasks[pluginID]
+	return task != nil && !task.terminal()
 }
 
 // active reports whether pluginID is currently being installed.
@@ -135,16 +130,13 @@ func (p *pluginInstallPool) start(pluginID string) (*pluginInstallTask, error) {
 		return nil, fmt.Errorf("plugin %s is already being installed", pluginID)
 	}
 
-	taskID := fmt.Sprintf("%d", time.Now().Unix())
-
 	task := &pluginInstallTask{
-		taskID:    taskID,
 		pluginID:  pluginID,
 		phase:     pluginInstallPhasePreparing,
 		message:   "starting install",
 		startedAt: time.Now(),
 	}
-	p.tasks[taskID] = task
+	p.tasks[pluginID] = task
 	return task, nil
 }
 
@@ -184,7 +176,7 @@ func HandleListPlugins(c echo.Context) error {
 // @Description Starts an async install of a plugin from the community registry:
 // @Description creates the veth interface its manifest specifies (if not already
 // @Description present), creates its mounts, and adds its container, then waits for
-// @Description the image to finish pulling. Poll GET /api/plugin/status/{taskId} for
+// @Description the image to finish pulling. Poll GET /api/plugin/status/{pluginId} for
 // @Description progress. At most one install per plugin id may run at a time;
 // @Description different plugins may install concurrently.
 // @Tags Plugin
@@ -235,8 +227,8 @@ func HandleInstallPlugin(c echo.Context) error {
 	go installPluginAsync(client, task)
 
 	return SuccessResponse(c, http.StatusOK, "Plugin installation started", InstallPluginResponse{
-		ID:     req.ID,
-		TaskID: task.taskID,
+		ID:       req.ID,
+		PluginID: task.pluginID,
 	})
 }
 
@@ -439,20 +431,21 @@ func startPluginContainer(ctx context.Context, client *routeros.Client, task *pl
 // @Tags Plugin
 // @Security BasicAuth
 // @Param X-RouterOS-Host header string true "RouterOS host address"
-// @Param taskId path string true "Task ID returned by POST /api/plugin/install"
+// @Param pluginId path string true "Plugin id passed to POST /api/plugin/install"
 // @Produce json
 // @Success 200 {object} Response{data=PluginInstallStatusResponse}
 // @Failure 404 {object} Response
-// @Router /api/plugin/status/{taskId} [get].
+// @Router /api/plugin/status/{pluginId} [get].
 func HandleGetPluginInstallStatus(c echo.Context) error {
-	taskID := c.Param("taskId")
+	pluginID := c.Param("pluginId")
 
 	pluginInstalls.mu.RLock()
-	task, ok := pluginInstalls.tasks[taskID]
+	task, ok := pluginInstalls.tasks[pluginID]
 	pluginInstalls.mu.RUnlock()
 
 	if !ok {
-		return ErrorResponse(c, http.StatusNotFound, "Unknown installation task", fmt.Errorf("no task with id %s", taskID))
+		return ErrorResponse(c, http.StatusNotFound, "Unknown installation task",
+			fmt.Errorf("no installation task for plugin %s", pluginID))
 	}
 
 	return SuccessResponse(c, http.StatusOK, "Installation status retrieved", task.snapshot())

--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -20,12 +20,26 @@ const pluginRegistryURL = "https://raw.githubusercontent.com/nasnet-community/na
 
 const (
 	pluginInstallPollInterval = 3 * time.Second
-	pluginInstallTimeout      = 20 * time.Minute
+	pluginInstallTimeout      = 5 * time.Minute
 
 	// Grace period between stopping a plugin's container and removing it, so
 	// RouterOS has finished the stop before the remove is issued.
 	pluginUninstallStopDelay = 2 * time.Second
+
+	// Ceiling on a single registry fetch. Manifests, settings schemas and
+	// scripts are a few KB each, so this is generous; it exists because an
+	// install runs detached from any request, and a registry host that accepts
+	// the connection then never finishes the response would otherwise leave the
+	// install goroutine blocked forever. Its task would never reach a terminal
+	// phase, and the plugin could not be installed again until the panel
+	// restarts.
+	pluginFetchTimeout = 30 * time.Second
 )
+
+// pluginHTTPClient fetches from the plugin registry. Deliberately not
+// http.DefaultClient, whose Timeout is zero, meaning no bound at all on the
+// whole exchange — dial, TLS, headers and body read included.
+var pluginHTTPClient = &http.Client{Timeout: pluginFetchTimeout}
 
 // pluginInstallPhase enumerates the stages of an async plugin installation,
 // tracked in-process so GET /api/plugin/status/{pluginId} has something to
@@ -234,8 +248,9 @@ func HandleInstallPlugin(c echo.Context) error {
 
 // installPluginAsync performs the actual install steps for task, updating its
 // phase/message as it progresses. Runs detached from the HTTP request that
-// triggered it, so it uses its own context and timeout rather than the
-// request's.
+// triggered it, so it takes a background context rather than the request's,
+// which would be cancelled the moment that request returned. Registry fetches
+// are bounded by pluginHTTPClient's own timeout instead of by this context.
 func installPluginAsync(client *routeros.Client, task *pluginInstallTask) {
 	pluginID := task.pluginID
 	ctx := context.Background()
@@ -583,7 +598,7 @@ func fetchPluginJSON(ctx context.Context, url string, target any) error {
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pluginHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -625,7 +640,7 @@ func fetchPluginScript(ctx context.Context, id, scriptPath string) (string, erro
 		return "", err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pluginHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -1,0 +1,680 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"nasnet-panel/pkg/routeros"
+
+	"github.com/labstack/echo/v4"
+)
+
+const pluginRegistryURL = "https://raw.githubusercontent.com/nasnet-community/nasnet-panel-plugins/main/plugins.json"
+
+const (
+	pluginInstallPollInterval = 3 * time.Second
+	pluginInstallTimeout      = 20 * time.Minute
+
+	// Grace period between stopping a plugin's container and removing it, so
+	// RouterOS has finished the stop before the remove is issued.
+	pluginUninstallStopDelay = 2 * time.Second
+)
+
+// pluginInstallPhase enumerates the stages of an async plugin installation,
+// tracked in-process so GET /api/plugin/status/{taskId} has something to
+// report while the background goroutine runs independently of the request
+// that started it.
+type pluginInstallPhase string
+
+const (
+	pluginInstallPhasePreparing          pluginInstallPhase = "preparing"
+	pluginInstallPhaseCreatingInterface  pluginInstallPhase = "creating_interface"
+	pluginInstallPhaseCreatingMounts     pluginInstallPhase = "creating_mounts"
+	pluginInstallPhaseRunningPreInstall  pluginInstallPhase = "running_pre_install_script"
+	pluginInstallPhaseCreatingContainer  pluginInstallPhase = "creating_container"
+	pluginInstallPhasePulling            pluginInstallPhase = "pulling"
+	pluginInstallPhaseStartingContainer  pluginInstallPhase = "starting_container"
+	pluginInstallPhaseRunningPostInstall pluginInstallPhase = "running_post_install_script"
+	pluginInstallPhaseDone               pluginInstallPhase = "done"
+	pluginInstallPhaseError              pluginInstallPhase = "error"
+)
+
+// pluginInstallTask tracks one in-flight (or completed) async installation.
+type pluginInstallTask struct {
+	mu          sync.RWMutex
+	taskID      string
+	pluginID    string
+	phase       pluginInstallPhase
+	message     string
+	startedAt   time.Time
+	containerID string
+	iface       string
+}
+
+func (t *pluginInstallTask) set(phase pluginInstallPhase, message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.phase = phase
+	t.message = message
+}
+
+func (t *pluginInstallTask) setContainer(containerID, iface string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.containerID = containerID
+	t.iface = iface
+}
+
+// terminal reports whether the task has finished, one way or another.
+func (t *pluginInstallTask) terminal() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.phase == pluginInstallPhaseDone || t.phase == pluginInstallPhaseError
+}
+
+func (t *pluginInstallTask) snapshot() PluginInstallStatusResponse {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return PluginInstallStatusResponse{
+		TaskID:      t.taskID,
+		PluginID:    t.pluginID,
+		Phase:       string(t.phase),
+		Message:     t.message,
+		StartedAt:   t.startedAt.Format(time.RFC3339),
+		ContainerID: t.containerID,
+		Interface:   t.iface,
+	}
+}
+
+// pluginInstallPool tracks every plugin installation task, keyed by task ID.
+// One plugin id may have at most one non-terminal task at a time; different
+// plugin ids may install concurrently.
+type pluginInstallPool struct {
+	mu    sync.RWMutex
+	tasks map[string]*pluginInstallTask
+}
+
+var pluginInstalls = &pluginInstallPool{tasks: make(map[string]*pluginInstallTask)}
+
+// activeLocked reports whether pluginID has a non-terminal task in flight.
+// Callers must already hold p.mu, since sync.RWMutex is not reentrant.
+func (p *pluginInstallPool) activeLocked(pluginID string) bool {
+	for _, t := range p.tasks {
+		t.mu.RLock()
+		samePlugin := t.pluginID == pluginID
+		t.mu.RUnlock()
+		if samePlugin && !t.terminal() {
+			return true
+		}
+	}
+	return false
+}
+
+// active reports whether pluginID is currently being installed.
+func (p *pluginInstallPool) active(pluginID string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.activeLocked(pluginID)
+}
+
+// start registers a new task for pluginID, rejecting it if pluginID already
+// has a non-terminal task in flight.
+func (p *pluginInstallPool) start(pluginID string) (*pluginInstallTask, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.activeLocked(pluginID) {
+		return nil, fmt.Errorf("plugin %s is already being installed", pluginID)
+	}
+
+	taskID := fmt.Sprintf("%d", time.Now().Unix())
+
+	task := &pluginInstallTask{
+		taskID:    taskID,
+		pluginID:  pluginID,
+		phase:     pluginInstallPhasePreparing,
+		message:   "starting install",
+		startedAt: time.Now(),
+	}
+	p.tasks[taskID] = task
+	return task, nil
+}
+
+// HandleListPlugins godoc
+// @Summary List available plugins
+// @Description Fetches the community plugin registry and returns the list of available
+// @Description plugins, each annotated with installed/running status from the router's
+// @Description own containers (a plugin is installed as a container named after its id).
+// @Tags Plugin
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Produce json
+// @Success 200 {object} Response{data=[]PluginInfo}
+// @Failure 502 {object} Response
+// @Router /api/plugin/plugins [get].
+func HandleListPlugins(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	registry, err := fetchPluginRegistry(c.Request().Context())
+	if err != nil {
+		return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin registry", err)
+	}
+
+	containers, err := client.ListContainers()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list containers", err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Plugins retrieved", finalizePlugins(registry.Plugins, containers))
+}
+
+// HandleInstallPlugin godoc
+// @Summary Install a plugin
+// @Description Starts an async install of a plugin from the community registry:
+// @Description creates the veth interface its manifest specifies (if not already
+// @Description present), creates its mounts, and adds its container, then waits for
+// @Description the image to finish pulling. Poll GET /api/plugin/status/{taskId} for
+// @Description progress. At most one install per plugin id may run at a time;
+// @Description different plugins may install concurrently.
+// @Tags Plugin
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Accept json
+// @Produce json
+// @Param request body InstallPluginRequest true "Plugin to install"
+// @Success 200 {object} Response{data=InstallPluginResponse}
+// @Failure 400 {object} Response
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 502 {object} Response
+// @Router /api/plugin/install [post].
+func HandleInstallPlugin(c echo.Context) error {
+	var req InstallPluginRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+	}
+	if req.ID == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "plugin id is required", nil)
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.GetContainer(req.ID); err == nil {
+		return ErrorResponse(c, http.StatusConflict, "Plugin is already installed",
+			fmt.Errorf("a container named %s already exists", req.ID))
+	}
+
+	registry, err := fetchPluginRegistry(c.Request().Context())
+	if err != nil {
+		return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin registry", err)
+	}
+	if !registryHasPlugin(registry, req.ID) {
+		return ErrorResponse(c, http.StatusNotFound, "Plugin not found in registry",
+			fmt.Errorf("no plugin with id %s in the registry", req.ID))
+	}
+
+	task, err := pluginInstalls.start(req.ID)
+	if err != nil {
+		return ErrorResponse(c, http.StatusConflict, "Plugin installation already in progress", err)
+	}
+
+	go installPluginAsync(client, task)
+
+	return SuccessResponse(c, http.StatusOK, "Plugin installation started", InstallPluginResponse{
+		ID:     req.ID,
+		TaskID: task.taskID,
+	})
+}
+
+// installPluginAsync performs the actual install steps for task, updating its
+// phase/message as it progresses. Runs detached from the HTTP request that
+// triggered it, so it uses its own context and timeout rather than the
+// request's.
+func installPluginAsync(client *routeros.Client, task *pluginInstallTask) {
+	pluginID := task.pluginID
+	ctx := context.Background()
+
+	manifest, err := fetchPluginManifest(ctx, pluginID)
+	if err != nil {
+		task.set(pluginInstallPhaseError, "failed to fetch plugin manifest: "+err.Error())
+		log.Printf("[plugin-install %s] failed to fetch manifest: %v", pluginID, err)
+		return
+	}
+
+	resources, err := client.GetResourceInfo()
+	if err != nil {
+		task.set(pluginInstallPhaseError, "failed to check router architecture: "+err.Error())
+		log.Printf("[plugin-install %s] failed to get resource info: %v", pluginID, err)
+		return
+	}
+	if !supportsArchitecture(manifest.Architectures, resources.Architecture) {
+		task.set(pluginInstallPhaseError, fmt.Sprintf("router architecture %s not supported (plugin supports %s)",
+			resources.Architecture, strings.Join(manifest.Architectures, ", ")))
+		return
+	}
+
+	iface := manifest.Container.Interface
+	if iface.Name == "" {
+		task.set(pluginInstallPhaseError, "plugin manifest is missing a container interface name")
+		return
+	}
+
+	// Settings defaults resolve "{{settings.<key>}}" placeholders (e.g. in env
+	// values); a manifest with no settings schema simply has none to resolve.
+	settingsValues := map[string]string{}
+	if manifest.SettingsSchema != "" {
+		settingsSchema, err := fetchPluginSettings(ctx, pluginID, manifest.SettingsSchema)
+		if err != nil {
+			task.set(pluginInstallPhaseError, "failed to fetch plugin settings schema: "+err.Error())
+			log.Printf("[plugin-install %s] failed to fetch settings: %v", pluginID, err)
+			return
+		}
+		settingsValues, err = settingsDefaults(settingsSchema)
+		if err != nil {
+			task.set(pluginInstallPhaseError, "failed to resolve plugin settings defaults: "+err.Error())
+			log.Printf("[plugin-install %s] failed to resolve settings defaults: %v", pluginID, err)
+			return
+		}
+	}
+
+	task.set(pluginInstallPhaseCreatingInterface, "creating veth interface "+iface.Name)
+	if _, err := client.GetInterface(iface.Name); err != nil {
+		if _, err := client.AddVethInterface(routeros.VethConfig{
+			Name:    iface.Name,
+			Address: iface.Address,
+			Gateway: iface.Gateway,
+		}); err != nil {
+			task.set(pluginInstallPhaseError, "failed to create veth interface: "+err.Error())
+			log.Printf("[plugin-install %s] failed to create veth interface: %v", pluginID, err)
+			return
+		}
+	}
+
+	task.set(pluginInstallPhaseCreatingMounts, "creating container mounts")
+	mountListNames := make([]string, 0, len(manifest.Container.Mounts))
+	for _, mount := range manifest.Container.Mounts {
+		name := strings.TrimSpace(mount.Name)
+		if name == "" {
+			continue // nothing to reference from MountLists without a list name
+		}
+		exists, err := client.ContainerMountExists(name)
+		if err != nil {
+			task.set(pluginInstallPhaseError, "failed to check container mount "+name+": "+err.Error())
+			log.Printf("[plugin-install %s] failed to check mount %s: %v", pluginID, name, err)
+			return
+		}
+		if !exists {
+			if _, err := client.AddContainerMount(name, mount.Src, mount.Dst); err != nil {
+				task.set(pluginInstallPhaseError, "failed to create container mount "+name+": "+err.Error())
+				log.Printf("[plugin-install %s] failed to create mount %s: %v", pluginID, name, err)
+				return
+			}
+		}
+		mountListNames = append(mountListNames, name)
+	}
+
+	if manifest.Scripts.PreInstall != "" {
+		task.set(pluginInstallPhaseRunningPreInstall, "running pre-install script")
+		if err := runPluginScript(ctx, client, pluginID, manifest.Scripts.PreInstall); err != nil {
+			task.set(pluginInstallPhaseError, "pre-install script failed: "+err.Error())
+			log.Printf("[plugin-install %s] pre-install script failed: %v", pluginID, err)
+			return
+		}
+	}
+
+	task.set(pluginInstallPhaseCreatingContainer, "creating container "+pluginID)
+	containerID, err := client.AddContainer(routeros.ContainerConfig{
+		Name:        pluginID,
+		Interface:   iface.Name,
+		RootDir:     "/" + pluginID,
+		RemoteImage: manifest.Container.Image,
+		Env:         joinEnvPairs(resolveEnvPlaceholders(manifest.Container.Env, settingsValues)),
+		MountLists:  strings.Join(mountListNames, ","),
+		Logging:     true,
+		StartOnBoot: false,
+	})
+	if err != nil {
+		task.set(pluginInstallPhaseError, "failed to create plugin container: "+err.Error())
+		log.Printf("[plugin-install %s] failed to create container: %v", pluginID, err)
+		return
+	}
+	task.setContainer(containerID, iface.Name)
+
+	task.set(pluginInstallPhasePulling, "pulling "+manifest.Container.Image)
+
+	deadline := time.Now().Add(pluginInstallTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(pluginInstallPollInterval)
+
+		info, err := client.GetContainer(pluginID)
+		if err != nil {
+			task.set(pluginInstallPhaseError, "lost track of container during pull: "+err.Error())
+			log.Printf("[plugin-install %s] failed to poll container: %v", pluginID, err)
+			return
+		}
+
+		if info.DownloadExtractFailed {
+			msg := info.About
+			if msg == "" {
+				msg = "image pull failed"
+			}
+			task.set(pluginInstallPhaseError, msg)
+			log.Printf("[plugin-install %s] pull failed: %s", pluginID, msg)
+			return
+		}
+
+		if info.DownloadingExtracting {
+			task.set(pluginInstallPhasePulling, "pulling "+info.RemoteImage)
+			continue
+		}
+
+		startPluginContainer(ctx, client, task, pluginID, manifest.Scripts.PostInstall)
+		return
+	}
+
+	task.set(pluginInstallPhaseError, "timed out waiting for image pull to finish")
+}
+
+// startPluginContainer starts a freshly pulled plugin container, waits for it
+// to report itself running, then runs the plugin's post-install script (if
+// any) and marks the task done. Adding a container only downloads/extracts
+// its image; RouterOS never starts a container automatically, so this is a
+// required step, not an optional nicety.
+func startPluginContainer(ctx context.Context, client *routeros.Client, task *pluginInstallTask, pluginID, postInstallScript string) {
+	task.set(pluginInstallPhaseStartingContainer, "starting container "+pluginID)
+	if err := client.StartContainer(pluginID); err != nil {
+		task.set(pluginInstallPhaseError, "failed to start container: "+err.Error())
+		log.Printf("[plugin-install %s] failed to start container: %v", pluginID, err)
+		return
+	}
+
+	deadline := time.Now().Add(pluginInstallTimeout)
+	for {
+		info, err := client.GetContainer(pluginID)
+		if err != nil {
+			task.set(pluginInstallPhaseError, "lost track of container while starting: "+err.Error())
+			log.Printf("[plugin-install %s] failed to poll container while starting: %v", pluginID, err)
+			return
+		}
+		if info.Running || info.Healthy {
+			break
+		}
+		if !time.Now().Before(deadline) {
+			task.set(pluginInstallPhaseError, "timed out waiting for container to start")
+			return
+		}
+		time.Sleep(pluginInstallPollInterval)
+	}
+
+	if postInstallScript != "" {
+		task.set(pluginInstallPhaseRunningPostInstall, "running post-install script")
+		if err := runPluginScript(ctx, client, pluginID, postInstallScript); err != nil {
+			task.set(pluginInstallPhaseError, "post-install script failed: "+err.Error())
+			log.Printf("[plugin-install %s] post-install script failed: %v", pluginID, err)
+			return
+		}
+	}
+
+	task.set(pluginInstallPhaseDone, "plugin installed")
+}
+
+// HandleGetPluginInstallStatus godoc
+// @Summary Get plugin installation status
+// @Description Returns the current phase of an in-progress or completed plugin
+// @Description installation task.
+// @Tags Plugin
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param taskId path string true "Task ID returned by POST /api/plugin/install"
+// @Produce json
+// @Success 200 {object} Response{data=PluginInstallStatusResponse}
+// @Failure 404 {object} Response
+// @Router /api/plugin/status/{taskId} [get].
+func HandleGetPluginInstallStatus(c echo.Context) error {
+	taskID := c.Param("taskId")
+
+	pluginInstalls.mu.RLock()
+	task, ok := pluginInstalls.tasks[taskID]
+	pluginInstalls.mu.RUnlock()
+
+	if !ok {
+		return ErrorResponse(c, http.StatusNotFound, "Unknown installation task", fmt.Errorf("no task with id %s", taskID))
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Installation status retrieved", task.snapshot())
+}
+
+// HandleUninstallPlugin godoc
+// @Summary Uninstall a plugin
+// @Description Removes an installed plugin: runs the preUninstall script from its
+// @Description manifest (if it names one), stops and removes its container, then
+// @Description removes the mount lists and veth interface the manifest declares.
+// @Description Cleanup steps that fail once the container is already gone are
+// @Description reported in the response as warnings rather than failing the request.
+// @Tags Plugin
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param name path string true "Plugin id, which is also its container name"
+// @Produce json
+// @Success 200 {object} Response{data=UninstallPluginResponse}
+// @Failure 400 {object} Response
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 500 {object} Response
+// @Failure 502 {object} Response
+// @Router /api/plugin/plugin/{name} [delete].
+func HandleUninstallPlugin(c echo.Context) error {
+	name := c.Param("name")
+	if name == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "plugin name is required", nil)
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+
+	registry, err := fetchPluginRegistry(ctx)
+	if err != nil {
+		return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin registry", err)
+	}
+	if !registryHasPlugin(registry, name) {
+		return ErrorResponse(c, http.StatusNotFound, "Plugin not found in registry",
+			fmt.Errorf("no plugin with id %s in the registry", name))
+	}
+
+	container, err := client.GetContainer(name)
+	if err != nil {
+		return ErrorResponse(c, http.StatusNotFound, "Plugin is not installed", err)
+	}
+
+	// An install goroutine for this plugin is still creating and polling the
+	// very container about to be removed, so let it finish first.
+	if pluginInstalls.active(name) {
+		return ErrorResponse(c, http.StatusConflict, "Plugin installation is still in progress",
+			fmt.Errorf("plugin %s is currently being installed", name))
+	}
+
+	manifest, err := fetchPluginManifest(ctx, name)
+	if err != nil {
+		return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin manifest", err)
+	}
+
+	warnings := []string{}
+
+	if manifest.Scripts.PreUninstall != "" {
+		// A failing cleanup script must not block the uninstall, or a plugin
+		// with a broken script could never be removed.
+		if err := runPluginScript(ctx, client, name, manifest.Scripts.PreUninstall); err != nil {
+			warnings = append(warnings, "pre-uninstall script failed: "+err.Error())
+			log.Printf("[plugin-uninstall %s] pre-uninstall script failed: %v", name, err)
+		}
+	}
+
+	if err := client.StopContainer(name); err != nil {
+		log.Printf("[plugin-uninstall %s] failed to stop container: %v", name, err)
+		// RouterOS rejects a stop on an already-stopped container, which is
+		// nothing to report; only a container that looked alive is worth a warning.
+		if container.Running || container.Healthy {
+			warnings = append(warnings, "failed to stop container: "+err.Error())
+		}
+	}
+
+	// RouterOS refuses to remove a container it hasn't finished stopping.
+	time.Sleep(pluginUninstallStopDelay)
+
+	if err := client.RemoveContainer(name); err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to remove plugin container", err)
+	}
+
+	removedLists := make([]string, 0, len(manifest.Container.Mounts))
+	seen := make(map[string]bool, len(manifest.Container.Mounts))
+	for i := range manifest.Container.Mounts {
+		listName := strings.TrimSpace(manifest.Container.Mounts[i].Name)
+		if listName == "" || seen[listName] {
+			continue // several mounts may share one list, which is removed whole
+		}
+		seen[listName] = true
+
+		if err := client.RemoveContainerMount(listName); err != nil {
+			warnings = append(warnings, "failed to remove mount list "+listName+": "+err.Error())
+			log.Printf("[plugin-uninstall %s] failed to remove mount list %s: %v", name, listName, err)
+			continue
+		}
+		removedLists = append(removedLists, listName)
+	}
+
+	removedInterface := strings.TrimSpace(manifest.Container.Interface.Name)
+	if removedInterface != "" {
+		if err := client.RemoveVethInterface(removedInterface); err != nil {
+			warnings = append(warnings, "failed to remove veth interface "+removedInterface+": "+err.Error())
+			log.Printf("[plugin-uninstall %s] failed to remove veth interface %s: %v", name, removedInterface, err)
+			removedInterface = ""
+		}
+	}
+
+	message := "Plugin uninstalled"
+	if len(warnings) > 0 {
+		message = "Plugin uninstalled with warnings"
+	}
+
+	return SuccessResponse(c, http.StatusOK, message, UninstallPluginResponse{
+		ID:         name,
+		MountLists: removedLists,
+		Interface:  removedInterface,
+		Warnings:   warnings,
+	})
+}
+
+// fetchPluginJSON fetches url and decodes its body as JSON into target.
+func fetchPluginJSON(ctx context.Context, url string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return fmt.Errorf("empty response fetching %s", url)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned %d", url, resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+// runPluginScript fetches one of the RouterOS scripts a plugin's manifest names
+// and executes it on the router. An empty or whitespace-only script file is a
+// no-op: ExecuteScriptString rejects an empty string, so a plugin shipping a
+// placeholder script file would otherwise fail the whole operation.
+func runPluginScript(ctx context.Context, client *routeros.Client, pluginID, scriptPath string) error {
+	script, err := fetchPluginScript(ctx, pluginID, scriptPath)
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s: %w", scriptPath, err)
+	}
+
+	if strings.TrimSpace(script) == "" {
+		return nil
+	}
+
+	return client.ExecuteScriptString(script)
+}
+
+// fetchPluginScript fetches the raw text of a RouterOS script file (e.g. a
+// preInstall/postInstall entry from a plugin's manifest.json), named relative
+// to the plugin's directory in the registry repository.
+func fetchPluginScript(ctx context.Context, id, scriptPath string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pluginAssetsBaseURL+"/"+id+"/"+scriptPath, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", fmt.Errorf("empty response fetching %s", scriptPath)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s returned %d", scriptPath, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func fetchPluginRegistry(ctx context.Context) (*PluginRegistry, error) {
+	var registry PluginRegistry
+	if err := fetchPluginJSON(ctx, pluginRegistryURL, &registry); err != nil {
+		return nil, err
+	}
+	return &registry, nil
+}
+
+func fetchPluginManifest(ctx context.Context, id string) (*PluginManifest, error) {
+	var manifest PluginManifest
+	if err := fetchPluginJSON(ctx, pluginAssetsBaseURL+"/"+id+"/manifest.json", &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+// fetchPluginSettings fetches a plugin's settings schema, at the filename the
+// plugin's own manifest names via its settingsSchema field (typically
+// "settings.json", but not assumed to always be).
+func fetchPluginSettings(ctx context.Context, id, settingsSchema string) (*PluginSettingsSchema, error) {
+	var schema PluginSettingsSchema
+	if err := fetchPluginJSON(ctx, pluginAssetsBaseURL+"/"+id+"/"+settingsSchema, &schema); err != nil {
+		return nil, err
+	}
+	return &schema, nil
+}

--- a/backend/internal/handler/plugin_dto.go
+++ b/backend/internal/handler/plugin_dto.go
@@ -1,0 +1,335 @@
+package handler
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"nasnet-panel/pkg/routeros"
+)
+
+// Base URL hosting per-plugin assets (such as the icon and manifest) in the
+// community plugin registry repository, keyed by plugin id.
+const pluginAssetsBaseURL = "https://raw.githubusercontent.com/nasnet-community/nasnet-panel-plugins/refs/heads/main/plugins"
+
+// PluginInfo represents a single plugin entry from the community plugin registry.
+type PluginInfo struct {
+	ID         string `json:"id"`
+	Version    string `json:"version"`
+	Name       string `json:"name"`
+	Author     string `json:"author"`
+	Category   string `json:"category"`
+	Tagline    string `json:"tagline"`
+	URL        string `json:"url"`
+	Icon       string `json:"icon"`
+	Installed  bool   `json:"installed"`
+	Running    bool   `json:"running"`
+	Installing bool   `json:"installing"`
+	Failed     bool   `json:"failed"`
+	Note       string `json:"note,omitempty"`
+}
+
+// PluginRegistry is the top-level structure of plugins.json fetched from the
+// community plugin registry repository.
+type PluginRegistry struct {
+	RegistryVersion int          `json:"registryVersion"`
+	Plugins         []PluginInfo `json:"plugins"`
+}
+
+// PluginManifestInterface describes the veth interface a plugin's container
+// is attached to.
+type PluginManifestInterface struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Gateway string `json:"gateway"`
+}
+
+// PluginManifestMount describes one directory a plugin's container mounts.
+// Name groups this entry under a /container/mounts list of the same name.
+type PluginManifestMount struct {
+	Name string `json:"name"`
+	Src  string `json:"src"`
+	Dst  string `json:"dst"`
+}
+
+// PluginManifestPort describes one port a plugin's container publishes.
+// HostPort may be given in the manifest as either a fixed JSON number (e.g.
+// 443) or a string, often a "{{settings.<key>}}" placeholder resolved against
+// the plugin's settings at install time; both forms decode to a string here.
+type PluginManifestPort struct {
+	Protocol      string `json:"protocol"`
+	ContainerPort int    `json:"containerPort"`
+	HostPort      string `json:"hostPort"`
+	Description   string `json:"description"`
+}
+
+// UnmarshalJSON allows HostPort to be given as either a JSON string or a bare
+// JSON number, normalizing either form to a string.
+func (p *PluginManifestPort) UnmarshalJSON(data []byte) error {
+	type alias PluginManifestPort
+	aux := &struct {
+		HostPort json.RawMessage `json:"hostPort"`
+		*alias
+	}{alias: (*alias)(p)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.HostPort) == 0 {
+		return nil
+	}
+
+	var asString string
+	if err := json.Unmarshal(aux.HostPort, &asString); err == nil {
+		p.HostPort = asString
+		return nil
+	}
+
+	var asNumber json.Number
+	if err := json.Unmarshal(aux.HostPort, &asNumber); err != nil {
+		return fmt.Errorf("hostPort must be a string or number: %w", err)
+	}
+	p.HostPort = asNumber.String()
+	return nil
+}
+
+// PluginManifestContainer describes the container a plugin installs.
+type PluginManifestContainer struct {
+	Image     string                  `json:"image"`
+	Interface PluginManifestInterface `json:"interface"`
+	Env       map[string]string       `json:"env"`
+	Mounts    []PluginManifestMount   `json:"mounts"`
+	Ports     []PluginManifestPort    `json:"ports"`
+}
+
+// PluginManifestScripts names RouterOS scripts run at various install and
+// uninstall stages. Paths are relative to the plugin's directory in the
+// registry repository.
+type PluginManifestScripts struct {
+	PreInstall   string `json:"preInstall"`
+	PostInstall  string `json:"postInstall"`
+	PreUninstall string `json:"preUninstall"`
+}
+
+// PluginManifest is the per-plugin manifest.json fetched from the community
+// plugin registry.
+type PluginManifest struct {
+	ID             string                  `json:"id"`
+	Name           string                  `json:"name"`
+	Version        string                  `json:"version"`
+	Author         string                  `json:"author"`
+	License        string                  `json:"license"`
+	Website        string                  `json:"website"`
+	Category       string                  `json:"category"`
+	Tagline        string                  `json:"tagline"`
+	Description    string                  `json:"description"`
+	Icon           string                  `json:"icon"`
+	Architectures  []string                `json:"architectures"`
+	Container      PluginManifestContainer `json:"container"`
+	Scripts        PluginManifestScripts   `json:"scripts"`
+	SettingsSchema string                  `json:"settingsSchema"`
+}
+
+// PluginSettingField describes one configurable setting for a plugin. Default
+// may be a string or a number depending on Type, hence the untyped value.
+type PluginSettingField struct {
+	Key         string   `json:"key"`
+	Label       string   `json:"label"`
+	Type        string   `json:"type"`
+	Options     []string `json:"options,omitempty"`
+	Default     any      `json:"default,omitempty"`
+	Required    bool     `json:"required"`
+	Description string   `json:"description"`
+	Generate    string   `json:"generate,omitempty"`
+}
+
+// PluginSettingsSchema is the per-plugin settings.json fetched from the
+// community plugin registry.
+type PluginSettingsSchema struct {
+	Settings []PluginSettingField `json:"settings"`
+}
+
+// InstallPluginRequest is the request body for POST /api/plugin/install.
+type InstallPluginRequest struct {
+	ID string `json:"id"`
+}
+
+// InstallPluginResponse is the response for POST /api/plugin/install.
+// Installation runs asynchronously; poll GET /api/plugin/status/{taskId} for
+// progress and the resulting container details.
+type InstallPluginResponse struct {
+	ID     string `json:"id"`
+	TaskID string `json:"taskId"`
+}
+
+// UninstallPluginResponse is the response for DELETE /api/plugin/plugin/{name}.
+// Warnings collects cleanup steps that failed after the plugin's container was
+// already removed: the plugin is gone either way, but its mount lists or veth
+// interface may have been left behind.
+type UninstallPluginResponse struct {
+	ID         string   `json:"id"`
+	MountLists []string `json:"mountLists,omitempty"`
+	Interface  string   `json:"interface,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
+// PluginInstallStatusResponse is the response for GET /api/plugin/status/{taskId}.
+type PluginInstallStatusResponse struct {
+	TaskID      string `json:"taskId"`
+	PluginID    string `json:"pluginId"`
+	Phase       string `json:"phase"` // preparing, creating_interface, creating_mounts, running_pre_install_script, creating_container, pulling, starting_container, running_post_install_script, done, error
+	Message     string `json:"message,omitempty"`
+	StartedAt   string `json:"startedAt,omitempty"`
+	ContainerID string `json:"containerId,omitempty"`
+	Interface   string `json:"interface,omitempty"`
+}
+
+// finalizePlugins fills in fields plugins.json itself doesn't carry before a
+// plugin list is returned to the client: Icon (derived from each entry's id),
+// and Installed/Running/Installing/Failed/Note by matching each plugin's id
+// against the name of a container currently on the router (a plugin is
+// installed as a container named after its id). Running is true if the
+// container reports itself as running or as healthy — RouterOS surfaces these
+// as independent flags, and a container can be healthy-checked without ever
+// setting the plain running flag depending on firmware version, so either is
+// treated as "running" here. Installing/Failed mirror the container's
+// DownloadingExtracting/DownloadExtractFailed flags directly. Note carries
+// the container's .about text (e.g. a pull error, or in-progress
+// status) whenever RouterOS has one to report.
+func finalizePlugins(plugins []PluginInfo, containers []routeros.ContainerInfo) []PluginInfo {
+	byName := make(map[string]*routeros.ContainerInfo, len(containers))
+	for i := range containers {
+		byName[containers[i].Name] = &containers[i]
+	}
+
+	result := make([]PluginInfo, len(plugins))
+	for i := range plugins {
+		result[i] = plugins[i]
+		result[i].Icon = pluginAssetsBaseURL + "/" + result[i].ID + "/icon.svg"
+
+		if container, ok := byName[result[i].ID]; ok {
+			result[i].Installed = true
+			result[i].Running = container.Running || container.Healthy
+			result[i].Installing = container.DownloadingExtracting
+			result[i].Failed = container.DownloadExtractFailed
+			if container.About != "" {
+				result[i].Note = container.About
+			}
+		}
+	}
+	return result
+}
+
+// registryHasPlugin reports whether id is a plugin known to the registry.
+func registryHasPlugin(registry *PluginRegistry, id string) bool {
+	for i := range registry.Plugins {
+		if registry.Plugins[i].ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// joinEnvPairs renders a plugin manifest's env map as bare `KEY=VALUE,KEY2=VALUE2`
+// pairs, sorted by key for deterministic output (Go map iteration order is
+// otherwise randomized). A key with an empty value is written as just the
+// bare key, with no trailing "=".
+func joinEnvPairs(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(env))
+	for _, k := range keys {
+		if v := env[k]; v != "" {
+			pairs = append(pairs, k+"="+v)
+		} else {
+			pairs = append(pairs, k)
+		}
+	}
+	return strings.Join(pairs, ",")
+}
+
+// settingsDefaults renders each setting's default value as a string, keyed by
+// its key, for substituting "{{settings.<key>}}" placeholders found elsewhere
+// in a plugin's manifest. A field with no default but "generate":"uuid" gets
+// a freshly generated UUID v4 instead; any other field with neither resolves
+// to an empty string, leaving unresolved-looking placeholders as a visible
+// signal of a manifest/settings mismatch rather than silently failing.
+func settingsDefaults(schema *PluginSettingsSchema) (map[string]string, error) {
+	defaults := make(map[string]string, len(schema.Settings))
+	for i := range schema.Settings {
+		field := &schema.Settings[i]
+		switch {
+		case field.Default != nil:
+			defaults[field.Key] = fmt.Sprintf("%v", field.Default)
+		case field.Generate == "uuid":
+			id, err := generateUUIDv4()
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate value for setting %s: %w", field.Key, err)
+			}
+			defaults[field.Key] = id
+		default:
+			defaults[field.Key] = ""
+		}
+	}
+	return defaults, nil
+}
+
+// resolveSettingsPlaceholders replaces every "{{settings.<key>}}" placeholder
+// in value with defaults[key], leaving placeholders for unknown keys as-is.
+func resolveSettingsPlaceholders(value string, defaults map[string]string) string {
+	for key, val := range defaults {
+		value = strings.ReplaceAll(value, "{{settings."+key+"}}", val)
+	}
+	return value
+}
+
+// resolveEnvPlaceholders returns a copy of env with every value passed through
+// resolveSettingsPlaceholders.
+func resolveEnvPlaceholders(env, defaults map[string]string) map[string]string {
+	resolved := make(map[string]string, len(env))
+	for k, v := range env {
+		resolved[k] = resolveSettingsPlaceholders(v, defaults)
+	}
+	return resolved
+}
+
+// generateUUIDv4 returns a random RFC 4122 version 4 UUID string.
+func generateUUIDv4() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// supportsArchitecture reports whether a plugin manifest's architectures list
+// includes the router's CPU architecture. RouterOS's own architecture-name
+// (from GetResourceInfo) uses "x86" for Intel/AMD devices where manifests use
+// the OCI-style "amd64" for the same platform; "arm"/"arm64" already match
+// between the two, so only that one name needs normalizing before comparing.
+func supportsArchitecture(manifestArchitectures []string, routerArch string) bool {
+	normalized := routerArch
+	if routerArch == "x86" {
+		normalized = "amd64"
+	}
+
+	for _, arch := range manifestArchitectures {
+		if arch == normalized {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/handler/plugin_dto.go
+++ b/backend/internal/handler/plugin_dto.go
@@ -158,11 +158,11 @@ type InstallPluginRequest struct {
 }
 
 // InstallPluginResponse is the response for POST /api/plugin/install.
-// Installation runs asynchronously; poll GET /api/plugin/status/{taskId} for
+// Installation runs asynchronously; poll GET /api/plugin/status/{pluginId} for
 // progress and the resulting container details.
 type InstallPluginResponse struct {
-	ID     string `json:"id"`
-	TaskID string `json:"taskId"`
+	ID       string `json:"id"`
+	PluginID string `json:"pluginId"`
 }
 
 // UninstallPluginResponse is the response for DELETE /api/plugin/plugin/{name}.
@@ -176,9 +176,8 @@ type UninstallPluginResponse struct {
 	Warnings   []string `json:"warnings,omitempty"`
 }
 
-// PluginInstallStatusResponse is the response for GET /api/plugin/status/{taskId}.
+// PluginInstallStatusResponse is the response for GET /api/plugin/status/{pluginId}.
 type PluginInstallStatusResponse struct {
-	TaskID      string `json:"taskId"`
 	PluginID    string `json:"pluginId"`
 	Phase       string `json:"phase"` // preparing, creating_interface, creating_mounts, running_pre_install_script, creating_container, pulling, starting_container, running_post_install_script, done, error
 	Message     string `json:"message,omitempty"`

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -19,6 +19,13 @@ func RegisterRoutes(e *echo.Echo) {
 	appGroup.POST("/install-update", handler.HandleAppInstallUpdate)
 	appGroup.GET("/update-status", handler.HandleAppUpdateStatus)
 
+	pluginGroup := e.Group("/api/plugin")
+	pluginGroup.Use(middleware.RouterOSAuth)
+	pluginGroup.GET("/plugins", handler.HandleListPlugins)
+	pluginGroup.POST("/install", handler.HandleInstallPlugin)
+	pluginGroup.DELETE("/plugin/:name", handler.HandleUninstallPlugin)
+	pluginGroup.GET("/status/:taskId", handler.HandleGetPluginInstallStatus)
+
 	systemGroup := e.Group("/api/system")
 	systemGroup.Use(middleware.RouterOSAuth)
 	systemGroup.GET("/info", handler.HandleGetSystemInfo)

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -24,7 +24,7 @@ func RegisterRoutes(e *echo.Echo) {
 	pluginGroup.GET("/plugins", handler.HandleListPlugins)
 	pluginGroup.POST("/install", handler.HandleInstallPlugin)
 	pluginGroup.DELETE("/plugin/:name", handler.HandleUninstallPlugin)
-	pluginGroup.GET("/status/:taskId", handler.HandleGetPluginInstallStatus)
+	pluginGroup.GET("/status/:pluginId", handler.HandleGetPluginInstallStatus)
 
 	systemGroup := e.Group("/api/system")
 	systemGroup.Use(middleware.RouterOSAuth)

--- a/backend/pkg/routeros/common.go
+++ b/backend/pkg/routeros/common.go
@@ -1,6 +1,10 @@
 package routeros
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/go-routeros/routeros/v3/proto"
+)
 
 // nameOrIDFilterArg builds a GetFirst filter for either a RouterOS internal
 // .id (e.g. "*1") or a resource name.
@@ -9,4 +13,19 @@ func nameOrIDFilterArg(nameOrID string) string {
 		return "?=.id=" + nameOrID
 	}
 	return "?=name=" + nameOrID
+}
+
+// joinPairValues concatenates every value for key found in pairs, in order,
+// separated by "; ". RouterOS can return more than one entry for a key such
+// as .about (e.g. a progress message followed by the actual error); a plain
+// map collapses those down to just the last one, so callers that need all of
+// them must read the sentence's raw ordered pair list instead.
+func joinPairValues(pairs []proto.Pair, key string) string {
+	var values []string
+	for _, p := range pairs {
+		if p.Key == key && p.Value != "" {
+			values = append(values, p.Value)
+		}
+	}
+	return strings.Join(values, "; ")
 }

--- a/backend/pkg/routeros/container.go
+++ b/backend/pkg/routeros/container.go
@@ -1,6 +1,10 @@
 package routeros
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/go-routeros/routeros/v3/proto"
+)
 
 // ContainerConfig represents the configuration used to add a new container.
 // RemoteImage and File are both optional, but at most one may be set:
@@ -14,6 +18,7 @@ type ContainerConfig struct {
 	RemoteImage string // e.g. "pihole/pihole:latest"
 	File        string // local tarball path, e.g. "disk1/pihole.tar"
 	Hostname    string
+	Env         string // "KEY=VALUE,KEY2=VALUE2" pairs; a key with no value is written bare, with no trailing "="
 	EnvLists    string // comma-separated names of /container/envs lists
 	MountLists  string // comma-separated names of /container/mounts lists
 	Cmd         string
@@ -63,6 +68,7 @@ type ContainerInfo struct {
 	DefaultShell                    string
 	DefaultWorkdir                  string
 	DefaultUser                     string
+	User                            string // effective runtime user, distinct from DefaultUser
 	DefaultStopSignal               string
 	StopTime                        string
 	Logging                         bool
@@ -80,6 +86,7 @@ type ContainerInfo struct {
 	Devices                         string
 	ImageID                         string
 	ConfigJSON                      string // OCI image config blob (architecture, entrypoint, env, healthcheck, rootfs digests, ...)
+	ContainerSize                   string // disk usage in bytes; only reported once the container is fully pulled
 	Layers                          string
 	DefaultHealthcheckCmd           string
 	DefaultHealthcheckInterval      string
@@ -89,17 +96,25 @@ type ContainerInfo struct {
 	DefaultHealthcheckRetries       string
 	HealthcheckStatus               string
 	// RouterOS has no stable "status" property for containers; it instead adds
-	// transient boolean flags matching the current print flag (S/N/R/T/E/D/F).
-	// Only the ones observed in practice are modeled; all are absent (false)
-	// outside their respective states.
-	Healthy               bool   // present while running with a passing healthcheck
-	DownloadingExtracting bool   // present while pulling/extracting the image (flag E)
-	DownloadExtractFailed bool   // present when the pull/extract failed (flag F)
-	About                 string // error detail set alongside DownloadExtractFailed
-	Comment               string
+	// exactly one transient boolean flag matching the current print flag
+	// (S/N/R/T/E/D/F/C). Only the ones observed in practice are modeled; all
+	// are absent (false) outside their respective states, and Running is only
+	// present regardless of whether a healthcheck is configured — Healthy
+	// additionally requires one.
+	Running               bool // present while running (flag R), independent of healthcheck
+	Healthy               bool // present while running with a passing healthcheck
+	DownloadingExtracting bool // present while pulling/extracting the image (flag E)
+	DownloadExtractFailed bool // present when the pull/extract failed (flag F)
+	Stopped               bool // present while stopped (flag S)
+	// About carries .about detail, e.g. the error set alongside
+	// DownloadExtractFailed. RouterOS can return more than one .about entry
+	// for a single container (observed: a progress message alongside the
+	// actual error) — all of them are joined here, in order, separated by "; ".
+	About   string
+	Comment string
 }
 
-func parseContainerInfo(result map[string]string) ContainerInfo {
+func parseContainerInfo(result map[string]string, pairs []proto.Pair) ContainerInfo {
 	return ContainerInfo{
 		ID:                              result[".id"],
 		Name:                            result["name"],
@@ -129,6 +144,7 @@ func parseContainerInfo(result map[string]string) ContainerInfo {
 		DefaultShell:                    result["default-shell"],
 		DefaultWorkdir:                  result["default-workdir"],
 		DefaultUser:                     result["default-user"],
+		User:                            result["user"],
 		DefaultStopSignal:               result["default-stop-signal"],
 		StopTime:                        result["stop-time"],
 		Logging:                         result["logging"] == "yes" || result["logging"] == "true",
@@ -146,6 +162,7 @@ func parseContainerInfo(result map[string]string) ContainerInfo {
 		Devices:                         result["devices"],
 		ImageID:                         result["image-id"],
 		ConfigJSON:                      result["config-json"],
+		ContainerSize:                   result["container-size"],
 		Layers:                          result["layers"],
 		DefaultHealthcheckCmd:           result["default-healthcheck-cmd"],
 		DefaultHealthcheckInterval:      result["default-healthcheck-interval"],
@@ -154,10 +171,12 @@ func parseContainerInfo(result map[string]string) ContainerInfo {
 		DefaultHealthcheckStartInterval: result["default-healthcheck-start-interval"],
 		DefaultHealthcheckRetries:       result["default-healthcheck-retries"],
 		HealthcheckStatus:               result["healthcheck-status"],
+		Running:                         result["running"] == "true",
 		Healthy:                         result["healthy"] == "true",
 		DownloadingExtracting:           result["downloading/extracting"] == "true",
 		DownloadExtractFailed:           result["download/extract failed"] == "true",
-		About:                           result[".about"],
+		Stopped:                         result["stopped"] == "true",
+		About:                           joinPairValues(pairs, ".about"),
 		Comment:                         result["comment"],
 	}
 }
@@ -191,6 +210,9 @@ func (c *Client) AddContainer(config ContainerConfig) (string, error) {
 	}
 	if config.Hostname != "" {
 		args = append(args, "=hostname="+config.Hostname)
+	}
+	if config.Env != "" {
+		args = append(args, "=env="+config.Env)
 	}
 	if config.EnvLists != "" {
 		args = append(args, "=envlists="+config.EnvLists)
@@ -303,12 +325,17 @@ func (c *Client) GetContainer(nameOrID string) (*ContainerInfo, error) {
 		return nil, fmt.Errorf("container name or ID is required")
 	}
 
-	result, err := c.GetFirst("/container", nameOrIDFilterArg(nameOrID))
+	// Bypasses GetFirst: it only exposes the collapsed Map, but joinPairValues
+	// needs the sentence's raw ordered pair list to catch multiple .about entries.
+	reply, err := c.Query("/container", nameOrIDFilterArg(nameOrID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container %s: %w", nameOrID, err)
 	}
+	if len(reply.Re) == 0 {
+		return nil, fmt.Errorf("failed to get container %s: no results found", nameOrID)
+	}
 
-	info := parseContainerInfo(result)
+	info := parseContainerInfo(reply.Re[0].Map, reply.Re[0].List)
 	return &info, nil
 }
 
@@ -470,15 +497,74 @@ func (c *Client) UpdateContainer(nameOrID string) error {
 
 // ListContainers retrieves all containers.
 func (c *Client) ListContainers() ([]ContainerInfo, error) {
-	results, err := c.GetAll("/container")
+	// Bypasses GetAll: see the comment in GetContainer.
+	reply, err := c.Query("/container")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	containers := make([]ContainerInfo, 0, len(results))
-	for _, result := range results {
-		containers = append(containers, parseContainerInfo(result))
+	containers := make([]ContainerInfo, 0, len(reply.Re))
+	for _, sen := range reply.Re {
+		containers = append(containers, parseContainerInfo(sen.Map, sen.List))
 	}
 
 	return containers, nil
+}
+
+// AddContainerMount creates a /container/mounts entry under listName and
+// returns its RouterOS .id. One or more mounts can share the same listName;
+// a container references them all at once via its MountLists property.
+func (c *Client) AddContainerMount(listName, src, dst string) (string, error) {
+	if listName == "" || src == "" || dst == "" {
+		return "", fmt.Errorf("mount list name, src, and dst are all required")
+	}
+
+	id, err := c.Add("/container/mounts", "=list="+listName, "=src="+src, "=dst="+dst)
+	if err != nil {
+		return "", fmt.Errorf("failed to add container mount %s: %w", listName, err)
+	}
+
+	return id, nil
+}
+
+// RemoveContainerMount deletes every /container/mounts entry under listName.
+// A list may hold more than one entry and RouterOS addresses them only by
+// .id, so each is looked up and removed individually. A list with no entries
+// left (or that never existed) is not an error.
+func (c *Client) RemoveContainerMount(listName string) error {
+	if listName == "" {
+		return fmt.Errorf("mount list name is required")
+	}
+
+	results, err := c.GetAll("/container/mounts", "?=list="+listName)
+	if err != nil {
+		return fmt.Errorf("failed to look up container mount %s: %w", listName, err)
+	}
+
+	for i := range results {
+		id := results[i][".id"]
+		if id == "" {
+			continue
+		}
+		if _, err := c.Remove("/container/mounts", "=.id="+id); err != nil {
+			return fmt.Errorf("failed to remove container mount %s: %w", listName, err)
+		}
+	}
+
+	return nil
+}
+
+// ContainerMountExists reports whether any /container/mounts entry already
+// exists under listName.
+func (c *Client) ContainerMountExists(listName string) (bool, error) {
+	if listName == "" {
+		return false, fmt.Errorf("mount list name is required")
+	}
+
+	results, err := c.GetAll("/container/mounts", "?=list="+listName)
+	if err != nil {
+		return false, fmt.Errorf("failed to check container mount %s: %w", listName, err)
+	}
+
+	return len(results) > 0, nil
 }

--- a/backend/pkg/routeros/interface.go
+++ b/backend/pkg/routeros/interface.go
@@ -251,6 +251,14 @@ type MacvlanConfig struct {
 	LoopProtectSendInterval string // time interval
 }
 
+// VethConfig represents the configuration used to add a new veth interface,
+// typically for backing a container (see ContainerConfig.Interface).
+type VethConfig struct {
+	Name    string // referenced afterward by RouterOS interface/container commands
+	Address string // e.g. "192.168.50.12/24"
+	Gateway string
+}
+
 // MacvlanInfo represents a MACVLAN interface.
 type MacvlanInfo struct {
 	ID                      string
@@ -999,4 +1007,52 @@ func parseEthernetInfo(result map[string]string) EthernetInfo {
 		Running:                 getBoolPtr(result, "running"),
 		Comment:                 getStringPtr(result, "comment"),
 	}
+}
+
+// AddVethInterface creates a new veth interface and returns its RouterOS .id.
+func (c *Client) AddVethInterface(config VethConfig) (string, error) {
+	if config.Name == "" {
+		return "", fmt.Errorf("veth interface name is required")
+	}
+
+	args := []string{"=name=" + config.Name}
+	if config.Address != "" {
+		args = append(args, "=address="+config.Address)
+	}
+	if config.Gateway != "" {
+		args = append(args, "=gateway="+config.Gateway)
+	}
+
+	id, err := c.Add("/interface/veth", args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to add veth interface %s: %w", config.Name, err)
+	}
+
+	return id, nil
+}
+
+// RemoveVethInterface deletes the veth interface with the given name. An
+// interface that is already gone is not an error, so callers cleaning up after
+// a partially applied configuration can call this unconditionally.
+func (c *Client) RemoveVethInterface(name string) error {
+	if name == "" {
+		return fmt.Errorf("veth interface name is required")
+	}
+
+	results, err := c.GetAll("/interface/veth", "?=name="+name)
+	if err != nil {
+		return fmt.Errorf("failed to look up veth interface %s: %w", name, err)
+	}
+
+	for i := range results {
+		id := results[i][".id"]
+		if id == "" {
+			continue
+		}
+		if _, err := c.Remove("/interface/veth", "=.id="+id); err != nil {
+			return fmt.Errorf("failed to remove veth interface %s: %w", name, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
* Closes #406
## feat(be): Introduce plugin system

Adds a plugin system that installs community plugins from the
[nasnet-panel-plugins](https://github.com/nasnet-community/nasnet-panel-plugins)
registry as RouterOS containers, plus the `pkg/routeros` primitives it needs.

A plugin is a container named after its plugin id. Everything else — the veth
interface, mount lists, env vars, lifecycle scripts — comes from the plugin's
own `manifest.json` in the registry.

### Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/api/plugin/plugins` | List registry plugins, annotated with live router state |
| `POST` | `/api/plugin/install` | Start an async install, returns a `taskId` |
| `GET` | `/api/plugin/status/{taskId}` | Poll install progress |
| `DELETE` | `/api/plugin/plugin/{name}` | Uninstall a plugin and its resources |

`GET /plugins` cross-references the registry against `ListContainers()` and
annotates each entry with `installed`, `running`, `installing`, `failed`, and a
`note` carrying RouterOS's `.about` text (typically a pull error), plus an
`icon` URL derived from the plugin id.

### Install flow

Installs run in a detached goroutine because an image pull can take minutes;
`POST /install` returns immediately with a task id. Up-front validation happens
synchronously so bad requests fail fast: the plugin must exist in the registry
(404), no container may already own the name (409), and no install for the same
plugin may be in flight (409). Different plugins install concurrently.

Phases reported by `/status/{taskId}`:

```
preparing → creating_interface → creating_mounts → running_pre_install_script
→ creating_container → pulling → starting_container
→ running_post_install_script → done | error
```

Details worth noting:

- **Architecture gate.** The manifest's `architectures` is checked against
  `GetResourceInfo().Architecture` before anything is created. RouterOS reports
  `x86` where manifests use OCI's `amd64`, so that one name is normalized.
- **Idempotent prerequisites.** The veth interface and each mount list are
  created only if absent, so a retried or partially-failed install doesn't
  duplicate them.
- **Settings placeholders.** `{{settings.<key>}}` in env values resolves against
  the defaults in the manifest's `settingsSchema`; a field with `"generate":"uuid"`
  and no default gets a fresh UUID v4.
- **Explicit start.** `/container/add` only downloads and extracts — RouterOS
  never starts a container itself — so the flow starts the container and polls
  until it reports `running`/`healthy` before running `postInstall`.
- **Lifecycle scripts.** `preInstall` runs before the container is created,
  `postInstall` only once it's confirmed running. Both are fetched as raw `.rsc`
  text and executed via `ExecuteScriptString`. An empty or whitespace-only
  script file is a no-op, since `ExecuteScriptString` rejects an empty string and
  a placeholder file shouldn't fail an install.

### Uninstall flow

`DELETE /plugin/{name}` validates the plugin is in the registry and installed,
then runs `preUninstall` → stops the container → waits 2s for the stop to
settle → removes the container → removes the manifest's mount lists → removes
its veth interface.

Once the container is gone the plugin *is* uninstalled, so later cleanup
failures return `200` with a `warnings[]` array rather than a `500` that would
imply nothing happened — same shape `HandleDeleteOvpnServer` already uses. Only
a failed container removal is a `500`. A failing `preUninstall` script also only
warns, otherwise a plugin with a broken script could never be removed.

### `pkg/routeros` additions

- `AddVethInterface` / `RemoveVethInterface`, and `VethConfig`
- `AddContainerMount` / `RemoveContainerMount` / `ContainerMountExists`
- `ContainerConfig.Env`, wired to the `env=` property
- `joinPairValues` helper in `common.go`

Both `Remove*` helpers treat "already absent" as success, so cleanup paths can
call them unconditionally.

### RouterOS behaviours this had to account for

These were established against live device output, not docs — several are
undocumented or documented incorrectly:

- **`running` and `stopped` are real, independent flags.** Verified against four
  containers in different states. A container can report `healthy` without ever
  setting `running`, depending on firmware, so "is it up?" checks test both.
- **`.about` can appear more than once in a single reply** — observed as a
  progress message followed by the actual error. The collapsed `Map` keeps only
  the last, so `GetContainer`/`ListContainers` now bypass `GetFirst`/`GetAll` and
  read the sentence's ordered `proto.Pair` list, joining all values via
  `joinPairValues`.
- **The property is `envlists`, not `envlist`.**
- **`env=` wants bare `KEY=VALUE` pairs**, comma-separated, unquoted, with an
  empty-valued key written as just the bare key (no trailing `=`). Pairs are
  sorted by key so output is deterministic.
- **New fields modeled:** `user` (distinct from `default-user`) and
  `container-size`.

### Known gaps / follow-ups

- `manifest.container.ports` is decoded (including `hostPort` as either a JSON
  number or a `{{settings.*}}` string) but **not yet applied** to the container —
  no port publishing happens yet.
- Settings resolve to **manifest defaults only**; there's no way for a user to
  supply values at install time.
- `startOnBoot` is hardcoded `false`.
- Task ids are `time.Now().Unix()`, so two plugins whose installs start in the
  same second collide on the registry key.
- The task registry has no eviction — completed tasks are retained for the
  process lifetime.
- Uninstall removes mount lists and the veth **unconditionally**, but install
  *reuses* pre-existing ones. Two plugins declaring the same mount-list or
  interface name means uninstalling one pulls that resource out from under the
  other.
