### PR TITLE
feat(fe): rename WAN uplink actions to Change

### DIFF
--- a/frontend/src/routes/vpn/sections/SectionHeader.tsx
+++ b/frontend/src/routes/vpn/sections/SectionHeader.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Plus } from 'lucide-react';
 import { Badge, Button, CardDescription, CardHeader, CardTitle, Input } from '@nasnet/ui';
 import styles from '../../VPNPage.module.scss';
@@ -8,6 +9,7 @@ interface Action {
   onClick: () => void;
   variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'success';
   showPlus?: boolean;
+  icon?: ReactNode;
 }
 
 interface Props {
@@ -57,7 +59,9 @@ export function SectionHeader({ title, count, description, search, action, extra
             onClick={a.onClick}
             disabled={a.disabled}
           >
-            {a.showPlus !== false && a === action ? <Plus size={14} aria-hidden /> : null} {a.label}
+            {a.icon ??
+              (a.showPlus !== false && a === action ? <Plus size={14} aria-hidden /> : null)}{' '}
+            {a.label}
           </Button>
         ))}
       </div>

--- a/frontend/src/routes/wan/WanTable.tsx
+++ b/frontend/src/routes/wan/WanTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowUpDown, Pencil, Trash2 } from 'lucide-react';
+import { ArrowUpDown, Trash2 } from 'lucide-react';
 import { Badge, Button, DataTable, Switch } from '@nasnet/ui';
 import styles from './WanPage.module.scss';
 
