### PR TITLE
fix(fe): bigger free VPN button with label on wizard IP-Mask step

### DIFF
--- a/frontend/src/routes/easy-config/steps/ipmask/IpMaskL2tpFields.tsx
+++ b/frontend/src/routes/easy-config/steps/ipmask/IpMaskL2tpFields.tsx
@@ -39,10 +39,10 @@ export function IpMaskL2tpFields({ state, dispatch }: Props) {
               type="button"
               variant="secondary"
               onClick={() => setClaimOpen(true)}
-              aria-label="Claim a free VPN"
-              title="Claim a free VPN"
+              style={{ whiteSpace: 'nowrap' }}
             >
-              <Sparkles size={14} strokeWidth={2} />
+              <Sparkles size={16} strokeWidth={2} />
+              Claim free VPN
             </Button>
           </div>
         </Label>


### PR DESCRIPTION
<img width="422" height="338" alt="Screenshot 2026-08-06 at 00 27 10" src="https://github.com/user-attachments/assets/8b1a8cdf-5d85-4551-8fbf-5f1139cfbdce" />

Closes #471

## Summary

- the free VPN button on the IP-Mask step was a small icon-only button and easy to miss
- it now shows a "Claim free VPN" label next to the sparkles icon at normal button size