### PR TITLE
fix(be): Removing completedAt from wizard status due to high resource usage

### DIFF
--- a/backend/internal/handler/wizard.go
+++ b/backend/internal/handler/wizard.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"nasnet-panel/pkg/routeros"
@@ -58,8 +57,8 @@ func HandleGetVPNCredentials(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "VPN credentials retrieved successfully", response)
 }
 
-// HandleGetWizardStatus retrieves the wizard status: Completed/CompletedAt from
-// the wizardSuccessFile marker, Progress from environment variables.
+// HandleGetWizardStatus retrieves the wizard status: Completed from the
+// wizardSuccessFile marker, Progress from environment variables.
 // @Summary Get Wizard Status
 // @Description Retrieve the current wizard configuration status
 // @Tags Wizard
@@ -77,9 +76,8 @@ func HandleGetWizardStatus(c echo.Context) error {
 	}
 
 	status := &WizardStatus{
-		Completed:   false,
-		CompletedAt: nil,
-		Progress:    0,
+		Completed: false,
+		Progress:  0,
 	}
 	if progress, err := client.GetEnvironmentVariable("WizardProgress"); err == nil && progress != "" {
 		if p, err := strconv.Atoi(progress); err == nil {
@@ -90,14 +88,6 @@ func HandleGetWizardStatus(c echo.Context) error {
 	if exists, err := client.FileExists(wizardSuccessFile); err == nil && exists {
 		status.Progress = 100
 		status.Completed = true
-		if contents, err := client.GetFileContents(wizardSuccessFile, 0); err == nil {
-			completedAt := strings.TrimSpace(contents)
-			if t, err := time.Parse(time.RFC3339, completedAt); err == nil {
-				status.CompletedAt = &t
-			} else if t, err := time.Parse("2006-01-02 15:04:05", completedAt); err == nil {
-				status.CompletedAt = &t
-			}
-		}
 	}
 
 	return SuccessResponse(c, http.StatusOK, "Wizard status retrieved successfully", status)

--- a/backend/internal/handler/wizard_dto.go
+++ b/backend/internal/handler/wizard_dto.go
@@ -1,9 +1,5 @@
 package handler
 
-import (
-	"time"
-)
-
 // VPNCredentialsResponse represents VPN credentials in the API response.
 type VPNCredentialsResponse struct {
 	Username   string `json:"username" example:"NNC_zN9RI61d"`
@@ -14,9 +10,8 @@ type VPNCredentialsResponse struct {
 
 // WizardStatus represents the current status of a setup wizard.
 type WizardStatus struct {
-	Completed   bool       `json:"completed" example:"false"`
-	CompletedAt *time.Time `json:"completedAt" example:"null"`
-	Progress    int        `json:"progress" example:"0"`
+	Completed bool `json:"completed" example:"false"`
+	Progress  int  `json:"progress" example:"0"`
 }
 
 // InterfaceConfig represents a network interface configuration.


### PR DESCRIPTION
in file based wizard status, to get completedAt date, we have to read file contents from device which has high overhead and sometimes causes unexpected errors, and this data is not used anywere in system so dropping this to decrease load.

Fixes #501