### PR TITLE
feat(fe): implement plugins page UI

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -106,6 +106,18 @@ export {
   type AppUpdateStatusResponse,
 } from './updates';
 export {
+  fetchPlugins,
+  installPlugin,
+  fetchPluginInstallStatus,
+  uninstallPlugin,
+  type PluginCredentials,
+  type PluginInfoResponse,
+  type PluginInstallPhase,
+  type InstallPluginResponse,
+  type PluginInstallStatusResponse,
+  type UninstallPluginResponse,
+} from './plugins';
+export {
   generateDiag,
   fetchDiagStatus,
   fetchDiagReport,

--- a/frontend/src/api/plugins.ts
+++ b/frontend/src/api/plugins.ts
@@ -1,0 +1,109 @@
+import { apiRequest } from './http';
+import type { SystemCredentials } from './system';
+
+export type PluginCredentials = SystemCredentials;
+
+export interface PluginInfoResponse {
+  id: string;
+  version: string;
+  name: string;
+  author: string;
+  category: string;
+  tagline: string;
+  url: string;
+  icon: string;
+  installed: boolean;
+  running: boolean;
+  installing: boolean;
+  failed: boolean;
+  note?: string;
+}
+
+export type PluginInstallPhase =
+  | 'preparing'
+  | 'creating_interface'
+  | 'creating_mounts'
+  | 'running_pre_install_script'
+  | 'creating_container'
+  | 'pulling'
+  | 'starting_container'
+  | 'running_post_install_script'
+  | 'done'
+  | 'error';
+
+export interface InstallPluginResponse {
+  id: string;
+  pluginId: string;
+}
+
+export interface PluginInstallStatusResponse {
+  pluginId: string;
+  phase: PluginInstallPhase;
+  message?: string;
+  startedAt?: string;
+  containerId?: string;
+  interface?: string;
+}
+
+export interface UninstallPluginResponse {
+  id: string;
+  mountLists?: string[];
+  interface?: string;
+  warnings?: string[];
+}
+
+function authHeaders({ host, username, password }: PluginCredentials): Record<string, string> {
+  return {
+    Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    'X-RouterOS-Host': host,
+  };
+}
+
+export async function fetchPlugins(
+  creds: PluginCredentials,
+  signal?: AbortSignal,
+): Promise<PluginInfoResponse[]> {
+  return apiRequest<PluginInfoResponse[]>('/api/plugin/plugins', {
+    method: 'GET',
+    headers: authHeaders(creds),
+    cache: 'no-store',
+    signal,
+  });
+}
+
+export async function installPlugin(
+  creds: PluginCredentials,
+  id: string,
+): Promise<InstallPluginResponse> {
+  return apiRequest<InstallPluginResponse>('/api/plugin/install', {
+    method: 'POST',
+    headers: authHeaders(creds),
+    body: JSON.stringify({ id }),
+  });
+}
+
+export async function fetchPluginInstallStatus(
+  creds: PluginCredentials,
+  pluginId: string,
+  signal?: AbortSignal,
+): Promise<PluginInstallStatusResponse> {
+  return apiRequest<PluginInstallStatusResponse>(
+    `/api/plugin/status/${encodeURIComponent(pluginId)}`,
+    {
+      method: 'GET',
+      headers: authHeaders(creds),
+      cache: 'no-store',
+      signal,
+    },
+  );
+}
+
+export async function uninstallPlugin(
+  creds: PluginCredentials,
+  name: string,
+): Promise<UninstallPluginResponse> {
+  return apiRequest<UninstallPluginResponse>(`/api/plugin/plugin/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+    headers: authHeaders(creds),
+  });
+}

--- a/frontend/src/routes/PluginsPage.module.scss
+++ b/frontend/src/routes/PluginsPage.module.scss
@@ -69,11 +69,49 @@
   flex-shrink: 0;
 }
 
-.cardTagline {
+.badgeGroup {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs, 4px);
+}
+
+.cardIcon {
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  object-fit: contain;
+}
+
+.cardIconFallback {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted, var(--color-surface));
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.cardNote {
   margin: 0;
-  font-size: var(--font-sm);
-  font-weight: var(--weight-medium);
-  color: var(--color-text);
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+  word-break: break-word;
+}
+
+.cardNoteFailed {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--color-danger);
+  word-break: break-word;
+}
+
+.noteBadge {
+  margin-left: var(--space-xs, 4px);
+  white-space: nowrap;
 }
 
 .cardDesc {

--- a/frontend/src/routes/PluginsPage.tsx
+++ b/frontend/src/routes/PluginsPage.tsx
@@ -1,5 +1,29 @@
-import { Download } from 'lucide-react';
-import { Badge, Button, PageShell, Stack, useToast } from '@nasnet/ui';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Blocks, Download, Trash2 } from 'lucide-react';
+import {
+  Badge,
+  Button,
+  ConfirmDialog,
+  EmptyState,
+  PageShell,
+  Progress,
+  Skeleton,
+  Stack,
+  useToast,
+} from '@nasnet/ui';
+import {
+  ApiError,
+  fetchPlugins,
+  fetchPluginInstallStatus,
+  installPlugin,
+  uninstallPlugin,
+  type PluginCredentials,
+  type PluginInfoResponse,
+} from '../api';
+import { useRouter } from '../state/RouterStoreContext';
+import { useSession } from '../state/SessionContext';
+import { usePolling } from '../utils/usePolling';
 import {
   DeltaChatLogo,
   NasnetMonitorLogo,
@@ -9,126 +33,359 @@ import {
 } from './plugins/PluginLogos';
 import styles from './PluginsPage.module.scss';
 
-interface Plugin {
-  id: string;
-  name: string;
-  author: string;
-  homepage: string;
-  category: string;
-  tagline: string;
-  description: string;
-  Logo: React.FC<{ size?: number }>;
+const PLUGIN_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+const PLUGIN_INSTALL_STEPS: Record<string, { value: number; label: string }> = {
+  preparing: { value: 5, label: 'Preparing' },
+  creating_interface: { value: 15, label: 'Creating interface' },
+  creating_mounts: { value: 25, label: 'Creating mounts' },
+  running_pre_install_script: { value: 35, label: 'Running pre-install script' },
+  creating_container: { value: 45, label: 'Creating container' },
+  pulling: { value: 65, label: 'Pulling image' },
+  starting_container: { value: 85, label: 'Starting container' },
+  running_post_install_script: { value: 95, label: 'Running post-install script' },
+};
+
+const FALLBACK_LOGOS: Record<string, React.FC<{ size?: number }>> = {
+  'telegram-mtproto': TelegramMtprotoLogo,
+  'xray-server': XrayLogo,
+  'deltachat-madmail': DeltaChatLogo,
+  'ooni-probe': OONIProbeLogo,
+  'nasnet-monitor': NasnetMonitorLogo,
+};
+
+function PluginIcon({ plugin }: { plugin: PluginInfoResponse }) {
+  const [broken, setBroken] = useState(false);
+  if (!plugin.icon || broken) {
+    const Fallback = FALLBACK_LOGOS[plugin.id];
+    if (Fallback) return <Fallback size={56} />;
+    return (
+      <span className={styles.cardIconFallback}>
+        <Blocks size={32} aria-hidden />
+      </span>
+    );
+  }
+  return (
+    <img
+      src={plugin.icon}
+      alt=""
+      width={56}
+      height={56}
+      className={styles.cardIcon}
+      onError={() => setBroken(true)}
+    />
+  );
 }
 
-const PLUGINS: Plugin[] = [
-  {
-    id: 'telegram-mtproto',
-    name: 'Telegram MTProto',
-    author: 'Telegram',
-    homepage: 'https://github.com/TelegramMessenger/MTProxy',
-    category: 'Proxy',
-    tagline: 'Self-hosted MTProto proxy for Telegram.',
-    description:
-      'Spin up an MTProto proxy on this router so devices on your network can reach Telegram through it.',
-    Logo: TelegramMtprotoLogo,
-  },
-  {
-    id: 'xray-server',
-    name: 'V2Ray / Xray',
-    author: 'Project X',
-    homepage: 'https://github.com/XTLS/Xray-core',
-    category: 'Proxy',
-    tagline: 'Self-hosted V2Ray/Xray proxy server.',
-    description:
-      'Run an Xray (V2Ray-compatible) server on this router for VLESS or VMess proxying, with TCP or WebSocket transport.',
-    Logo: XrayLogo,
-  },
-  {
-    id: 'deltachat-madmail',
-    name: 'DeltaChat',
-    author: 'DeltaChat Team',
-    homepage: 'https://delta.chat',
-    category: 'Messaging',
-    tagline: 'Decentralized email-based chat relay.',
-    description:
-      'Bring up a DeltaChat relay endpoint for offline-friendly, end-to-end encrypted messaging over standard email.',
-    Logo: DeltaChatLogo,
-  },
-  {
-    id: 'ooni-probe',
-    name: 'OONI Probe',
-    author: 'OONI',
-    homepage: 'https://ooni.org',
-    category: 'Measurement',
-    tagline: 'Measure internet censorship from your network.',
-    description:
-      'Run scheduled OONI Probe tests from this router to detect blocking of websites and apps, and contribute open measurement data to the OONI network.',
-    Logo: OONIProbeLogo,
-  },
-  {
-    id: 'nasnet-monitor',
-    name: 'NASNET Monitor',
-    author: 'NASNET Community',
-    homepage: 'https://github.com/nasnet-community',
-    category: 'Monitoring',
-    tagline: 'Router and network health monitoring.',
-    description:
-      'Collect router metrics, container status and connectivity checks on this router, with a local dashboard and optional alert webhooks.',
-    Logo: NasnetMonitorLogo,
-  },
-];
+const NOTE_PROGRESS_RE = /^(.*?)\s*(\d+(?:\.\d+)?%)\/(\S+)$/;
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function PluginNote({ note, failed }: { note: string; failed: boolean }) {
+  const className = failed ? styles.cardNoteFailed : styles.cardNote;
+  const match = NOTE_PROGRESS_RE.exec(note);
+  if (!match) return <p className={className}>{capitalize(note)}</p>;
+  const [, text, percent, size] = match;
+  return (
+    <p className={className}>
+      {capitalize(text)}
+      <Badge tone={failed ? 'danger' : 'info'} className={styles.noteBadge}>
+        {percent} / {size}
+      </Badge>
+    </p>
+  );
+}
+
+function statusBadge(
+  plugin: PluginInfoResponse,
+  localInstalling: boolean,
+): { tone: 'success' | 'danger' | 'info' | 'neutral'; label: string } | null {
+  if (plugin.failed) return { tone: 'danger', label: 'failed' };
+  if (plugin.installing || localInstalling) return { tone: 'info', label: 'installing' };
+  if (plugin.running) return { tone: 'success', label: 'running' };
+  if (plugin.installed) return { tone: 'neutral', label: 'installed' };
+  return null;
+}
+
+function CardSkeleton() {
+  return (
+    <article className={styles.card} aria-busy>
+      <div className={styles.cardTop}>
+        <Skeleton width={56} height={56} radius={14} />
+        <Stack $gap="8px" className={styles.cardHead}>
+          <Skeleton width={140} height={18} />
+          <Skeleton width={100} height={12} />
+        </Stack>
+      </div>
+      <Skeleton width={220} height={12} />
+      <Skeleton width={180} height={12} />
+      <div className={styles.cardActions}>
+        <Skeleton width={72} height={22} radius={999} />
+        <Skeleton width={90} height={28} radius={8} />
+      </div>
+    </article>
+  );
+}
 
 export function PluginsPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter(id);
+  const { getCredentials } = useSession();
   const toast = useToast();
 
-  const install = (plugin: Plugin) => {
-    toast.notify({
-      title: `${plugin.name} is not available yet`,
-      description: 'Plugin installation is coming in a future release.',
-      tone: 'info',
+  const [plugins, setPlugins] = useState<PluginInfoResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [installs, setInstalls] = useState<Record<string, { value: number; label: string }>>({});
+  const [confirmingUninstall, setConfirmingUninstall] = useState<PluginInfoResponse | null>(null);
+  const [uninstallingId, setUninstallingId] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+  const watchingRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    const watching = watchingRef.current;
+    return () => {
+      watching.clear();
+    };
+  }, []);
+
+  const creds = useMemo<PluginCredentials | null>(() => {
+    if (!id) return null;
+    const c = getCredentials(id);
+    const host = router?.host;
+    if (!c || !host) return null;
+    return { host, username: c.username, password: c.password };
+  }, [id, router?.host, getCredentials]);
+
+  const reload = useCallback(
+    async (silent = false) => {
+      if (!creds) return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      if (!silent) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const data = await fetchPlugins(creds);
+        setPlugins(data);
+        if (silent) setError(null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load plugins.';
+        if (!silent) {
+          setError(message);
+          setPlugins([]);
+        }
+      } finally {
+        inFlightRef.current = false;
+        setLoading(false);
+      }
+    },
+    [creds],
+  );
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  usePolling(() => reload(true), 5000, Boolean(creds));
+
+  const stopWatching = (pluginId: string) => {
+    watchingRef.current.delete(pluginId);
+    setInstalls((prev) => {
+      const next = { ...prev };
+      delete next[pluginId];
+      return next;
     });
+  };
+
+  const failInstall = (pluginId: string, name: string, message: string) => {
+    stopWatching(pluginId);
+    toast.notify({ title: `${name} install failed`, description: message, tone: 'danger' });
+    void reload(true);
+  };
+
+  const watchInstall = (pluginId: string, name: string, startedAt: number) => {
+    if (!watchingRef.current.has(pluginId) || !creds) return;
+    if (Date.now() - startedAt > PLUGIN_INSTALL_TIMEOUT_MS) {
+      failInstall(pluginId, name, 'Timed out waiting for the install to finish');
+      return;
+    }
+    void fetchPluginInstallStatus(creds, pluginId)
+      .then(
+        (status) => status,
+        (err) => (err instanceof ApiError && err.status === 404 ? ('gone' as const) : null),
+      )
+      .then((status) => {
+        if (!watchingRef.current.has(pluginId)) return;
+        if (status === 'gone') {
+          stopWatching(pluginId);
+          void reload(true);
+          return;
+        }
+        if (status?.phase === 'error') {
+          failInstall(pluginId, name, status.message || 'Plugin install failed');
+          return;
+        }
+        if (status?.phase === 'done') {
+          stopWatching(pluginId);
+          toast.notify({ title: `${name} installed`, tone: 'success' });
+          void reload(true);
+          return;
+        }
+        const step = status ? PLUGIN_INSTALL_STEPS[status.phase] : undefined;
+        if (step) setInstalls((prev) => ({ ...prev, [pluginId]: step }));
+        window.setTimeout(() => watchInstall(pluginId, name, startedAt), 2000);
+      });
+  };
+
+  const install = async (plugin: PluginInfoResponse) => {
+    if (!creds) return;
+    watchingRef.current.add(plugin.id);
+    setInstalls((prev) => ({ ...prev, [plugin.id]: { value: 5, label: 'Starting install' } }));
+    try {
+      await installPlugin(creds, plugin.id);
+      watchInstall(plugin.id, plugin.name, Date.now());
+    } catch (err) {
+      stopWatching(plugin.id);
+      toast.notify({
+        title: `${plugin.name} install failed`,
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+      void reload(true);
+    }
+  };
+
+  const uninstall = async () => {
+    const plugin = confirmingUninstall;
+    setConfirmingUninstall(null);
+    if (!plugin || !creds) return;
+    setUninstallingId(plugin.id);
+    try {
+      const result = await uninstallPlugin(creds, plugin.id);
+      if (result.warnings?.length) {
+        toast.notify({
+          title: `${plugin.name} uninstalled with warnings`,
+          description: result.warnings.join(' '),
+          tone: 'warning',
+        });
+      } else {
+        toast.notify({ title: `${plugin.name} uninstalled`, tone: 'success' });
+      }
+    } catch (err) {
+      toast.notify({
+        title: `${plugin.name} uninstall failed`,
+        description: err instanceof Error ? err.message : undefined,
+        tone: 'danger',
+      });
+    } finally {
+      setUninstallingId(null);
+      void reload(true);
+    }
   };
 
   return (
     <PageShell>
-      <div className={styles.grid}>
-        {PLUGINS.map((plugin) => {
-          const { Logo } = plugin;
-          return (
-            <article key={plugin.id} className={styles.card}>
-              <div className={styles.cardTop}>
-                <Logo size={56} />
-                <Stack $gap="4px" className={styles.cardHead}>
-                  <h3 className={styles.cardTitle} title={plugin.name}>
-                    {plugin.name}
-                  </h3>
-                  <p className={styles.cardAuthor}>
-                    by{' '}
-                    <a
-                      href={plugin.homepage}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={styles.cardAuthorLink}
+      {loading && plugins.length === 0 ? (
+        <div className={styles.grid}>
+          {Array.from({ length: 4 }, (_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      ) : error && plugins.length === 0 ? (
+        <EmptyState
+          title="Failed to load plugins"
+          description={error}
+          actions={<Button onClick={() => reload()}>Retry</Button>}
+        />
+      ) : plugins.length === 0 ? (
+        <EmptyState
+          title="No plugins available"
+          description="The plugin registry did not return any plugins."
+        />
+      ) : (
+        <div className={styles.grid}>
+          {plugins.map((plugin) => {
+            const localInstall = installs[plugin.id];
+            const badge = statusBadge(plugin, Boolean(localInstall));
+            const installing = Boolean(localInstall) || plugin.installing;
+            return (
+              <article key={plugin.id} className={styles.card}>
+                <div className={styles.cardTop}>
+                  <PluginIcon plugin={plugin} />
+                  <Stack $gap="4px" className={styles.cardHead}>
+                    <h3 className={styles.cardTitle} title={plugin.name}>
+                      {plugin.name}
+                    </h3>
+                    <p className={styles.cardAuthor}>
+                      by{' '}
+                      <a
+                        href={plugin.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.cardAuthorLink}
+                      >
+                        {plugin.author}
+                      </a>{' '}
+                      · v{plugin.version}
+                    </p>
+                  </Stack>
+                </div>
+                <p className={styles.cardDesc}>{plugin.tagline}</p>
+                {plugin.note ? <PluginNote note={plugin.note} failed={plugin.failed} /> : null}
+                {localInstall ? (
+                  <Progress value={localInstall.value} label={localInstall.label} />
+                ) : null}
+                <div className={styles.cardActions}>
+                  <div className={styles.badgeGroup}>
+                    <Badge tone="neutral" className={styles.categoryBadge}>
+                      {plugin.category}
+                    </Badge>
+                    {badge ? <Badge tone={badge.tone}>{badge.label}</Badge> : null}
+                  </div>
+                  {installing ? (
+                    <Button variant="primary" size="sm" loading>
+                      Installing…
+                    </Button>
+                  ) : plugin.installed ? (
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => setConfirmingUninstall(plugin)}
+                      loading={uninstallingId === plugin.id}
                     >
-                      {plugin.author}
-                    </a>
-                  </p>
-                </Stack>
-              </div>
-              <p className={styles.cardTagline}>{plugin.tagline}</p>
-              <p className={styles.cardDesc}>{plugin.description}</p>
-              <div className={styles.cardActions}>
-                <Badge tone="neutral" className={styles.categoryBadge}>
-                  {plugin.category}
-                </Badge>
-                <Button variant="primary" size="sm" onClick={() => install(plugin)}>
-                  <Download size={14} aria-hidden /> Install
-                </Button>
-              </div>
-            </article>
-          );
-        })}
-      </div>
+                      {uninstallingId === plugin.id ? (
+                        'Uninstalling…'
+                      ) : (
+                        <>
+                          <Trash2 size={14} aria-hidden /> Uninstall
+                        </>
+                      )}
+                    </Button>
+                  ) : (
+                    <Button variant="primary" size="sm" onClick={() => install(plugin)}>
+                      <Download size={14} aria-hidden /> Install
+                    </Button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmingUninstall !== null}
+        title={`Uninstall ${confirmingUninstall?.name ?? 'plugin'}?`}
+        description="The plugin container and its resources are removed from the router."
+        destructive
+        confirmLabel="Uninstall"
+        onConfirm={uninstall}
+        onCancel={() => setConfirmingUninstall(null)}
+      />
     </PageShell>
   );
 }

--- a/frontend/tests/e2e/26-plugins-page.spec.ts
+++ b/frontend/tests/e2e/26-plugins-page.spec.ts
@@ -2,16 +2,60 @@ import { test, expect } from './fixtures';
 
 const ROUTER = { id: 'rtr_plugins', name: 'Plugins Router', host: '10.0.0.6' };
 
+const envelope = <T>(data: T) => JSON.stringify({ status: 200, message: 'OK', data });
+
+const basePlugin = {
+  version: '1.0.0',
+  category: 'Proxy',
+  url: 'https://example.com',
+  icon: '',
+  installed: false,
+  running: false,
+  installing: false,
+  failed: false,
+};
+
+const CATALOG = [
+  {
+    ...basePlugin,
+    id: 'xray-server',
+    name: 'V2Ray / Xray',
+    author: 'Project X',
+    tagline: 'Self-hosted V2Ray/Xray proxy server.',
+  },
+  {
+    ...basePlugin,
+    id: 'ooni-probe',
+    name: 'OONI Probe',
+    author: 'OONI',
+    category: 'Measurement',
+    url: 'https://ooni.org',
+    tagline: 'Measure internet censorship from your network.',
+  },
+];
+
 test.describe('Plugins page', () => {
-  test('Plugins tab navigates to the page and lists the catalog', async ({
+  test('Plugins tab navigates to the page and lists registry plugins', async ({
+    context,
     page,
     resetMocks,
     seedRouter,
+    seedCredentials,
     mockOverviewBackend,
   }) => {
     await resetMocks();
     await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
     await mockOverviewBackend({ id: ROUTER.id });
+
+    await context.route('**/api/plugin/plugins', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([CATALOG[0], { ...CATALOG[1], installed: true, running: true }]),
+      });
+    });
+
     await page.goto(`/router/${ROUTER.id}`);
 
     const pluginsTab = page.getByRole('tab', { name: 'Plugins' });
@@ -19,36 +63,24 @@ test.describe('Plugins page', () => {
     await pluginsTab.click();
 
     await expect(page).toHaveURL(new RegExp(`/router/${ROUTER.id}/plugins$`));
-    await expect(page.getByRole('article')).toHaveCount(5);
-    await expect(page.getByRole('heading', { name: 'Telegram MTProto' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'NASNET Monitor' })).toBeVisible();
-  });
-
-  test('install button reports that installation is not available yet', async ({
-    page,
-    resetMocks,
-    seedRouter,
-    seedCredentials,
-  }) => {
-    await resetMocks();
-    await seedRouter(ROUTER);
-    await seedCredentials(ROUTER.id);
-    await page.goto(`/router/${ROUTER.id}/plugins`);
+    await expect(page.getByRole('article')).toHaveCount(2);
+    await expect(page.getByRole('heading', { name: 'V2Ray / Xray' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'OONI Probe' })).toBeVisible();
 
     const ooniCard = page
       .getByRole('article')
       .filter({ has: page.getByRole('heading', { name: 'OONI Probe' }) });
-    const installButton = ooniCard.getByRole('button', { name: /install/i });
+    await expect(ooniCard.getByText('running', { exact: true })).toBeVisible();
+    await expect(ooniCard.getByRole('button', { name: /uninstall/i })).toBeVisible();
 
-    await expect(installButton).toHaveText('Install');
-    await installButton.click();
-
-    await expect(page.getByText('OONI Probe is not available yet')).toBeVisible();
-    await expect(installButton).toHaveText('Install');
-    await expect(installButton).toBeEnabled();
+    const authorLink = ooniCard.getByRole('link', { name: 'OONI' });
+    await expect(authorLink).toHaveAttribute('target', '_blank');
+    await expect(authorLink).toHaveAttribute('rel', /noopener/);
+    await expect(authorLink).toHaveAttribute('href', 'https://ooni.org');
   });
 
-  test('author name links to the project site in a new tab', async ({
+  test('install starts an async install, polls status, and refreshes the list', async ({
+    context,
     page,
     resetMocks,
     seedRouter,
@@ -57,15 +89,163 @@ test.describe('Plugins page', () => {
     await resetMocks();
     await seedRouter(ROUTER);
     await seedCredentials(ROUTER.id);
+
+    let installed = false;
+
+    await context.route('**/api/plugin/plugins', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([{ ...CATALOG[0], installed, running: installed }, CATALOG[1]]),
+      });
+    });
+
+    await context.route('**/api/plugin/install', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      installed = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ id: 'xray-server', pluginId: 'xray-server' }),
+      });
+    });
+
+    await context.route('**/api/plugin/status/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ pluginId: 'xray-server', phase: 'done' }),
+      });
+    });
+
     await page.goto(`/router/${ROUTER.id}/plugins`);
 
-    const deltaChatCard = page
+    const xrayCard = page
       .getByRole('article')
-      .filter({ has: page.getByRole('heading', { name: 'DeltaChat' }) });
-    const authorLink = deltaChatCard.getByRole('link', { name: 'DeltaChat Team' });
+      .filter({ has: page.getByRole('heading', { name: 'V2Ray / Xray' }) });
+    await xrayCard.getByRole('button', { name: /^install$/i }).click();
 
-    await expect(authorLink).toHaveAttribute('target', '_blank');
-    await expect(authorLink).toHaveAttribute('rel', /noopener/);
-    await expect(authorLink).toHaveAttribute('href', 'https://delta.chat');
+    await expect(page.getByText('V2Ray / Xray installed')).toBeVisible();
+    await expect(xrayCard.getByRole('button', { name: /uninstall/i })).toBeVisible();
+  });
+
+  test('install failure surfaces the error on the plugin without blocking others', async ({
+    context,
+    page,
+    resetMocks,
+    seedRouter,
+    seedCredentials,
+  }) => {
+    await resetMocks();
+    await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
+
+    let failed = false;
+
+    await context.route('**/api/plugin/plugins', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([
+          {
+            ...CATALOG[0],
+            installed: failed,
+            failed,
+            note: failed ? 'Errc: failed to pull image' : undefined,
+          },
+          CATALOG[1],
+        ]),
+      });
+    });
+
+    await context.route('**/api/plugin/install', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      failed = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({ id: 'xray-server', pluginId: 'xray-server' }),
+      });
+    });
+
+    await context.route('**/api/plugin/status/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          pluginId: 'xray-server',
+          phase: 'error',
+          message: 'Errc: failed to pull image',
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER.id}/plugins`);
+
+    const xrayCard = page
+      .getByRole('article')
+      .filter({ has: page.getByRole('heading', { name: 'V2Ray / Xray' }) });
+    await xrayCard.getByRole('button', { name: /^install$/i }).click();
+
+    await expect(page.getByText('V2Ray / Xray install failed')).toBeVisible();
+    await expect(xrayCard.getByText('failed', { exact: true })).toBeVisible();
+    await expect(xrayCard.getByText('Errc: failed to pull image')).toBeVisible();
+
+    const ooniCard = page
+      .getByRole('article')
+      .filter({ has: page.getByRole('heading', { name: 'OONI Probe' }) });
+    await expect(ooniCard.getByRole('button', { name: /^install$/i })).toBeEnabled();
+  });
+
+  test('uninstall requires confirmation and surfaces cleanup warnings', async ({
+    context,
+    page,
+    resetMocks,
+    seedRouter,
+    seedCredentials,
+  }) => {
+    await resetMocks();
+    await seedRouter(ROUTER);
+    await seedCredentials(ROUTER.id);
+
+    let installed = true;
+
+    await context.route('**/api/plugin/plugins', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope([{ ...CATALOG[0], installed, running: installed }, CATALOG[1]]),
+      });
+    });
+
+    await context.route('**/api/plugin/plugin/*', async (route) => {
+      if (route.request().method() !== 'DELETE') return route.fallback();
+      installed = false;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          id: 'xray-server',
+          warnings: ['Failed to remove veth interface veth-xray'],
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER.id}/plugins`);
+
+    const xrayCard = page
+      .getByRole('article')
+      .filter({ has: page.getByRole('heading', { name: 'V2Ray / Xray' }) });
+    await xrayCard.getByRole('button', { name: /uninstall/i }).click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /uninstall/i })
+      .click();
+
+    await expect(page.getByText('V2Ray / Xray uninstalled with warnings')).toBeVisible();
+    await expect(page.getByText('Failed to remove veth interface veth-xray')).toBeVisible();
+    await expect(xrayCard.getByRole('button', { name: /^install$/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
<img width="1268" height="535" alt="Screenshot 2026-07-31 at 02 03 59" src="https://github.com/user-attachments/assets/f8f0b319-c1ee-4f59-8c69-ec7552a802e9" />

Closes #451

## Summary

- Plugins page now lists registry plugins with live state badges, icons, and pull progress notes
- Install runs async with per plugin phase progress, a failure only affects its own card
- Uninstall asks for confirmation and surfaces cleanup warnings