### PR TITLE
fix(installer): move firewall rules past leading dynamic rules

### DIFF
--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -284,7 +284,9 @@ func (e *Engine) moveToTop(path, selector string) {
 	if e.opts.DryRun {
 		return
 	}
-	_, _ = e.cl.RunRaw(fmt.Sprintf("%s/move [find %s] destination=0", path, selector), 15*time.Second)
+	cmd := fmt.Sprintf(`:local n 0; :local stop false; :foreach i in=[%s/find] do={ :if (!$stop) do={ :if ([%s/get $i dynamic]) do={ :set n ($n + 1) } else={ :set stop true } } }; %s/move [find %s] destination=$n`,
+		path, path, path, selector)
+	_, _ = e.cl.RunRaw(cmd, 15*time.Second)
 }
 
 var filePrintRow = regexp.MustCompile(`(?m)^\s*\d+`)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -295,7 +295,7 @@ ros_remove() {
 ros_move_to_top() {
   local path="$1" selector="$2"
   (( DRY_RUN )) && return 0
-  ros_cmd "${path}/move [find ${selector}] destination=0" >/dev/null 2>&1 || true
+  ros_cmd ":local n 0; :local stop false; :foreach i in=[${path}/find] do={ :if (!\$stop) do={ :if ([${path}/get \$i dynamic]) do={ :set n (\$n + 1) } else={ :set stop true } } }; ${path}/move [find ${selector}] destination=\$n" >/dev/null 2>&1 || true
 }
 
 ros_ensure_dir() {


### PR DESCRIPTION
## Summary

- Installer reordered its firewall rules with a hard-coded `destination=0`, which RouterOS rejects when dynamic rules occupy the top of the table
- Both installers now count the leading run of dynamic rules and move the rule immediately after them
- Resolves to 0 where no dynamic rules lead, so behaviour is unchanged on routers that already worked