@@ -13,8 +13,6 @@ interface Props<T> {
   emptyIcon: React.ReactNode;
   emptyMessage: string;
   onToggle?: (row: T, enabled: boolean) => void;
-  onEdit?: (row: T) => void;
-  editLabel?: (row: T) => string;
   onMove?: (row: T) => void;
   moveLabel?: (row: T) => string;
   onDelete?: (row: T) => void;
@@ -30,13 +28,11 @@ export function WanTable<T>({
   emptyIcon,
   emptyMessage,
   onToggle,
-  onEdit,
-  editLabel,
   onMove,
   moveLabel,
   onDelete,
 }: Props<T>) {
-  const showActions = !!onEdit || !!onMove || !!onDelete;
+  const showActions = !!onMove || !!onDelete;
   return (
     <DataTable<T>
       rows={rows}
@@ -74,18 +70,6 @@ export function WanTable<T>({
                 header: '',
                 render: (r: T) => (
                   <span className={styles.rowActions}>
-                    {onEdit ? (
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        className={styles.iconBtn}
-                        title={editLabel ? editLabel(r) : `Edit ${name(r)}`}
-                        aria-label={editLabel ? editLabel(r) : `edit ${name(r)}`}
-                        onClick={() => onEdit(r)}
-                      >
-                        <Pencil size={14} aria-hidden />
-                      </Button>
-                    ) : null}
                     {onMove ? (
                       <Button
                         size="sm"

--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Cable } from 'lucide-react';
+import { Cable, Pencil } from 'lucide-react';
 import { Card, ConfirmDialog, Stack, useToast } from '@nasnet/ui';
 import {
   ApiError,
@@ -73,7 +73,7 @@ export function DomesticUplinkSection({
             ? err.message
             : 'Failed to assign interface.';
       toast.notify({
-        title: 'Failed to add domestic uplink',
+        title: 'Failed to change domestic uplink',
         description: message,
         tone: 'danger',
       });
@@ -81,7 +81,7 @@ export function DomesticUplinkSection({
     }
     await onChanged();
     closeDialog();
-    toast.notify({ title: 'Domestic uplink added', tone: 'success' });
+    toast.notify({ title: 'Domestic uplink changed', tone: 'success' });
   };
 
   const onConfirmMove = async () => {
@@ -138,7 +138,7 @@ export function DomesticUplinkSection({
         <SectionHeader
           title="Domestic"
           description="Interfaces tagged as the domestic uplink."
-          action={{ label: 'Change', onClick: openAdd }}
+          action={{ label: 'Change', onClick: openAdd, icon: <Pencil size={14} aria-hidden /> }}
         />
         <WanTable
           rows={items}
@@ -156,7 +156,7 @@ export function DomesticUplinkSection({
       {dialogOpen ? (
         <WanUplinkDialog
           variant="domestic"
-          title="Add domestic uplink"
+          title="Change domestic uplink"
           interfaces={interfaces}
           excludeNames={excludeNames}
           interfacesLoading={interfacesLoading}

--- a/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
+++ b/frontend/src/routes/wan/sections/DomesticUplinkSection.tsx
@@ -138,7 +138,7 @@ export function DomesticUplinkSection({
         <SectionHeader
           title="Domestic"
           description="Interfaces tagged as the domestic uplink."
-          action={{ label: 'New', onClick: openAdd }}
+          action={{ label: 'Change', onClick: openAdd }}
         />
         <WanTable
           rows={items}

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { SatelliteDish } from 'lucide-react';
+import { Pencil, SatelliteDish } from 'lucide-react';
 import { Card, ConfirmDialog, Stack, useToast } from '@nasnet/ui';
 import {
   ApiError,
@@ -35,7 +35,6 @@ export function StarlinkSection({
   const { getCredentials } = useSession();
   const router = useRouter(routerId);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<InterfaceResponse | null>(null);
   const [pendingMove, setPendingMove] = useState<InterfaceResponse | null>(null);
   const [moveSubmitting, setMoveSubmitting] = useState(false);
 
@@ -74,7 +73,7 @@ export function StarlinkSection({
             ? err.message
             : 'Failed to assign interface.';
       toast.notify({
-        title: 'Failed to add Starlink uplink',
+        title: 'Failed to change Starlink uplink',
         description: message,
         tone: 'danger',
       });
@@ -82,23 +81,7 @@ export function StarlinkSection({
     }
     await onChanged();
     closeDialog();
-    toast.notify({ title: 'Starlink uplink added', tone: 'success' });
-  };
-
-  const onEditSubmit = async ({ interfaceName, ssid, password }: WanUplinkValues) => {
-    const creds = resolveCreds();
-    if (!creds) {
-      toast.notify({
-        title: 'Missing router credentials',
-        description: 'Reconnect to the router and try again.',
-        tone: 'danger',
-      });
-      return;
-    }
-    await updateWanInterface(creds, { interface: interfaceName, type: 'foreign', ssid, password });
-    await onChanged();
-    setEditTarget(null);
-    toast.notify({ title: `Updated "${interfaceName}"`, tone: 'success' });
+    toast.notify({ title: 'Starlink uplink changed', tone: 'success' });
   };
 
   const onConfirmMove = async () => {
@@ -155,7 +138,7 @@ export function StarlinkSection({
         <SectionHeader
           title="Foreign / Starlink"
           description="Interfaces tagged as the foreign (Starlink) uplink."
-          action={{ label: 'Change', onClick: openAdd }}
+          action={{ label: 'Change', onClick: openAdd, icon: <Pencil size={14} aria-hidden /> }}
         />
         <WanTable
           rows={items}
@@ -166,8 +149,6 @@ export function StarlinkSection({
           enabled={(i) => !i.disabled}
           emptyIcon={<SatelliteDish size={20} aria-hidden />}
           emptyMessage="No Starlink uplinks yet"
-          editLabel={(i) => `Edit ${i.name}`}
-          onEdit={(i) => setEditTarget(i)}
           moveLabel={(i) => `Move ${i.name} to Domestic`}
           onMove={(i) => setPendingMove(i)}
         />
@@ -175,22 +156,12 @@ export function StarlinkSection({
       {dialogOpen ? (
         <WanUplinkDialog
           variant="foreign"
-          title="Add Starlink uplink"
+          title="Change Starlink uplink"
           interfaces={interfaces}
           excludeNames={excludeNames}
           interfacesLoading={interfacesLoading}
           onCancel={closeDialog}
           onSubmit={onSubmit}
-        />
-      ) : null}
-      {editTarget ? (
-        <WanUplinkDialog
-          variant="foreign"
-          title={`Edit ${editTarget.name}`}
-          interfaces={[editTarget]}
-          initialInterface={editTarget}
-          onCancel={() => setEditTarget(null)}
-          onSubmit={onEditSubmit}
         />
       ) : null}
       {pendingMove && moveWireless ? (

--- a/frontend/src/routes/wan/sections/StarlinkSection.tsx
+++ b/frontend/src/routes/wan/sections/StarlinkSection.tsx
@@ -138,7 +138,7 @@ export function StarlinkSection({
         <SectionHeader
           title="Foreign / Starlink"
           description="Interfaces tagged as the foreign (Starlink) uplink."
-          action={{ label: 'New', onClick: openAdd }}
+          action={{ label: 'Change', onClick: openAdd }}
         />
         <WanTable
           rows={items}

--- a/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
+++ b/frontend/tests/e2e/09-vpn-clients-crud.spec.ts
@@ -282,7 +282,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(2).click();
+    await page.getByRole('button', { name: 'New' }).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
@@ -377,7 +377,7 @@ test.describe('WAN VPN clients section', () => {
 
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await page.getByRole('button', { name: 'New' }).nth(2).click();
+    await page.getByRole('button', { name: 'New' }).click();
     const dialog = page.getByRole('dialog');
     await dialog.getByLabel('Name').fill('home-l2tp');
     await dialog.getByLabel('Connect to').fill('vpn.example.com');

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -333,7 +333,7 @@ test.describe('WAN tab', () => {
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
     await changeButton(page, 0).click();
-    const dialog = page.getByRole('dialog', { name: 'Add Starlink uplink' });
+    const dialog = page.getByRole('dialog', { name: 'Change Starlink uplink' });
     await expect(dialog).toBeVisible();
 
     await dialog.getByRole('radio', { name: 'Wireless' }).click();

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -3,9 +3,11 @@ import type { BrowserContext, Page } from '@playwright/test';
 
 const ROUTER_ID = 'rtr_wan';
 
-// "New" button order in WanPage: 0 Starlink, 1 Domestic, 2 Starlink Masking VPN Client.
-const newButton = (page: Page, index: number) =>
-  page.getByRole('button', { name: 'New' }).nth(index);
+// "Change" button order in WanPage: 0 Starlink, 1 Domestic.
+const changeButton = (page: Page, index: number) =>
+  page.getByRole('button', { name: 'Change' }).nth(index);
+
+const newClientButton = (page: Page) => page.getByRole('button', { name: 'New' });
 
 const envelope = <T>(data: T, status = 200) => JSON.stringify({ status, message: 'OK', data });
 
@@ -256,7 +258,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 0).click();
+    await changeButton(page, 0).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
@@ -293,7 +295,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state, { wanApplyDelayMs: 2500 });
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 0).click();
+    await changeButton(page, 0).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
@@ -331,7 +333,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 0).click();
+    await changeButton(page, 0).click();
     const dialog = page.getByRole('dialog', { name: 'Add Starlink uplink' });
     await expect(dialog).toBeVisible();
 
@@ -370,7 +372,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 1).click(); // Domestic add modal
+    await changeButton(page, 1).click(); // Domestic add modal
     const dialog = page.getByRole('dialog');
     await dialog.getByLabel('Domestic WAN').click();
 
@@ -392,7 +394,7 @@ test.describe('WAN tab', () => {
     await setupWanRoutes(context, state);
     await page.goto(`/router/${ROUTER_ID}/wan`);
 
-    await newButton(page, 2).click();
+    await newClientButton(page).click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 


### PR DESCRIPTION
Closes #486

- Rename the New action to Change on the Domestic and Foreign/Starlink WAN sections
- Label-only change, dialogs and move behavior untouched