### PR TITLE
fix(fe): display correct version in footer

### DIFF
--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,0 +1,11 @@
+import { apiRequest } from './http';
+
+export interface HealthResponse {
+  status: string;
+  server: string;
+  version: string;
+}
+
+export async function fetchHealth(signal?: AbortSignal): Promise<HealthResponse> {
+  return apiRequest<HealthResponse>('/health', { signal });
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -104,6 +104,7 @@ export {
   type DiagStatusResponse,
 } from './diag';
 export { fetchNetStatus, type NetStatusEntry, type NetHostType } from './net';
+export { fetchHealth, type HealthResponse } from './health';
 export {
   listVPNClients,
   updateVPNClient,

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -1,19 +1,32 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Badge, Inline } from '@nasnet/ui';
+import { fetchHealth } from '../api';
 import { AppHeader } from './AppHeader';
 import styles from './AppShell.module.scss';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
-export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className={styles.root}>
-    <AppHeader />
-    <main className={styles.main}>{children}</main>
-    <footer className={styles.footer}>
-      <Inline $gap="8px" $justify="center">
-        <span>© 2026 Nasnet Panel v0.1.0</span>
-        {isDev ? <Badge tone="warning">DEV</Badge> : null}
-      </Inline>
-    </footer>
-  </div>
-);
+export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [version, setVersion] = useState('');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchHealth(controller.signal)
+      .then((health) => setVersion(health.version))
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <div className={styles.root}>
+      <AppHeader />
+      <main className={styles.main}>{children}</main>
+      <footer className={styles.footer}>
+        <Inline $gap="8px" $justify="center">
+          <span>© 2026 Nasnet Panel{version ? ` ${version}` : ''}</span>
+          {isDev ? <Badge tone="warning">DEV</Badge> : null}
+        </Inline>
+      </footer>
+    </div>
+  );
+};

--- a/frontend/tests/e2e/34-footer-version.spec.ts
+++ b/frontend/tests/e2e/34-footer-version.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from './fixtures';
+
+test.describe('Footer version', () => {
+  test('shows the backend-reported version', async ({ page, context, resetMocks }) => {
+    await resetMocks();
+    await context.route('**/health', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'healthy', server: 'nasnet-panel', version: 'v9.9.9-e2e' }),
+      });
+    });
+    await page.goto('/');
+    await expect(page.locator('footer')).toContainText('Nasnet Panel v9.9.9-e2e');
+  });
+
+  test('omits the version when the backend is unreachable', async ({
+    page,
+    context,
+    resetMocks,
+  }) => {
+    await resetMocks();
+    await context.route('**/health', (route) => route.abort());
+    await page.goto('/');
+    await expect(page.locator('footer')).toContainText('Nasnet Panel');
+    await expect(page.locator('footer')).not.toContainText(/v\d/);
+  });
+});


### PR DESCRIPTION
Closes #434

## Summary
- Footer showed a hardcoded v0.1.0 regardless of the running build
- It now displays the version reported by the backend
- Nothing is shown in place of the version until it loads, so a stale number never appears