### PR TITLE
feat(fe): distinct badge color for station mode wifi interfaces

### DIFF
--- a/frontend/src/routes/WirelessPage.module.scss
+++ b/frontend/src/routes/WirelessPage.module.scss
@@ -116,3 +116,8 @@
   border: 1px solid var(--color-border);
   color: var(--color-text-muted);
 }
+
+.stationBadge {
+  background: var(--color-primary-strong);
+  color: var(--color-primary-text);
+}

--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -19,8 +19,11 @@ const formatMode = (mode: string): string =>
     )
     .join(' ');
 
+const isStationMode = (mode: string): boolean => mode.toLowerCase().startsWith('station');
+
 export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
   const enabled = !iface.disabled;
+  const station = iface.mode ? isStationMode(iface.mode) : false;
   return (
     <div className={styles.interfaceRow}>
       <div className={cx(styles.iconTone, toneClass('primary'))}>
@@ -32,7 +35,12 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
         {iface.mode ? (
           <>
             {' '}
-            <Badge className={styles.modeBadge}>{formatMode(iface.mode)}</Badge>
+            <Badge
+              tone={station ? 'info' : 'neutral'}
+              className={station ? undefined : styles.modeBadge}
+            >
+              {formatMode(iface.mode)}
+            </Badge>
           </>
         ) : null}
         <div>

--- a/frontend/src/routes/wireless/InterfaceRow.tsx
+++ b/frontend/src/routes/wireless/InterfaceRow.tsx
@@ -35,10 +35,7 @@ export function InterfaceRow({ iface, settings, onToggle, onEdit }: Props) {
         {iface.mode ? (
           <>
             {' '}
-            <Badge
-              tone={station ? 'info' : 'neutral'}
-              className={station ? undefined : styles.modeBadge}
-            >
+            <Badge className={station ? styles.stationBadge : styles.modeBadge}>
               {formatMode(iface.mode)}
             </Badge>
           </>


### PR DESCRIPTION
Closes #487

## Summary
- station mode interfaces on the WiFi page now render an info-toned badge instead of the muted outline used for AP
- matches on a station prefix so station-bridge and pseudobridge variants get the same treatment