### PR TITLE
fix(fe): prompt for credentials when opening a saved router

### DIFF
--- a/frontend/src/routes/RouterCredentialsDialog.tsx
+++ b/frontend/src/routes/RouterCredentialsDialog.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Dialog,
+  FieldRow,
+  FormError,
+  Input,
+  Label,
+  PasswordInput,
+  Stack,
+} from '@nasnet/ui';
+import { ApiError, testCredentials, type Router } from '../api';
+import { useSession } from '../state/SessionContext';
+
+interface Props {
+  router: Router;
+}
+
+export function RouterCredentialsDialog({ router }: Props) {
+  const navigate = useNavigate();
+  const { setCredentials } = useSession();
+  const [username, setUsername] = useState('admin');
+  const [password, setPassword] = useState('');
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const close = () => navigate('/');
+
+  const onConnect = async () => {
+    if (!username.trim()) {
+      setError('Username is required.');
+      return;
+    }
+    setConnecting(true);
+    setError(null);
+    try {
+      await testCredentials(router.host, username, password);
+      setCredentials(router.id, { username, password });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError('Invalid username or password');
+      } else {
+        setError(err instanceof Error ? err.message : 'Connection failed');
+      }
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={() => {
+        if (!connecting) close();
+      }}
+      title={`Connect to ${router.name || router.host}`}
+      description={`Enter credentials for ${router.host}.`}
+      size="sm"
+      footer={
+        <>
+          <Button variant="ghost" onClick={close} disabled={connecting}>
+            Cancel
+          </Button>
+          <Button
+            variant="success"
+            onClick={() => {
+              void onConnect();
+            }}
+            loading={connecting}
+          >
+            Connect
+          </Button>
+        </>
+      }
+    >
+      <Stack>
+        <FieldRow>
+          <Label>
+            <span>Username</span>
+            <Input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="username"
+              aria-label="Username"
+              autoFocus
+            />
+          </Label>
+          <Label>
+            <span>Password</span>
+            <PasswordInput
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !connecting) {
+                  e.preventDefault();
+                  void onConnect();
+                }
+              }}
+              autoComplete="current-password"
+              aria-label="Password"
+            />
+          </Label>
+        </FieldRow>
+        {error ? <FormError>{error}</FormError> : null}
+      </Stack>
+    </Dialog>
+  );
+}

