### PR TITLE
fix(fe): update WAN interfaces after change

### DIFF
--- a/frontend/src/routes/WanPage.tsx
+++ b/frontend/src/routes/WanPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useToast } from '@nasnet/ui';
 import {
@@ -20,6 +20,19 @@ import { mapClientFromBE } from './vpn/adapters';
 import { ClientsSection } from './vpn/sections/ClientsSection';
 
 const WAN_INTERFACE_TYPES = ['ether', 'wireless', 'wifi', 'wlan', 'w60g', 'lte'];
+const WAN_REFRESH_ATTEMPTS = 5;
+const WAN_REFRESH_DELAY_MS = 1000;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+
+const wanSignature = (list: InterfaceResponse[]) =>
+  list
+    .map((i) => `${i.name}|${i.comment ?? ''}`)
+    .sort()
+    .join(';');
 
 export function WanPage() {
   const { id } = useParams<{ id: string }>();
@@ -28,6 +41,7 @@ export function WanPage() {
   const router = useRouter(id);
 
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
+  const interfacesRef = useRef<InterfaceResponse[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState(false);
   const [vpnClients, setVpnClients] = useState<VPNClient[]>([]);
   const [vpnDialogOpen, setVpnDialogOpen] = useState(false);
@@ -40,16 +54,21 @@ export function WanPage() {
     return { host, ...creds };
   }, [id, router?.host, getCredentials]);
 
+  const applyInterfaces = useCallback((wan: InterfaceResponse[]) => {
+    interfacesRef.current = wan;
+    setInterfaces(wan);
+  }, []);
+
   const loadInterfaces = useCallback(async () => {
     const creds = resolveCreds();
     if (!creds) {
-      setInterfaces([]);
+      applyInterfaces([]);
       return;
     }
     setInterfacesLoading(true);
     try {
       const list = await fetchInterfaces(creds);
-      setInterfaces(list.filter((i) => WAN_INTERFACE_TYPES.includes(i.type)));
+      applyInterfaces(list.filter((i) => WAN_INTERFACE_TYPES.includes(i.type)));
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -61,7 +80,7 @@ export function WanPage() {
     } finally {
       setInterfacesLoading(false);
     }
-  }, [resolveCreds, toast]);
+  }, [resolveCreds, applyInterfaces, toast]);
 
   const loadVpn = useCallback(async () => {
     const creds = resolveCreds();
@@ -83,9 +102,34 @@ export function WanPage() {
     }
   }, [id, resolveCreds, toast]);
 
-  const reload = useCallback(async () => {
-    await Promise.all([loadInterfaces(), loadVpn()]);
-  }, [loadInterfaces, loadVpn]);
+  const reloadAfterWanChange = useCallback(async () => {
+    void loadVpn();
+    const creds = resolveCreds();
+    if (!creds) return;
+    const before = wanSignature(interfacesRef.current);
+    setInterfacesLoading(true);
+    try {
+      for (let attempt = 1; attempt <= WAN_REFRESH_ATTEMPTS; attempt += 1) {
+        await sleep(WAN_REFRESH_DELAY_MS);
+        const list = await fetchInterfaces(creds);
+        const wan = list.filter((i) => WAN_INTERFACE_TYPES.includes(i.type));
+        if (attempt === WAN_REFRESH_ATTEMPTS || wanSignature(wan) !== before) {
+          applyInterfaces(wan);
+          return;
+        }
+      }
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to load interfaces.';
+      toast.notify({ title: 'Failed to load interfaces', description: message, tone: 'danger' });
+    } finally {
+      setInterfacesLoading(false);
+    }
+  }, [resolveCreds, loadVpn, applyInterfaces, toast]);
 
   useEffect(() => {
     void loadInterfaces();
@@ -107,7 +151,7 @@ export function WanPage() {
         interfaces={interfaces}
         excludeNames={assignedNames}
         interfacesLoading={interfacesLoading}
-        onChanged={reload}
+        onChanged={reloadAfterWanChange}
       />
       <DomesticUplinkSection
         routerId={id}
@@ -115,7 +159,7 @@ export function WanPage() {
         interfaces={interfaces}
         excludeNames={assignedNames}
         interfacesLoading={interfacesLoading}
-        onChanged={reload}
+        onChanged={reloadAfterWanChange}
       />
       <ClientsSection
         creds={resolveCreds()}

--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -20,7 +20,7 @@ interface Props {
   interfaces: InterfaceResponse[];
   excludeNames?: string[];
   interfacesLoading?: boolean;
-  onChanged: () => void;
+  onChanged: () => Promise<void>;
 }
 
 export function DomesticUplinkSection({
@@ -79,9 +79,9 @@ export function DomesticUplinkSection({
       });
       return;
     }
+    await onChanged();
     closeDialog();
     toast.notify({ title: 'Domestic uplink added', tone: 'success' });
-    onChanged();
   };
 
   const onConfirmMove = async () => {
@@ -108,10 +108,10 @@ export function DomesticUplinkSection({
       setMoveSubmitting(false);
       return;
     }
+    await onChanged();
     setMoveSubmitting(false);
     setPendingMove(null);
     toast.notify({ title: `Moved "${target.name}" to Foreign`, tone: 'info' });
-    onChanged();
   };
 
   const moveWireless = pendingMove ? classifyInterface(pendingMove) === 'wireless' : false;
@@ -127,9 +127,9 @@ export function DomesticUplinkSection({
       return;
     }
     await updateWanInterface(creds, { interface: interfaceName, type: 'foreign', ssid, password });
+    await onChanged();
     setPendingMove(null);
     toast.notify({ title: `Moved "${interfaceName}" to Foreign`, tone: 'info' });
-    onChanged();
   };
 
   return (

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -20,7 +20,7 @@ interface Props {
   interfaces: InterfaceResponse[];
   excludeNames?: string[];
   interfacesLoading?: boolean;
-  onChanged: () => void;
+  onChanged: () => Promise<void>;
 }
 
 export function StarlinkSection({
@@ -79,9 +79,9 @@ export function StarlinkSection({
       });
       return;
     }
+    await onChanged();
     closeDialog();
     toast.notify({ title: 'Starlink uplink added', tone: 'success' });
-    onChanged();
   };
 
   const onConfirmMove = async () => {
@@ -108,10 +108,10 @@ export function StarlinkSection({
       setMoveSubmitting(false);
       return;
     }
+    await onChanged();
     setMoveSubmitting(false);
     setPendingMove(null);
     toast.notify({ title: `Moved "${target.name}" to Domestic`, tone: 'info' });
-    onChanged();
   };
 
   const moveWireless = pendingMove ? classifyInterface(pendingMove) === 'wireless' : false;
@@ -127,9 +127,9 @@ export function StarlinkSection({
       return;
     }
     await updateWanInterface(creds, { interface: interfaceName, type: 'domestic', ssid, password });
+    await onChanged();
     setPendingMove(null);
     toast.notify({ title: `Moved "${interfaceName}" to Domestic`, tone: 'info' });
-    onChanged();
   };
 
   return (

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -57,7 +57,11 @@ const setSessionCreds = async (context: BrowserContext, routerId: string) => {
   }, routerId);
 };
 
-const setupWanRoutes = async (context: BrowserContext, state: WanRouteState) => {
+const setupWanRoutes = async (
+  context: BrowserContext,
+  state: WanRouteState,
+  opts: { wanApplyDelayMs?: number } = {},
+) => {
   await context.route('**/api/interface/interfaces', async (route) => {
     await route.fulfill({
       status: 200,
@@ -77,8 +81,12 @@ const setupWanRoutes = async (context: BrowserContext, state: WanRouteState) => 
     state.wanPuts.push({ body });
     const comment =
       body.type === 'foreign' ? 'WAN - Foreign Link(Foreign)' : 'WAN - Domestic Link(Domestic)';
-    const idx = state.interfaces.findIndex((i) => i.name === body.interface);
-    if (idx >= 0) state.interfaces[idx] = { ...state.interfaces[idx], comment };
+    const apply = () => {
+      const idx = state.interfaces.findIndex((i) => i.name === body.interface);
+      if (idx >= 0) state.interfaces[idx] = { ...state.interfaces[idx], comment };
+    };
+    if (opts.wanApplyDelayMs) setTimeout(apply, opts.wanApplyDelayMs);
+    else apply();
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -270,6 +278,37 @@ test.describe('WAN tab', () => {
 
     await expect.poll(() => state.wanPuts.length).toBe(2);
     expect(state.wanPuts[1]).toMatchObject({ body: { interface: 'ether1', type: 'domestic' } });
+  });
+
+  test('slow WAN change keeps the dialog in progress until the table reflects it', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'WAN Router' });
+    await setSessionCreds(context, ROUTER_ID);
+    const state = blankState();
+    await setupWanRoutes(context, state, { wanApplyDelayMs: 2500 });
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    await newButton(page, 0).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Starlink WAN').click();
+    await page.getByRole('option', { name: 'ether1' }).click();
+    await dialog.getByRole('button', { name: /^save$/i }).click();
+
+    await expect.poll(() => state.wanPuts.length).toBe(1);
+    await expect(dialog.getByRole('button', { name: 'Saving…' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'ether1', exact: true })).toBeHidden();
+
+    await expect(page.getByRole('cell', { name: 'ether1', exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(dialog).toBeHidden();
   });
 
   test('add a wireless Starlink uplink sends ssid and password', async ({


### PR DESCRIPTION
Closes #421

## Summary
- poll interfaces for a few seconds after a domestic/foreign change instead of refetching stale data once
- keep the Saving/Moving dialog state visible until the refreshed list lands, then close and toast
- e2e mock can now apply the change with a delay to cover the slow-router case