### PR TITLE
feat(fe): hide VPN server step in Starlink-only wizard

### DIFF
--- a/frontend/src/routes/EasyConfigWizard.tsx
+++ b/frontend/src/routes/EasyConfigWizard.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { Button, FormError, Stack, Stepper } from '@nasnet/ui';
 import styles from './EasyConfigWizard.module.scss';
-import { stepOrder, stepTitles } from './easy-config/state';
+import { stepsForMode, stepTitles } from './easy-config/state';
 import { useEasyConfig } from './easy-config/useEasyConfig';
 import { ModeStep } from './easy-config/steps/ModeStep';
 import { WanStep } from './easy-config/steps/WanStep';
@@ -26,9 +26,10 @@ export function EasyConfigWizard() {
     goPrev,
     advanceProblem,
   } = useEasyConfig(id);
-  const activeIndex = stepOrder.indexOf(state.currentStep);
+  const steps = stepsForMode(state.mode);
+  const activeIndex = steps.indexOf(state.currentStep);
   const canSave = advanceProblem === null;
-  const isLastStep = activeIndex === stepOrder.length - 1;
+  const isLastStep = activeIndex === steps.length - 1;
   const { dialogOpen, openDialog, closeDialog, goToOverview } = useApplyDialog(
     state.applying,
     state.applied,
@@ -124,7 +125,7 @@ export function EasyConfigWizard() {
       <Stepper
         orientation="horizontal"
         activeIndex={activeIndex}
-        steps={stepOrder.map((stepId) => ({
+        steps={steps.map((stepId) => ({
           id: stepId,
           title: stepTitles[stepId].title,
           description: stepTitles[stepId].description,

--- a/frontend/src/routes/easy-config/state.ts
+++ b/frontend/src/routes/easy-config/state.ts
@@ -133,7 +133,11 @@ export type Action =
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'setMode':
-      return { ...state, mode: action.mode };
+      return {
+        ...state,
+        mode: action.mode,
+        vpnServerEnabled: action.mode === 'starlink-only' ? false : state.vpnServerEnabled,
+      };
     case 'setField':
       return { ...state, [action.field]: action.value } as State;
     case 'setKeys':
@@ -158,6 +162,10 @@ export function reducer(state: State, action: Action): State {
 }
 
 export const stepOrder: StepId[] = ['mode', 'wan', 'ipmask', 'wifi', 'vpnsrv'];
+
+export function stepsForMode(mode: Mode | null): StepId[] {
+  return mode === 'starlink-only' ? stepOrder.filter((s) => s !== 'vpnsrv') : stepOrder;
+}
 
 export const stepTitles: Record<StepId, { title: string; description: string }> = {
   mode: { title: 'Choose', description: 'Setup type' },

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -15,7 +15,7 @@ import { useRouter } from '../../state/RouterStoreContext';
 import { useWizardGate } from '../../state/WizardGateContext';
 import { buildEasyConfigScript, type EasyConfigInput } from '../../utils/rsc-builder';
 import { canAdvance } from './validation';
-import { initial, reducer, stepOrder, type State } from './state';
+import { initial, reducer, stepsForMode, type State } from './state';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 6 * 60 * 1000;
@@ -298,14 +298,16 @@ export function useEasyConfig(routerId: string | undefined) {
       dispatch({ type: 'error', message: advanceProblem });
       return;
     }
-    const idx = stepOrder.indexOf(state.currentStep);
-    const next = stepOrder[idx + 1];
+    const steps = stepsForMode(state.mode);
+    const idx = steps.indexOf(state.currentStep);
+    const next = steps[idx + 1];
     if (next) dispatch({ type: 'step', step: next });
   };
 
   const goPrev = () => {
-    const idx = stepOrder.indexOf(state.currentStep);
-    const prev = stepOrder[idx - 1];
+    const steps = stepsForMode(state.mode);
+    const idx = steps.indexOf(state.currentStep);
+    const prev = steps[idx - 1];
     if (prev) dispatch({ type: 'step', step: prev });
   };
 

--- a/frontend/tests/e2e/07-easy-config-starlink-only.spec.ts
+++ b/frontend/tests/e2e/07-easy-config-starlink-only.spec.ts
@@ -14,7 +14,9 @@ test.describe('Easy-Mode wizard — Starlink-only', () => {
 
     // Step 1 — Choose (Starlink-only drops the VPN Server step)
     await page.getByRole('radio', { name: /starlink-only/i }).check();
-    await expect(page.getByText('VPN Server')).toHaveCount(0);
+    await expect(
+      page.getByRole('list', { name: 'Wizard progress' }).getByText('VPN Server'),
+    ).toHaveCount(0);
     await page.getByRole('button', { name: /^next$/i }).click();
 
     // Step 2 — WAN (Ethernet tile is default)

--- a/frontend/tests/e2e/07-easy-config-starlink-only.spec.ts
+++ b/frontend/tests/e2e/07-easy-config-starlink-only.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test.describe('Easy-Mode wizard — Starlink-only', () => {
-  test('step through all five steps and apply', async ({
+  test('step through all four steps and apply', async ({
     page,
     resetMocks,
     seedRouter,
@@ -12,8 +12,9 @@ test.describe('Easy-Mode wizard — Starlink-only', () => {
     await mockEasyConfigBackend({ id: 'rtr_easy' });
     await page.goto('/router/rtr_easy/config');
 
-    // Step 1 — Choose
+    // Step 1 — Choose (Starlink-only drops the VPN Server step)
     await page.getByRole('radio', { name: /starlink-only/i }).check();
+    await expect(page.getByText('VPN Server')).toHaveCount(0);
     await page.getByRole('button', { name: /^next$/i }).click();
 
     // Step 2 — WAN (Ethernet tile is default)
@@ -33,12 +34,9 @@ AllowedIPs = 0.0.0.0/0
 PersistentKeepalive = 25`);
     await page.getByRole('button', { name: /^next$/i }).click();
 
-    // Step 4 — WiFi
+    // Step 4 — WiFi (last step) — Apply
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('Easy-SSID');
     await page.getByLabel('Wi-Fi password', { exact: true }).fill('longpassword');
-    await page.getByRole('button', { name: /^next$/i }).click();
-
-    // Step 5 — VPN Server (disabled by default) — Apply
     await page.getByRole('button', { name: /^apply$/i }).click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });

--- a/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
+++ b/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
@@ -12,13 +12,15 @@ test.describe('Easy-Mode wizard — VPN server step', () => {
     await mockEasyConfigBackend({ id: 'rtr_vpn' });
     await page.goto('/router/rtr_vpn/config');
 
-    // Step 1 — Choose
-    await page.getByRole('radio', { name: /starlink-only/i }).check();
+    // Step 1 — Choose (dual-link keeps the VPN Server step)
+    await page.getByRole('radio', { name: /dual-link/i }).check();
     await page.getByRole('button', { name: /^next$/i }).click();
 
     // Step 2 — WAN
     await page.getByLabel(/starlink wan/i).click();
     await page.getByRole('option', { name: 'ether1' }).click();
+    await page.getByLabel(/domestic wan/i).click();
+    await page.getByRole('option', { name: 'ether2' }).click();
     await page.getByRole('button', { name: /^next$/i }).click();
 
     // Step 3 — IP-Mask (WireGuard is default)

--- a/frontend/tests/e2e/22-easy-config-wireless-scan.spec.ts
+++ b/frontend/tests/e2e/22-easy-config-wireless-scan.spec.ts
@@ -52,12 +52,9 @@ Endpoint = mask.example.com:51820
 AllowedIPs = 0.0.0.0/0`);
     await page.getByRole('button', { name: /^next$/i }).click();
 
-    // Step 4 — WiFi
+    // Step 4 — WiFi (last step) — Apply
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('Wireless-Net');
     await page.getByLabel('Wi-Fi password', { exact: true }).fill('longpassword');
-    await page.getByRole('button', { name: /^next$/i }).click();
-
-    // Step 5 — Apply (vpn server stays disabled)
     await page.getByRole('button', { name: /^apply$/i }).click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });

--- a/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
+++ b/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
@@ -48,18 +48,16 @@ AllowedIPs = 0.0.0.0/0`);
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('NN-Home');
     await page.getByLabel('Wi-Fi password', { exact: true }).fill('longpassword');
 
-    // An empty SSID blocks Next
+    // An empty SSID blocks Apply
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('');
-    await expect(page.getByRole('button', { name: /^next$/i })).toBeDisabled();
+    await expect(page.getByRole('button', { name: /^apply$/i })).toBeDisabled();
     await page.getByLabel('Network name (SSID)', { exact: true }).fill('NN-Home');
 
     // Splitting can be turned off to keep the network on a single band
     await splitToggle.uncheck();
     await expect(splitToggle).not.toBeChecked();
 
-    await page.getByRole('button', { name: /^next$/i }).click();
-
-    // Step 5 — Apply
+    // WiFi is the last step in Starlink-only — Apply
     await page.getByRole('button', { name: /^apply$/i }).click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });

--- a/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
+++ b/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
@@ -20,8 +20,6 @@ AllowedIPs = 0.0.0.0/0`);
 
   await page.getByLabel('Network name (SSID)', { exact: true }).fill('Progress-Net');
   await page.getByLabel('Wi-Fi password', { exact: true }).fill('longpassword');
-  await page.getByRole('button', { name: /^next$/i }).click();
-
   await page.getByRole('button', { name: /^apply$/i }).click();
 }
 

--- a/frontend/tests/e2e/32-easy-config-no-wifi-hardware.spec.ts
+++ b/frontend/tests/e2e/32-easy-config-no-wifi-hardware.spec.ts
@@ -43,9 +43,7 @@ AllowedIPs = 0.0.0.0/0`);
     await expect(page.getByText(/no wi-fi hardware/i)).toBeVisible();
     await expect(page.getByLabel('Network name (SSID)', { exact: true })).not.toBeVisible();
 
-    await expect(page.getByRole('button', { name: /^next$/i })).toBeEnabled();
-    await page.getByRole('button', { name: /^next$/i }).click();
-
+    await expect(page.getByRole('button', { name: /^apply$/i })).toBeEnabled();
     await page.getByRole('button', { name: /^apply$/i }).click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });


### PR DESCRIPTION
Closes #480

## Summary
- Starlink-only mode drops the VPN Server step so the wizard applies from the WiFi step
- picking Starlink-only resets the VPN server toggle so it never reaches the apply payload
- e2e specs updated for the shorter flow, with the VPN server spec moved to dual-link