### PR TITLE
fix(fe): wizard wifi lists the router's wireless interfaces

### DIFF
--- a/frontend/src/routes/EasyConfigWizard.tsx
+++ b/frontend/src/routes/EasyConfigWizard.tsx
@@ -107,6 +107,7 @@ export function EasyConfigWizard() {
           <WifiStep
             state={state}
             dispatch={dispatch}
+            interfaces={interfaces}
             wifiInterfaces={wifiInterfaces}
             wifiSupported={wifiSupported}
             footer={footer}

--- a/frontend/src/routes/easy-config/steps/WifiStep.tsx
+++ b/frontend/src/routes/easy-config/steps/WifiStep.tsx
@@ -13,7 +13,7 @@ import {
   Switch,
 } from '@nasnet/ui';
 import wizardStyles from '../../EasyConfigWizard.module.scss';
-import type { WifiInterfaceResponse } from '../../../api';
+import type { InterfaceResponse, WifiInterfaceResponse } from '../../../api';
 import type { Action, State } from '../state';
 import { generatePassword, generateSsid } from './wifi/generate';
 import { GenerateButton } from './wifi/GenerateButton';
@@ -23,6 +23,7 @@ import { Collapsible } from './components/Collapsible';
 interface Props {
   state: State;
   dispatch: React.Dispatch<Action>;
+  interfaces: InterfaceResponse[];
   wifiInterfaces: WifiInterfaceResponse[];
   wifiSupported: boolean;
   footer?: React.ReactNode;
@@ -35,6 +36,13 @@ const BAND_LABELS: Record<BandKey, string> = {
   '5': '5 GHz',
   '6': '6 GHz',
 };
+
+const WIRELESS_TYPES = ['wireless', 'wifi', 'wlan', 'w60g'];
+
+interface WirelessEntry {
+  name: string;
+  label: string;
+}
 
 function bandKeyFor(wi: WifiInterfaceResponse): BandKey | null {
   const b = (wi.band ?? '').toLowerCase();
@@ -50,27 +58,40 @@ function bandKeyFor(wi: WifiInterfaceResponse): BandKey | null {
   return null;
 }
 
-export function WifiStep({ state, dispatch, wifiInterfaces, wifiSupported, footer }: Props) {
+export function WifiStep({
+  state,
+  dispatch,
+  interfaces,
+  wifiInterfaces,
+  wifiSupported,
+  footer,
+}: Props) {
   const setText = (field: keyof State) => (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch({ type: 'setField', field, value: e.target.value });
 
-  const availableBands = useMemo<BandKey[]>(() => {
-    const set = new Set<BandKey>();
-    for (const wi of wifiInterfaces) {
-      const key = bandKeyFor(wi);
-      if (key) set.add(key);
-    }
-    const order: BandKey[] = ['24', '5', '6'];
-    return order.filter((k) => set.has(k));
-  }, [wifiInterfaces]);
+  const wirelessEntries = useMemo<WirelessEntry[]>(() => {
+    const fromList = interfaces
+      .filter((i) => WIRELESS_TYPES.includes(i.type))
+      .map((i) => {
+        const wi = wifiInterfaces.find((w) => w.name === i.name || w.interface === i.name);
+        const band = wi ? bandKeyFor(wi) : null;
+        return { name: i.name, label: band ? BAND_LABELS[band] : i.name };
+      });
+    if (fromList.length > 0) return fromList;
+    return wifiInterfaces.map((wi) => {
+      const band = bandKeyFor(wi);
+      return { name: wi.name, label: band ? BAND_LABELS[band] : wi.name };
+    });
+  }, [interfaces, wifiInterfaces]);
 
-  const multiBand = availableBands.length > 1;
+  const multiBand = wirelessEntries.length > 1;
   const split = multiBand && state.wifiSplit;
-  const bandList = availableBands.map((k) => BAND_LABELS[k]).join(' and ');
+  const labels = wirelessEntries.map((e) => e.label);
+  const bandList = labels.join(labels.length > 2 ? ', ' : ' and ');
 
   const previewBands = split
-    ? availableBands.map((k) => ({ ssid: state.ssid, band: BAND_LABELS[k] }))
-    : [{ ssid: state.ssid, band: availableBands[0] ? BAND_LABELS[availableBands[0]] : undefined }];
+    ? wirelessEntries.map((e) => ({ id: e.name, ssid: state.ssid, band: e.label }))
+    : [{ ssid: state.ssid, band: wirelessEntries[0]?.label }];
 
   return (
     <Card>

--- a/frontend/src/routes/easy-config/steps/WifiStep.tsx
+++ b/frontend/src/routes/easy-config/steps/WifiStep.tsx
@@ -38,9 +38,9 @@ const BAND_LABELS: Record<BandKey, string> = {
 };
 
 const BAND_SUFFIXES: Record<BandKey, string> = {
-  '24': '2.4',
-  '5': '5',
-  '6': '6',
+  '24': '2.4G',
+  '5': '5G',
+  '6': '6G',
 };
 
 const WIRELESS_TYPES = ['wireless', 'wifi', 'wlan', 'w60g'];
@@ -102,7 +102,7 @@ export function WifiStep({
   const multiBand = wirelessEntries.length > 1;
   const split = multiBand && state.wifiSplit;
   const labels = wirelessEntries.map((e) => e.label);
-  const bandList = labels.join(labels.length > 2 ? ', ' : ' and ');
+  const bandList = labels.join(', ');
 
   const previewBands = split
     ? wirelessEntries.map((e) => ({
@@ -110,7 +110,7 @@ export function WifiStep({
         ssid: state.ssid.trim() ? `${state.ssid}-${e.suffix}` : state.ssid,
         band: e.label,
       }))
-    : [{ ssid: state.ssid, band: wirelessEntries[0]?.label }];
+    : [{ ssid: state.ssid, band: labels.length > 1 ? bandList : labels[0] }];
 
   return (
     <Card>

--- a/frontend/src/routes/easy-config/steps/wifi/WirelessPreview.tsx
+++ b/frontend/src/routes/easy-config/steps/wifi/WirelessPreview.tsx
@@ -2,6 +2,7 @@ import { Wifi, WifiOff } from 'lucide-react';
 import styles from './WirelessPreview.module.scss';
 
 export interface WirelessPreviewBand {
+  id?: string;
   ssid: string;
   band?: string;
 }
@@ -18,7 +19,7 @@ export function WirelessPreview({ bands, enabled }: Props) {
         {bands.map((b) => {
           const ssid = b.ssid.trim() || 'Your network name';
           const isPlaceholder = !b.ssid.trim();
-          const key = b.band ?? 'single';
+          const key = b.id ?? b.band ?? 'single';
           return (
             <div key={key} className={styles.preview}>
               <div className={`${styles.iconWrap} ${enabled ? '' : styles.iconWrapMuted}`}>

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -114,10 +114,10 @@ function buildScript(state: State): string {
       countryCode: state.countryCode,
       splitBands: state.wifiSplit,
       band24: state.wifiSplit
-        ? { ssid: `${state.ssid}-2.4`, password: state.wifiPassword }
+        ? { ssid: `${state.ssid}-2.4G`, password: state.wifiPassword }
         : undefined,
       band5: state.wifiSplit
-        ? { ssid: `${state.ssid}-5`, password: state.wifiPassword }
+        ? { ssid: `${state.ssid}-5G`, password: state.wifiPassword }
         : undefined,
     },
     ipMask: state.ipMaskEnabled

--- a/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
+++ b/frontend/tests/e2e/23-easy-config-multi-band-wifi.spec.ts
@@ -62,9 +62,9 @@ AllowedIPs = 0.0.0.0/0`);
 
     await splitToggle.check();
     await expect(splitToggle).toBeChecked();
-    await expect(page.getByText('NN-Home-2.4')).toBeVisible();
-    await expect(page.getByText('NN-Home-5', { exact: true })).toBeVisible();
-    await expect(page.getByText('NN-Home-6', { exact: true })).toBeVisible();
+    await expect(page.getByText('NN-Home-2.4G', { exact: true })).toBeVisible();
+    await expect(page.getByText('NN-Home-5G', { exact: true })).toBeVisible();
+    await expect(page.getByText('NN-Home-6G', { exact: true })).toBeVisible();
 
     // Splitting can be turned off to keep the network on a single band
     await splitToggle.uncheck();


### PR DESCRIPTION
Closes #479

## Summary
- wifi step shows one entry per wireless interface read from the interface list
- entries labeled by band when known, interface name otherwise
- split toggle and preview follow the interface count instead of deduped bands