### PR TITLE
feat(fe): foreign WAN edit dialog with move to Domestic

### DIFF
--- a/frontend/src/routes/WanPage.tsx
+++ b/frontend/src/routes/WanPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useToast } from '@nasnet/ui';
 import {
@@ -53,6 +53,8 @@ export function WanPage() {
     if (!creds || !host) return null;
     return { host, ...creds };
   }, [id, router?.host, getCredentials]);
+
+  const vpnCreds = useMemo(() => resolveCreds(), [resolveCreds]);
 
   const applyInterfaces = useCallback((wan: InterfaceResponse[]) => {
     interfacesRef.current = wan;
@@ -162,7 +164,7 @@ export function WanPage() {
         onChanged={reloadAfterWanChange}
       />
       <ClientsSection
-        creds={resolveCreds()}
+        creds={vpnCreds}
         clients={vpnClients}
         onChanged={loadVpn}
         onDialogOpenChange={setVpnDialogOpen}

--- a/frontend/src/routes/wan/WanTable.tsx
+++ b/frontend/src/routes/wan/WanTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { ArrowUpDown, Pencil, Trash2 } from 'lucide-react';
 import { Badge, Button, DataTable, Switch } from '@nasnet/ui';
 import styles from './WanPage.module.scss';
 
@@ -15,6 +15,8 @@ interface Props<T> {
   onToggle?: (row: T, enabled: boolean) => void;
   onEdit?: (row: T) => void;
   editLabel?: (row: T) => string;
+  onMove?: (row: T) => void;
+  moveLabel?: (row: T) => string;
   onDelete?: (row: T) => void;
 }
 
@@ -30,9 +32,11 @@ export function WanTable<T>({
   onToggle,
   onEdit,
   editLabel,
+  onMove,
+  moveLabel,
   onDelete,
 }: Props<T>) {
-  const showActions = !!onEdit || !!onDelete;
+  const showActions = !!onEdit || !!onMove || !!onDelete;
   return (
     <DataTable<T>
       rows={rows}
@@ -80,6 +84,18 @@ export function WanTable<T>({
                         onClick={() => onEdit(r)}
                       >
                         <Pencil size={14} aria-hidden />
+                      </Button>
+                    ) : null}
+                    {onMove ? (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        className={styles.iconBtn}
+                        title={moveLabel ? moveLabel(r) : `Move ${name(r)}`}
+                        aria-label={moveLabel ? moveLabel(r) : `move ${name(r)}`}
+                        onClick={() => onMove(r)}
+                      >
+                        <ArrowUpDown size={14} aria-hidden />
                       </Button>
                     ) : null}
                     {onDelete ? (

--- a/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
+++ b/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
@@ -23,7 +23,6 @@ interface Props {
   excludeNames?: string[];
   interfacesLoading?: boolean;
   initialInterface?: InterfaceResponse;
-  secondaryAction?: { label: string; onClick: () => void };
   onCancel: () => void;
   onSubmit: (values: WanUplinkValues) => Promise<void>;
 }
@@ -56,7 +55,6 @@ export function WanUplinkDialog({
   excludeNames,
   interfacesLoading,
   initialInterface,
-  secondaryAction,
   onCancel,
   onSubmit,
 }: Props) {
@@ -108,11 +106,6 @@ export function WanUplinkDialog({
       labelledBy="wan-uplink-title"
       footer={
         <>
-          {secondaryAction ? (
-            <Button variant="secondary" onClick={secondaryAction.onClick} disabled={submitting}>
-              {secondaryAction.label}
-            </Button>
-          ) : null}
           <Button variant="ghost" onClick={onCancel} disabled={submitting}>
             Cancel
           </Button>

--- a/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
+++ b/frontend/src/routes/wan/dialogs/WanUplinkDialog.tsx
@@ -23,6 +23,7 @@ interface Props {
   excludeNames?: string[];
   interfacesLoading?: boolean;
   initialInterface?: InterfaceResponse;
+  secondaryAction?: { label: string; onClick: () => void };
   onCancel: () => void;
   onSubmit: (values: WanUplinkValues) => Promise<void>;
 }
@@ -55,6 +56,7 @@ export function WanUplinkDialog({
   excludeNames,
   interfacesLoading,
   initialInterface,
+  secondaryAction,
   onCancel,
   onSubmit,
 }: Props) {
@@ -106,6 +108,11 @@ export function WanUplinkDialog({
       labelledBy="wan-uplink-title"
       footer={
         <>
+          {secondaryAction ? (
+            <Button variant="secondary" onClick={secondaryAction.onClick} disabled={submitting}>
+              {secondaryAction.label}
+            </Button>
+          ) : null}
           <Button variant="ghost" onClick={onCancel} disabled={submitting}>
             Cancel
           </Button>

--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -149,8 +149,8 @@ export function DomesticUplinkSection({
           enabled={(i) => !i.disabled}
           emptyIcon={<Cable size={20} aria-hidden />}
           emptyMessage="No domestic uplinks yet"
-          editLabel={(i) => `Move ${i.name} to Foreign`}
-          onEdit={(i) => setPendingMove(i)}
+          moveLabel={(i) => `Move ${i.name} to Foreign`}
+          onMove={(i) => setPendingMove(i)}
         />
       </Card>
       {dialogOpen ? (

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -35,6 +35,7 @@ export function StarlinkSection({
   const { getCredentials } = useSession();
   const router = useRouter(routerId);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<InterfaceResponse | null>(null);
   const [pendingMove, setPendingMove] = useState<InterfaceResponse | null>(null);
   const [moveSubmitting, setMoveSubmitting] = useState(false);
 
@@ -82,6 +83,22 @@ export function StarlinkSection({
     await onChanged();
     closeDialog();
     toast.notify({ title: 'Starlink uplink added', tone: 'success' });
+  };
+
+  const onEditSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
+    const creds = resolveCreds();
+    if (!creds) {
+      toast.notify({
+        title: 'Missing router credentials',
+        description: 'Reconnect to the router and try again.',
+        tone: 'danger',
+      });
+      return;
+    }
+    await updateWanInterface(creds, { interface: interfaceName, type: 'foreign', ssid, password });
+    await onChanged();
+    setEditTarget(null);
+    toast.notify({ title: `Updated "${interfaceName}"`, tone: 'success' });
   };
 
   const onConfirmMove = async () => {
@@ -149,8 +166,8 @@ export function StarlinkSection({
           enabled={(i) => !i.disabled}
           emptyIcon={<SatelliteDish size={20} aria-hidden />}
           emptyMessage="No Starlink uplinks yet"
-          editLabel={(i) => `Move ${i.name} to Domestic`}
-          onEdit={(i) => setPendingMove(i)}
+          editLabel={(i) => `Edit ${i.name}`}
+          onEdit={(i) => setEditTarget(i)}
         />
       </Card>
       {dialogOpen ? (
@@ -162,6 +179,23 @@ export function StarlinkSection({
           interfacesLoading={interfacesLoading}
           onCancel={closeDialog}
           onSubmit={onSubmit}
+        />
+      ) : null}
+      {editTarget ? (
+        <WanUplinkDialog
+          variant="foreign"
+          title={`Edit ${editTarget.name}`}
+          interfaces={[editTarget]}
+          initialInterface={editTarget}
+          secondaryAction={{
+            label: 'Move to Domestic',
+            onClick: () => {
+              setPendingMove(editTarget);
+              setEditTarget(null);
+            },
+          }}
+          onCancel={() => setEditTarget(null)}
+          onSubmit={onEditSubmit}
         />
       ) : null}
       {pendingMove && moveWireless ? (

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -168,6 +168,8 @@ export function StarlinkSection({
           emptyMessage="No Starlink uplinks yet"
           editLabel={(i) => `Edit ${i.name}`}
           onEdit={(i) => setEditTarget(i)}
+          moveLabel={(i) => `Move ${i.name} to Domestic`}
+          onMove={(i) => setPendingMove(i)}
         />
       </Card>
       {dialogOpen ? (
@@ -187,13 +189,6 @@ export function StarlinkSection({
           title={`Edit ${editTarget.name}`}
           interfaces={[editTarget]}
           initialInterface={editTarget}
-          secondaryAction={{
-            label: 'Move to Domestic',
-            onClick: () => {
-              setPendingMove(editTarget);
-              setEditTarget(null);
-            },
-          }}
           onCancel={() => setEditTarget(null)}
           onSubmit={onEditSubmit}
         />

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -268,12 +268,8 @@ test.describe('WAN tab', () => {
 
     await expect(page.getByRole('cell', { name: 'ether1', exact: true })).toBeVisible();
 
-    // Move to Domestic via the edit dialog's action.
-    await page.getByRole('button', { name: /edit ether1/i }).click();
-    await page
-      .getByRole('dialog')
-      .getByRole('button', { name: /move to domestic/i })
-      .click();
+    // Move to Domestic via the row action next to Edit.
+    await page.getByRole('button', { name: /move ether1 to domestic/i }).click();
     await page
       .getByRole('dialog')
       .getByRole('button', { name: /^move$/i })

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -269,8 +269,12 @@ test.describe('WAN tab', () => {
 
     await expect(page.getByRole('cell', { name: 'ether1', exact: true })).toBeVisible();
 
-    // Move to Domestic via the pencil button on the row.
-    await page.getByRole('button', { name: /move ether1 to domestic/i }).click();
+    // Move to Domestic via the edit dialog's action.
+    await page.getByRole('button', { name: /edit ether1/i }).click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /move to domestic/i })
+      .click();
     await page
       .getByRole('dialog')
       .getByRole('button', { name: /^move$/i })


### PR DESCRIPTION
Closes #485

## Summary
- foreign WAN pencil now opens a prefilled edit dialog instead of moving the uplink directly
- the dialog offers a Move to Domestic action that reuses the existing confirm and wireless re-entry flow
- updated the WAN e2e test for the new path