### PR TITLE
feat(fe): Show coming soon for plugins that cannot be installed

### DIFF
--- a/frontend/src/api/plugins.ts
+++ b/frontend/src/api/plugins.ts
@@ -11,6 +11,7 @@ export interface PluginInfoResponse {
   category: string;
   tagline: string;
   url: string;
+  canInstall: boolean;
   icon: string;
   installed: boolean;
   running: boolean;

--- a/frontend/src/routes/PluginsPage.tsx
+++ b/frontend/src/routes/PluginsPage.tsx
@@ -365,9 +365,13 @@ export function PluginsPage() {
                         </>
                       )}
                     </Button>
-                  ) : (
+                  ) : plugin.canInstall ? (
                     <Button variant="primary" size="sm" onClick={() => install(plugin)}>
                       <Download size={14} aria-hidden /> Install
+                    </Button>
+                  ) : (
+                    <Button variant="secondary" size="sm" disabled>
+                      Coming soon
                     </Button>
                   )}
                 </div>

--- a/frontend/tests/e2e/26-plugins-page.spec.ts
+++ b/frontend/tests/e2e/26-plugins-page.spec.ts
@@ -9,6 +9,7 @@ const basePlugin = {
   category: 'Proxy',
   url: 'https://example.com',
   icon: '',
+  canInstall: true,
   installed: false,
   running: false,
   installing: false,
@@ -52,7 +53,10 @@ test.describe('Plugins page', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: envelope([CATALOG[0], { ...CATALOG[1], installed: true, running: true }]),
+        body: envelope([
+          { ...CATALOG[0], canInstall: false },
+          { ...CATALOG[1], installed: true, running: true },
+        ]),
       });
     });
 
@@ -72,6 +76,12 @@ test.describe('Plugins page', () => {
       .filter({ has: page.getByRole('heading', { name: 'OONI Probe' }) });
     await expect(ooniCard.getByText('running', { exact: true })).toBeVisible();
     await expect(ooniCard.getByRole('button', { name: /uninstall/i })).toBeVisible();
+
+    const xrayCard = page
+      .getByRole('article')
+      .filter({ has: page.getByRole('heading', { name: 'V2Ray / Xray' }) });
+    await expect(xrayCard.getByRole('button', { name: 'Coming soon' })).toBeDisabled();
+    await expect(xrayCard.getByRole('button', { name: /install/i })).toHaveCount(0);
 
     const authorLink = ooniCard.getByRole('link', { name: 'OONI' });
     await expect(authorLink).toHaveAttribute('target', '_blank');


### PR DESCRIPTION
## Summary
- consume the new canInstall flag from the plugins list
- plugins with canInstall false get a disabled Coming soon button instead of Install
- e2e coverage for the disabled state