### PR TITLE
chore(installer): clear static firewall filter rules in LAN baseline

### DIFF
--- a/graphical-installer/assets/nasnet-lan-baseline.rsc
+++ b/graphical-installer/assets/nasnet-lan-baseline.rsc
@@ -2,6 +2,8 @@
   :log info "nasnet-panel: LANBridgeSplit already exists, skipping LAN baseline"
 } else={
   :log info "nasnet-panel: applying LAN baseline (192.168.10.0/24)"
+  :log info "nasnet-panel: clearing static firewall filter rules"
+  :do { /ip/firewall/filter remove [find dynamic=no !(comment~"nasnet-panel-installer")] } on-error={}
   :local wanIfaces [:toarray ""]
   :foreach c in=[/ip/dhcp-client find] do={
     :set wanIfaces ($wanIfaces , [/ip/dhcp-client get $c interface])

--- a/scripts/nasnet-lan-baseline.rsc
+++ b/scripts/nasnet-lan-baseline.rsc
@@ -2,6 +2,8 @@
   :log info "nasnet-panel: LANBridgeSplit already exists, skipping LAN baseline"
 } else={
   :log info "nasnet-panel: applying LAN baseline (192.168.10.0/24)"
+  :log info "nasnet-panel: clearing static firewall filter rules"
+  :do { /ip/firewall/filter remove [find dynamic=no !(comment~"nasnet-panel-installer")] } on-error={}
   :local wanIfaces [:toarray ""]
   :foreach c in=[/ip/dhcp-client find] do={
     :set wanIfaces ($wanIfaces , [/ip/dhcp-client get $c interface])


### PR DESCRIPTION
## Summary

- LAN baseline now removes static firewall filter rules so the router starts from a clean slate
- installer's own forward accepts are kept by comment tag, since the baseline runs after the network step
- sits behind the existing LANBridgeSplit guard, so it fires once on a fresh router and not on re-install