### PR TITLE
fix(fe): Remove completedAt from wizard status

### DIFF
--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -474,7 +474,6 @@ export async function finalizeWizard(
 
 export interface WizardStatus {
   completed: boolean;
-  completedAt: string | null;
   progress: number;
 }
 

--- a/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
+++ b/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
@@ -134,7 +134,7 @@ test.describe('Easy-Mode wizard — apply progress', () => {
         body: JSON.stringify({
           status: 200,
           message: 'OK',
-          data: { completed: true, completedAt: null, progress: 100 },
+          data: { completed: true, progress: 100 },
         }),
       });
     });

--- a/frontend/tests/e2e/31-wizard-gated-menu.spec.ts
+++ b/frontend/tests/e2e/31-wizard-gated-menu.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 const freshStatus = JSON.stringify({
   status: 200,
   message: 'OK',
-  data: { completed: false, completedAt: null, progress: 0 },
+  data: { completed: false, progress: 0 },
 });
 
 test.describe('Wizard-gated navigation', () => {

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -129,7 +129,7 @@ export const test = base.extend<TestFixtures>({
         body: JSON.stringify({
           status: 200,
           message: 'OK',
-          data: { completed: true, completedAt: null, progress: 100 },
+          data: { completed: true, progress: 100 },
         }),
       });
     });
@@ -714,7 +714,7 @@ export const test = base.extend<TestFixtures>({
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: envelope({ completed: progress >= 100, completedAt: null, progress }),
+          body: envelope({ completed: progress >= 100, progress }),
         });
       });
     });


### PR DESCRIPTION
Closes #503

- Drop completedAt from the wizard status type and e2e mocks
- Nothing read the value so no behavior change