### PR TITLE
feat(fe): wireguard peer client config via QR or download

### DIFF
--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -289,8 +289,8 @@ export interface WireguardDetailedResponse {
 export interface CreateWireguardPeerRequest {
   interfaceName: string;
   name?: string;
-  endpointAddress: string;
-  endpointPort: number;
+  endpointAddress?: string;
+  endpointPort?: number;
   allowedAddresses: string;
   privateKey?: string;
   publicKey?: string;

--- a/frontend/src/routes/vpn/dialogs/AddWgPeerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddWgPeerDialog.tsx
@@ -13,6 +13,7 @@ import {
   ApiError,
   createWireguardPeer,
   type CreateWireguardPeerRequest,
+  type CreateWireguardPeerResponse,
   type VPNCredentials,
 } from '../../../api';
 import { isPort } from '../../../utils/validators';
@@ -21,14 +22,14 @@ interface Props {
   creds: VPNCredentials | null;
   interfaceName: string;
   onCancel: () => void;
-  onCreated: () => void;
+  onCreated: (created: CreateWireguardPeerResponse) => void;
 }
 
 export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: Props) {
   const [name, setName] = useState('');
   const [endpointAddress, setEndpointAddress] = useState('');
   const [endpointPort, setEndpointPort] = useState('51820');
-  const [allowedAddresses, setAllowedAddresses] = useState('');
+  const [allowedAddresses, setAllowedAddresses] = useState('0.0.0.0/0');
   const [publicKey, setPublicKey] = useState('');
   const [presharedKey, setPresharedKey] = useState('');
   const [persistentKeepalive, setPersistentKeepalive] = useState('');
@@ -40,8 +41,8 @@ export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: P
 
   const errors = useMemo(
     () => ({
-      endpointAddress: endpointAddress.trim() === '' ? 'Endpoint address is required.' : null,
-      endpointPort: isPort(endpointPort) ? null : 'Port must be 1-65535.',
+      endpointPort:
+        endpointAddress.trim() === '' || isPort(endpointPort) ? null : 'Port must be 1-65535.',
       allowedAddresses: allowedAddresses.trim() === '' ? 'Allowed addresses is required.' : null,
       persistentKeepalive:
         persistentKeepalive.trim() === '' ||
@@ -57,7 +58,6 @@ export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: P
 
   const submit = async () => {
     setTouched({
-      endpointAddress: true,
       endpointPort: true,
       allowedAddresses: true,
       persistentKeepalive: true,
@@ -68,17 +68,21 @@ export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: P
 
     const body: CreateWireguardPeerRequest = {
       interfaceName,
-      endpointAddress: endpointAddress.trim(),
-      endpointPort: Number(endpointPort),
       allowedAddresses: allowedAddresses.trim(),
     };
+    if (endpointAddress.trim()) {
+      body.endpointAddress = endpointAddress.trim();
+      body.endpointPort = Number(endpointPort);
+    }
     if (name.trim()) body.name = name.trim();
     if (publicKey.trim()) body.publicKey = publicKey.trim();
+    else body.savePrivateKey = true;
     if (presharedKey.trim()) body.preSharedKey = presharedKey.trim();
     if (persistentKeepalive.trim()) body.persistentKeepalive = Number(persistentKeepalive);
 
+    let created: CreateWireguardPeerResponse;
     try {
-      await createWireguardPeer(creds, body);
+      created = await createWireguardPeer(creds, body);
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -91,7 +95,7 @@ export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: P
       return;
     }
     setSubmitting(false);
-    onCreated();
+    onCreated(created);
   };
 
   return (
@@ -125,18 +129,13 @@ export function AddWgPeerDialog({ creds, interfaceName, onCancel, onCreated }: P
         </FieldRow>
         <FieldRow>
           <Label>
-            <span>Endpoint address</span>
+            <span>Endpoint address (optional)</span>
             <Input
               value={endpointAddress}
               onChange={(e) => setEndpointAddress(e.target.value)}
-              onBlur={() => markTouched('endpointAddress')}
               placeholder="203.0.113.50"
               aria-label="Endpoint address"
-              aria-invalid={touched.endpointAddress && !!errors.endpointAddress}
             />
-            {touched.endpointAddress && errors.endpointAddress ? (
-              <FormError>{errors.endpointAddress}</FormError>
-            ) : null}
           </Label>
           <Label>
             <span>Endpoint port</span>

--- a/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Badge, Button, ConfirmDialog, Dialog, useToast } from '@nasnet/ui';
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Pencil, Plus, QrCode, Trash2 } from 'lucide-react';
 import styles from '../../VPNPage.module.scss';
 import {
   ApiError,
@@ -23,6 +23,18 @@ import {
 import { AddWgPeerDialog } from './AddWgPeerDialog';
 import { EditWgPeerDialog } from './EditWgPeerDialog';
 import { ExportOvpnDialog } from './ExportOvpnDialog';
+import { WgClientConfigDialog } from './WgClientConfigDialog';
+
+interface PeerClientConfig {
+  peerName: string;
+  privateKey: string;
+  serverPublicKey: string;
+  presharedKey?: string;
+  defaultEndpoint?: string;
+  defaultAddress?: string;
+  defaultAllowedIps?: string;
+  persistentKeepalive?: string;
+}
 
 type Details =
   | { kind: 'openvpn'; data: OvpnServerDetailsResponse }
@@ -45,6 +57,7 @@ export function ServerDetailsDialog({ server, creds, onClose }: Props) {
   const [exporting, setExporting] = useState(false);
   const [addingPeer, setAddingPeer] = useState(false);
   const [editingPeer, setEditingPeer] = useState<WireguardPeerResponse | null>(null);
+  const [configPeer, setConfigPeer] = useState<PeerClientConfig | null>(null);
   const [pendingDeletePeer, setPendingDeletePeer] = useState<WireguardPeerResponse | null>(null);
   const [peerDeleteSubmitting, setPeerDeleteSubmitting] = useState(false);
   const toast = useToast();
@@ -105,6 +118,22 @@ export function ServerDetailsDialog({ server, creds, onClose }: Props) {
   const isOvpn = server?.protocol === 'openvpn';
   const ovpnServerName = isOvpn && server ? server.id.replace(/^ovpn:/, '') : '';
 
+  const showPeerConfig = (p: WireguardPeerResponse) => {
+    if (details?.kind !== 'wireguard' || !p.privateKey) return;
+    setConfigPeer({
+      peerName: p.name,
+      privateKey: p.privateKey,
+      serverPublicKey: details.data.publicKey,
+      presharedKey: p.preSharedKey,
+      defaultEndpoint:
+        p.clientEndpoint || (creds ? `${creds.host}:${details.data.listenPort}` : ''),
+      defaultAddress:
+        p.allowedAddresses && p.allowedAddresses !== '0.0.0.0/0' ? p.allowedAddresses : '',
+      defaultAllowedIps: p.clientAllowedAddress || undefined,
+      persistentKeepalive: p.persistentKeepalive || undefined,
+    });
+  };
+
   return (
     <>
       <Dialog
@@ -135,6 +164,7 @@ export function ServerDetailsDialog({ server, creds, onClose }: Props) {
             onAddPeer={() => setAddingPeer(true)}
             onEditPeer={setEditingPeer}
             onDeletePeer={setPendingDeletePeer}
+            onShowPeerConfig={showPeerConfig}
           />
         ) : null}
       </Dialog>
@@ -153,11 +183,41 @@ export function ServerDetailsDialog({ server, creds, onClose }: Props) {
           creds={creds}
           interfaceName={details.data.name}
           onCancel={() => setAddingPeer(false)}
-          onCreated={() => {
+          onCreated={(created) => {
             setAddingPeer(false);
             toast.notify({ title: 'WireGuard peer created', tone: 'success' });
+            if (created.privateKey && details.kind === 'wireguard') {
+              setConfigPeer({
+                peerName: created.name,
+                privateKey: created.privateKey,
+                serverPublicKey: details.data.publicKey,
+                presharedKey: created.preSharedKey,
+                defaultEndpoint: creds ? `${creds.host}:${details.data.listenPort}` : '',
+                defaultAddress:
+                  created.allowedAddresses && created.allowedAddresses !== '0.0.0.0/0'
+                    ? created.allowedAddresses
+                    : '',
+                persistentKeepalive: created.persistentKeepalive
+                  ? String(created.persistentKeepalive)
+                  : undefined,
+              });
+            }
             reload();
           }}
+        />
+      ) : null}
+
+      {configPeer ? (
+        <WgClientConfigDialog
+          peerName={configPeer.peerName}
+          privateKey={configPeer.privateKey}
+          serverPublicKey={configPeer.serverPublicKey}
+          presharedKey={configPeer.presharedKey}
+          defaultEndpoint={configPeer.defaultEndpoint}
+          defaultAddress={configPeer.defaultAddress}
+          defaultAllowedIps={configPeer.defaultAllowedIps}
+          persistentKeepalive={configPeer.persistentKeepalive}
+          onClose={() => setConfigPeer(null)}
         />
       ) : null}
 
@@ -235,6 +295,7 @@ interface DetailsBodyProps {
   onAddPeer: () => void;
   onEditPeer: (peer: WireguardPeerResponse) => void;
   onDeletePeer: (peer: WireguardPeerResponse) => void;
+  onShowPeerConfig: (peer: WireguardPeerResponse) => void;
 }
 
 function DetailsBody({
@@ -244,6 +305,7 @@ function DetailsBody({
   onAddPeer,
   onEditPeer,
   onDeletePeer,
+  onShowPeerConfig,
 }: DetailsBodyProps) {
   switch (details.kind) {
     case 'openvpn': {
@@ -289,6 +351,7 @@ function DetailsBody({
             onAdd={onAddPeer}
             onEdit={onEditPeer}
             onDelete={onDeletePeer}
+            onShowConfig={onShowPeerConfig}
           />
         </>
       );
@@ -373,9 +436,17 @@ interface PeersSectionProps {
   onAdd: () => void;
   onEdit: (peer: WireguardPeerResponse) => void;
   onDelete: (peer: WireguardPeerResponse) => void;
+  onShowConfig: (peer: WireguardPeerResponse) => void;
 }
 
-function PeersSection({ peers, canMutate, onAdd, onEdit, onDelete }: PeersSectionProps) {
+function PeersSection({
+  peers,
+  canMutate,
+  onAdd,
+  onEdit,
+  onDelete,
+  onShowConfig,
+}: PeersSectionProps) {
   return (
     <div style={{ marginTop: 16 }}>
       <div
@@ -405,7 +476,7 @@ function PeersSection({ peers, canMutate, onAdd, onEdit, onDelete }: PeersSectio
                 <th style={{ padding: '6px 8px' }}>Endpoint</th>
                 <th style={{ padding: '6px 8px' }}>Last handshake</th>
                 <th style={{ padding: '6px 8px' }}>Status</th>
-                <th style={{ padding: '6px 8px', width: 120 }}>Actions</th>
+                <th style={{ padding: '6px 8px', width: 160 }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -426,6 +497,20 @@ function PeersSection({ peers, canMutate, onAdd, onEdit, onDelete }: PeersSectio
                   </td>
                   <td style={{ padding: '6px 8px' }}>
                     <span style={{ display: 'inline-flex', gap: 8 }}>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={!p.privateKey}
+                        title={
+                          p.privateKey
+                            ? `Client config for ${p.name}`
+                            : 'Private key not stored on router'
+                        }
+                        aria-label={`Client config for peer ${p.name}`}
+                        onClick={() => onShowConfig(p)}
+                      >
+                        <QrCode size={14} aria-hidden />
+                      </Button>
                       <Button
                         size="sm"
                         variant="secondary"

--- a/frontend/src/routes/vpn/dialogs/WgClientConfigDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/WgClientConfigDialog.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Button, Code, Dialog, FieldRow, FieldStack, Input, Label, useToast } from '@nasnet/ui';
+import {
+  buildWireguardClientConfig,
+  wireguardConfigFilename,
+} from '../../../utils/wireguard-client-config';
+
+interface Props {
+  peerName: string;
+  privateKey: string;
+  serverPublicKey: string;
+  presharedKey?: string;
+  defaultEndpoint?: string;
+  defaultAddress?: string;
+  defaultAllowedIps?: string;
+  persistentKeepalive?: string;
+  onClose: () => void;
+}
+
+export function WgClientConfigDialog({
+  peerName,
+  privateKey,
+  serverPublicKey,
+  presharedKey,
+  defaultEndpoint,
+  defaultAddress,
+  defaultAllowedIps,
+  persistentKeepalive,
+  onClose,
+}: Props) {
+  const [endpoint, setEndpoint] = useState(defaultEndpoint ?? '');
+  const [address, setAddress] = useState(defaultAddress ?? '');
+  const [dns, setDns] = useState('');
+  const [allowedIps, setAllowedIps] = useState(defaultAllowedIps ?? '0.0.0.0/0');
+  const toast = useToast();
+
+  const config = useMemo(
+    () =>
+      buildWireguardClientConfig({
+        privateKey,
+        address,
+        dns,
+        serverPublicKey,
+        presharedKey,
+        allowedIps,
+        endpoint,
+        persistentKeepalive: normalizeKeepalive(persistentKeepalive),
+      }),
+    [
+      privateKey,
+      address,
+      dns,
+      serverPublicKey,
+      presharedKey,
+      allowedIps,
+      endpoint,
+      persistentKeepalive,
+    ],
+  );
+
+  const download = () => {
+    const blob = new Blob([config], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = wireguardConfigFilename(peerName);
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(config);
+      toast.notify({ title: 'Config copied to clipboard', tone: 'success' });
+    } catch {
+      toast.notify({ title: 'Failed to copy config', tone: 'danger' });
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={`Client config - ${peerName}`}
+      size="md"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="secondary" onClick={copy}>
+            Copy
+          </Button>
+          <Button onClick={download}>Download .conf</Button>
+        </>
+      }
+    >
+      <FieldStack>
+        <FieldRow>
+          <Label>
+            <span>Server endpoint</span>
+            <Input
+              value={endpoint}
+              onChange={(e) => setEndpoint(e.target.value)}
+              placeholder="vpn.example.com:13231"
+              aria-label="Server endpoint"
+            />
+          </Label>
+          <Label>
+            <span>Client address</span>
+            <Input
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="10.8.0.2/24"
+              aria-label="Client address"
+            />
+          </Label>
+        </FieldRow>
+        <FieldRow>
+          <Label>
+            <span>DNS (optional)</span>
+            <Input
+              value={dns}
+              onChange={(e) => setDns(e.target.value)}
+              placeholder="1.1.1.1"
+              aria-label="DNS"
+            />
+          </Label>
+          <Label>
+            <span>Allowed IPs (client)</span>
+            <Input
+              value={allowedIps}
+              onChange={(e) => setAllowedIps(e.target.value)}
+              placeholder="0.0.0.0/0"
+              aria-label="Allowed IPs"
+            />
+          </Label>
+        </FieldRow>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <div style={{ background: '#fff', padding: 12, borderRadius: 8 }}>
+            <QRCodeSVG value={config} size={216} marginSize={0} />
+          </div>
+        </div>
+        <Code style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{config}</Code>
+      </FieldStack>
+    </Dialog>
+  );
+}
+
+function normalizeKeepalive(value?: string): string | undefined {
+  const match = value?.trim().match(/^\d+/);
+  return match ? match[0] : undefined;
+}

--- a/frontend/src/utils/wireguard-client-config.ts
+++ b/frontend/src/utils/wireguard-client-config.ts
@@ -1,0 +1,30 @@
+export interface WireguardClientConfigInput {
+  privateKey: string;
+  address?: string;
+  dns?: string;
+  serverPublicKey: string;
+  presharedKey?: string;
+  allowedIps?: string;
+  endpoint?: string;
+  persistentKeepalive?: string;
+}
+
+export function buildWireguardClientConfig(input: WireguardClientConfigInput): string {
+  const iface = ['[Interface]', `PrivateKey = ${input.privateKey}`];
+  if (input.address?.trim()) iface.push(`Address = ${input.address.trim()}`);
+  if (input.dns?.trim()) iface.push(`DNS = ${input.dns.trim()}`);
+
+  const peer = ['[Peer]', `PublicKey = ${input.serverPublicKey}`];
+  if (input.presharedKey?.trim()) peer.push(`PresharedKey = ${input.presharedKey.trim()}`);
+  peer.push(`AllowedIPs = ${input.allowedIps?.trim() || '0.0.0.0/0'}`);
+  if (input.endpoint?.trim()) peer.push(`Endpoint = ${input.endpoint.trim()}`);
+  if (input.persistentKeepalive?.trim())
+    peer.push(`PersistentKeepalive = ${input.persistentKeepalive.trim()}`);
+
+  return `${iface.join('\n')}\n\n${peer.join('\n')}\n`;
+}
+
+export function wireguardConfigFilename(peerName: string): string {
+  const base = peerName.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'wireguard';
+  return `${base.slice(0, 60)}.conf`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/react": "^10.65.0",
         "lucide-react": "^0.577.0",
         "motion": "^12.38.0",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0"
@@ -10802,6 +10803,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sentry/react": "^10.65.0",
     "lucide-react": "^0.577.0",
     "motion": "^12.38.0",
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0"


### PR DESCRIPTION
Closes #426

## Summary
- Allowed addresses defaults to 0.0.0.0/0 and endpoint address is now optional when adding a peer
- New client config dialog with QR code, .conf download and copy, shown after creating a peer and from a per-peer button
- Auto-generated peer keys are stored on the router so the config can be reopened later like WinBox