### PR TITLE
fix(fe): show only tagged WAN links on the Internet page

### DIFF
--- a/frontend/src/routes/internet/buildTopology.ts
+++ b/frontend/src/routes/internet/buildTopology.ts
@@ -62,25 +62,11 @@ function classifyWan(iface: InterfaceResponse): { kind: RoutingWanKind; label: s
 }
 
 function pickWanInterfaces(ifaces: InterfaceResponse[]): InterfaceResponse[] {
-  const candidates = ifaces.filter((i) => {
-    if (i.disabled) return false;
-    if (i.type !== 'ether') return false;
-    const comment = (i.comment ?? '').toLowerCase();
-    return (
-      comment.includes('wan') ||
-      comment.includes('uplink') ||
-      comment.includes('isp') ||
-      comment.includes('starlink') ||
-      comment.includes('fiber') ||
-      comment.includes('mobile') ||
-      comment.includes('lte') ||
-      comment.includes('5g') ||
-      comment.includes('hamrah') ||
-      comment.includes('irancell')
-    );
-  });
-  if (candidates.length > 0) return candidates;
-  return ifaces.filter((i) => i.type === 'ether' && !i.disabled);
+  return ifaces.filter(
+    (i) =>
+      !i.disabled &&
+      (matchesWanCategory(i.comment, 'domestic') || matchesWanCategory(i.comment, 'foreign')),
+  );
 }
 
 export async function buildTopology(

--- a/frontend/src/routes/wan/types.ts
+++ b/frontend/src/routes/wan/types.ts
@@ -1,4 +1,9 @@
 export type WanCategory = 'foreign' | 'domestic';
 
+const WAN_LINK_TAG: Record<WanCategory, string> = {
+  foreign: 'wan - foreign link',
+  domestic: 'wan - domestic link',
+};
+
 export const matchesWanCategory = (comment: string | undefined, category: WanCategory): boolean =>
-  (comment ?? '').toLowerCase().includes(category);
+  (comment ?? '').toLowerCase().includes(WAN_LINK_TAG[category]);


### PR DESCRIPTION
Closes #483

- Internet page now lists only interfaces whose comment marks them as a domestic or foreign WAN link
- drops the keyword filter and the fallback that showed every ethernet interface