--- a/frontend/src/routes/RouterCredentialsDialog.tsx
+++ b/frontend/src/routes/RouterCredentialsDialog.tsx
@@ -57,6 +57,7 @@ export function RouterCredentialsDialog({ router }: Props) {
       title={`Connect to ${router.name || router.host}`}
       description={`Enter credentials for ${router.host}.`}
       size="sm"
+      labelledBy="router-credentials-title"
       footer={
         <>
           <Button variant="ghost" onClick={close} disabled={connecting}>

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
 import { useWizardGate } from '../state/WizardGateContext';
 import { ROUTER_SECTIONS as TABS } from '../layout/routerSections';
+import { RouterCredentialsDialog } from './RouterCredentialsDialog';
 import styles from './RouterDashboard.module.scss';
 
 export function RouterDashboard() {
@@ -12,7 +13,7 @@ export function RouterDashboard() {
   const router = useRouter(id);
   const location = useLocation();
   const navigate = useNavigate();
-  const { setActiveRouterId } = useSession();
+  const { setActiveRouterId, getCredentials } = useSession();
   const { statusFor } = useWizardGate();
 
   useEffect(() => {
@@ -24,6 +25,14 @@ export function RouterDashboard() {
     return (
       <div className={styles.contentShell}>
         <div className={styles.notFound}>Router not found.</div>
+      </div>
+    );
+  }
+
+  if (!getCredentials(router.id)) {
+    return (
+      <div className={styles.contentShell}>
+        <RouterCredentialsDialog router={router} />
       </div>
     );
   }

--- a/frontend/src/state/SessionContext.tsx
+++ b/frontend/src/state/SessionContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 interface Credentials {
   username: string;
@@ -39,20 +39,28 @@ function persistCredentials(map: Map<string, Credentials>) {
 }
 
 export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const credentialsRef = useRef<Map<string, Credentials>>(loadCredentials());
+  const [credentialsMap, setCredentialsMap] = useState<Map<string, Credentials>>(loadCredentials);
   const [activeRouterId, setActiveRouterId] = useState<string | null>(null);
 
   const getCredentials = useCallback(
-    (routerId: string) => credentialsRef.current.get(routerId),
-    [],
+    (routerId: string) => credentialsMap.get(routerId),
+    [credentialsMap],
   );
   const setCredentials = useCallback((routerId: string, credentials: Credentials) => {
-    credentialsRef.current.set(routerId, credentials);
-    persistCredentials(credentialsRef.current);
+    setCredentialsMap((prev) => {
+      const next = new Map(prev);
+      next.set(routerId, credentials);
+      persistCredentials(next);
+      return next;
+    });
   }, []);
   const clearCredentials = useCallback((routerId: string) => {
-    credentialsRef.current.delete(routerId);
-    persistCredentials(credentialsRef.current);
+    setCredentialsMap((prev) => {
+      const next = new Map(prev);
+      next.delete(routerId);
+      persistCredentials(next);
+      return next;
+    });
   }, []);
 
   const value = useMemo<SessionContextValue>(

--- a/frontend/tests/e2e/25-help-page.spec.ts
+++ b/frontend/tests/e2e/25-help-page.spec.ts
@@ -29,9 +29,11 @@ test.describe('Help page', () => {
     page,
     resetMocks,
     seedRouter,
+    seedCredentials,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
     await page.goto(`/router/${ROUTER.id}/help`);
 
     const knowledgeBase = page.getByRole('link', { name: /knowledge base/i });

--- a/frontend/tests/e2e/26-plugins-page.spec.ts
+++ b/frontend/tests/e2e/26-plugins-page.spec.ts
@@ -28,9 +28,11 @@ test.describe('Plugins page', () => {
     page,
     resetMocks,
     seedRouter,
+    seedCredentials,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
     await page.goto(`/router/${ROUTER.id}/plugins`);
 
     const ooniCard = page
@@ -50,9 +52,11 @@ test.describe('Plugins page', () => {
     page,
     resetMocks,
     seedRouter,
+    seedCredentials,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
     await page.goto(`/router/${ROUTER.id}/plugins`);
 
     const deltaChatCard = page

--- a/frontend/tests/e2e/33-saved-router-credentials.spec.ts
+++ b/frontend/tests/e2e/33-saved-router-credentials.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures';
+
+test.describe('Saved router credentials prompt', () => {
+  test('prompts for credentials and loads the dashboard after connect', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({
+      id: 'rtr_saved',
+      name: 'Saved Router',
+      host: '10.0.0.50',
+      hostname: 'saved-router.home.',
+    });
+    await mockOverviewBackend({ model: 'hAP ax3', version: '7.14' });
+    await page.goto('/router/rtr_saved');
+
+    const dialog = page.getByRole('dialog', { name: /connect to saved router/i });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByLabel('Username')).toHaveValue('admin');
+    await dialog.getByLabel('Password').fill('test');
+    await dialog.getByRole('button', { name: 'Connect' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Resources', exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+  });
+
+  test('cancel returns to the router list', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_saved2', name: 'Saved Router Two', host: '10.0.0.51' });
+    await mockOverviewBackend({ model: 'hAP ax3', version: '7.14' });
+    await page.goto('/router/rtr_saved2');
+
+    const dialog = page.getByRole('dialog', { name: /connect to saved router two/i });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole('button', { name: /new router/i })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/frontend/tests/e2e/33-saved-router-credentials.spec.ts
+++ b/frontend/tests/e2e/33-saved-router-credentials.spec.ts
@@ -20,7 +20,7 @@ test.describe('Saved router credentials prompt', () => {
     const dialog = page.getByRole('dialog', { name: /connect to saved router/i });
     await expect(dialog).toBeVisible();
     await expect(dialog.getByLabel('Username')).toHaveValue('admin');
-    await dialog.getByLabel('Password').fill('test');
+    await dialog.getByLabel('Password', { exact: true }).fill('test');
     await dialog.getByRole('button', { name: 'Connect' }).click();
 
     await expect(page.getByRole('heading', { name: 'Resources', exact: true })).toBeVisible();

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -109,6 +109,7 @@ export interface EasyConfigBackendOptions {
 export interface TestFixtures {
   resetMocks: () => Promise<void>;
   seedRouter: (input: SeedInput) => Promise<void>;
+  seedCredentials: (routerId: string) => Promise<void>;
   mockBackendScan: (devices?: ScanMockDevice[]) => Promise<void>;
   mockOverviewBackend: (router?: OverviewBackendRouter) => Promise<void>;
   mockWifiBackend: (router?: WifiBackendRouter) => Promise<void>;
@@ -155,6 +156,24 @@ export const test = base.extend<TestFixtures>({
         window.__PENDING_SEEDS__ = window.__PENDING_SEEDS__ ?? [];
         window.__PENDING_SEEDS__.push(seed);
       }, input);
+    });
+  },
+  seedCredentials: async ({ context }, use) => {
+    await use(async (routerId) => {
+      await context.addInitScript((id) => {
+        try {
+          const key = 'nasnet-panel.session-credentials.v1';
+          const raw = window.sessionStorage.getItem(key);
+          const map = (raw ? JSON.parse(raw) : {}) as Record<
+            string,
+            { username: string; password: string }
+          >;
+          map[id] = { username: 'admin', password: 'test' };
+          window.sessionStorage.setItem(key, JSON.stringify(map));
+        } catch {
+          /* ignore */
+        }
+      }, routerId);
     });
   },
   mockBackendScan: async ({ context }, use) => {


### PR DESCRIPTION
Closes #417

- credentials live only in sessionStorage, so any fresh browser session had no way to re-enter them and the dashboard hung on skeletons with no backend requests
- opening a saved router without stored credentials now shows a connect dialog that verifies them before loading the dashboard
- e2e spec covering the connect and cancel paths