### PR TITLE
feat(fe): wizard WiFi split off by default

### DIFF
--- a/frontend/src/routes/easy-config/state.ts
+++ b/frontend/src/routes/easy-config/state.ts
@@ -79,7 +79,7 @@ export const initial: State = {
   staticDns: '',
   wifiInterface: '',
   wifiEnabled: true,
-  wifiSplit: true,
+  wifiSplit: false,
   ssid: '',
   wifiPassword: '',
   security: 'WPA2-PSK',

--- a/frontend/src/routes/easy-config/steps/WifiStep.tsx
+++ b/frontend/src/routes/easy-config/steps/WifiStep.tsx
@@ -36,6 +36,12 @@ const BAND_LABELS: Record<BandKey, string> = {
   '6': '6 GHz',
 };
 
+const BAND_SUFFIXES: Record<BandKey, string> = {
+  '24': '2.4',
+  '5': '5',
+  '6': '6',
+};
+
 function bandKeyFor(wi: WifiInterfaceResponse): BandKey | null {
   const b = (wi.band ?? '').toLowerCase();
   if (b.startsWith('2')) return '24';
@@ -69,7 +75,10 @@ export function WifiStep({ state, dispatch, wifiInterfaces, wifiSupported, foote
   const bandList = availableBands.map((k) => BAND_LABELS[k]).join(' and ');
 
   const previewBands = split
-    ? availableBands.map((k) => ({ ssid: state.ssid, band: BAND_LABELS[k] }))
+    ? availableBands.map((k) => ({
+        ssid: state.ssid.trim() ? `${state.ssid}-${BAND_SUFFIXES[k]}` : state.ssid,
+        band: BAND_LABELS[k],
+      }))
     : [{ ssid: state.ssid, band: availableBands[0] ? BAND_LABELS[availableBands[0]] : undefined }];
 
   return (

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -113,8 +113,12 @@ function buildScript(state: State): string {
       band: state.band,
       countryCode: state.countryCode,
       splitBands: state.wifiSplit,
-      band24: state.wifiSplit ? { ssid: state.ssid, password: state.wifiPassword } : undefined,
-      band5: state.wifiSplit ? { ssid: state.ssid, password: state.wifiPassword } : undefined,
+      band24: state.wifiSplit
+        ? { ssid: `${state.ssid}-2.4`, password: state.wifiPassword }
+        : undefined,
+      band5: state.wifiSplit
+        ? { ssid: `${state.ssid}-5`, password: state.wifiPassword }
+        : undefined,
     },
     ipMask: state.ipMaskEnabled
       ? state.ipMaskKind === 'wireguard'

--- a/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
+++ b/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test.describe('Easy-Mode wizard — multi-band WiFi', () => {
-  test('shares one SSID across bands via the split toggle and applies', async ({
+  test('offers the split toggle off by default, suffixes band names when enabled, and applies', async ({
     page,
     resetMocks,
     seedRouter,
@@ -39,12 +39,12 @@ Endpoint = mask.example.com:51820
 AllowedIPs = 0.0.0.0/0`);
     await page.getByRole('button', { name: /^next$/i }).click();
 
-    // Step 4 — the router reports three radios, so the split toggle is offered and on by default
+    // Step 4 — the router reports three radios, so the split toggle is offered, off by default
     const splitToggle = page.getByRole('switch', { name: /split across bands/i });
     await expect(splitToggle).toBeVisible();
-    await expect(splitToggle).toBeChecked();
+    await expect(splitToggle).not.toBeChecked();
 
-    // A single SSID and password now cover every band
+    // A single SSID and password cover every band
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('NN-Home');
     await page.getByLabel('Wi-Fi password', { exact: true }).fill('longpassword');
 
@@ -52,6 +52,12 @@ AllowedIPs = 0.0.0.0/0`);
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('');
     await expect(page.getByRole('button', { name: /^next$/i })).toBeDisabled();
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('NN-Home');
+
+    await splitToggle.check();
+    await expect(splitToggle).toBeChecked();
+    await expect(page.getByText('NN-Home-2.4')).toBeVisible();
+    await expect(page.getByText('NN-Home-5', { exact: true })).toBeVisible();
+    await expect(page.getByText('NN-Home-6', { exact: true })).toBeVisible();
 
     // Splitting can be turned off to keep the network on a single band
     await splitToggle.uncheck();


### PR DESCRIPTION
Closes #476

- Split switch on the wizard WiFi step now starts off
- Turning it on appends the 2.4 / 5 band suffixes to the wireless name in the preview and generated script
- E2E spec updated for the new default and suffixed names