### PR TITLE
feat(fe): default main page graph to foreign WAN

### DIFF
--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Activity,
@@ -54,6 +54,7 @@ import {
 import { useRouter, useRouterStore } from '../state/RouterStoreContext';
 import { useSession } from '../state/SessionContext';
 import { useThemeColors } from '../utils/theme-colors';
+import { matchesWanCategory } from './wan/types';
 import { RouterPortDiagramCard } from './overview-panel/RouterPortDiagramCard';
 import { UplinkIpCard } from './overview-panel/UplinkIpCard';
 import { resolveModelStrict } from './overview-panel/resolveModel';
@@ -118,6 +119,7 @@ export function OverviewTab() {
   const [ethernetRates, setEthernetRates] = useState<Record<string, string>>({});
   const [dhcpClients, setDhcpClients] = useState<DhcpClient[]>([]);
   const [selectedIface, setSelectedIface] = useState<string>(DEFAULT_TRAFFIC_INTERFACE);
+  const ifaceDefaultApplied = useRef(false);
   const [graphLoading, setGraphLoading] = useState(false);
   const [graphError, setGraphError] = useState<string | null>(null);
   const [powerAction, setPowerAction] = useState<'reboot' | 'shutdown' | null>(null);
@@ -213,6 +215,11 @@ export function OverviewTab() {
         );
         if (list.length > 0) {
           setSelectedIface((prev) => {
+            if (!ifaceDefaultApplied.current) {
+              ifaceDefaultApplied.current = true;
+              const foreign = list.find((i) => matchesWanCategory(i.comment, 'foreign'));
+              if (foreign) return foreign.name;
+            }
             if (list.some((i) => i.name === prev)) return prev;
             const preferred = list.find((i) => i.running && i.type === 'ether') ?? list[0];
             return preferred.name;

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -38,7 +38,7 @@ const defaultInterfaces = [
     type: 'ether',
     running: true,
     disabled: false,
-    comment: 'WAN - Foreign Link (Starlink uplink)',
+    comment: 'WAN - Foreign Link',
   },
   {
     id: '*2',
@@ -46,7 +46,7 @@ const defaultInterfaces = [
     type: 'ether',
     running: false,
     disabled: false,
-    comment: 'WAN - Foreign Link (Irancell mobile)',
+    comment: 'WAN - Foreign Link',
   },
   {
     id: '*3',
@@ -54,7 +54,7 @@ const defaultInterfaces = [
     type: 'ether',
     running: true,
     disabled: false,
-    comment: 'WAN - Domestic Link(Domestic)',
+    comment: 'WAN - Domestic Link',
   },
   { id: '*4', name: 'bridge1', type: 'bridge', running: true, disabled: false },
   wgMaskIface,
@@ -122,8 +122,8 @@ test.describe('Internet routing page', () => {
 
     await expect(page.getByRole('heading', { name: /internet routing/i })).toBeVisible();
     await expect(page.getByText('Clients', { exact: true }).first()).toBeVisible();
-    await expect(page.getByText('Starlink', { exact: true })).toBeVisible();
-    await expect(page.getByText('Irancell', { exact: true })).toBeVisible();
+    await expect(page.getByText('WAN - Foreign Link', { exact: true })).toHaveCount(2);
+    await expect(page.getByText('WAN - Domestic Link', { exact: true })).toBeVisible();
     await expect(page.getByText('wg-mask', { exact: true })).toBeVisible();
 
     const svg = page.getByRole('img', { name: 'Routing topology' });

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -38,7 +38,7 @@ const defaultInterfaces = [
     type: 'ether',
     running: true,
     disabled: false,
-    comment: 'Starlink uplink',
+    comment: 'WAN - Foreign Link (Starlink uplink)',
   },
   {
     id: '*2',
@@ -46,7 +46,7 @@ const defaultInterfaces = [
     type: 'ether',
     running: false,
     disabled: false,
-    comment: 'Irancell mobile',
+    comment: 'WAN - Foreign Link (Irancell mobile)',
   },
   {
     id: '*3',

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -79,8 +79,7 @@ const setupWanRoutes = async (
       password?: string;
     };
     state.wanPuts.push({ body });
-    const comment =
-      body.type === 'foreign' ? 'WAN - Foreign Link(Foreign)' : 'WAN - Domestic Link(Domestic)';
+    const comment = body.type === 'foreign' ? 'WAN - Foreign Link' : 'WAN - Domestic Link';
     const apply = () => {
       const idx = state.interfaces.findIndex((i) => i.name === body.interface);
       if (idx >= 0) state.interfaces[idx] = { ...state.interfaces[idx], comment };
@@ -366,7 +365,7 @@ test.describe('WAN tab', () => {
     await seedRouter({ id: ROUTER_ID, name: 'WAN Router' });
     await setSessionCreds(context, ROUTER_ID);
     const state = blankState();
-    state.interfaces[0].comment = 'WAN - Foreign Link(Foreign)';
+    state.interfaces[0].comment = 'WAN - Foreign Link';
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 


### PR DESCRIPTION
Closes #481

## Summary
- overview traffic graph defaults its dropdown to the interface tagged as the foreign WAN link
- matching reuses the shared WAN tag helper, so only interfaces carrying that tag count
- applies on first load only, manual selection and existing fallbacks unchanged
- retags the internet routing e2e fixtures, which still used pre-tag comments and broke on dev
