### PR TITLE
feat(be): Implemented DNS change/reset/validate/suggest endpoints

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -5,7 +5,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
+	"time"
 
 	"nasnet-panel/pkg/routeros"
 
@@ -105,6 +107,583 @@ func HandleUpdateDNS(c echo.Context) error {
 	}
 
 	return SuccessResponse(c, http.StatusOK, "DNS configuration updated successfully", nil)
+}
+
+// HandleSuggestDNS godoc
+// @Summary Suggest DNS server IPs
+// @Description Returns a curated list of domestic and foreign DNS server IPs, each with a
+// @Description short description of who operates it. The optional type query param restricts
+// @Description the response to just "domestic" or "foreign" (case-insensitive); omitted, both
+// @Description groups are returned.
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param type query string false "Restrict to domestic or foreign (case-insensitive); omit for both"
+// @Success 200 {object} Response{data=DNSSuggestResponse}
+// @Failure 400 {object} Response
+// @Router /api/dns/suggest [get].
+func HandleSuggestDNS(c echo.Context) error {
+	rawType := c.QueryParam("type")
+	suggestType := strings.ToLower(strings.TrimSpace(rawType))
+	if suggestType != "" && suggestType != dnsSuggestTypeDomestic && suggestType != dnsSuggestTypeForeign {
+		return ErrorResponse(c, http.StatusBadRequest,
+			fmt.Sprintf("Invalid type %q: must be %q or %q", rawType, dnsSuggestTypeDomestic, dnsSuggestTypeForeign), nil)
+	}
+
+	var response DNSSuggestResponse
+	if suggestType == "" || suggestType == dnsSuggestTypeDomestic {
+		response.Domestic = domesticDNSSuggestions
+	}
+	if suggestType == "" || suggestType == dnsSuggestTypeForeign {
+		response.Foreign = foreignDNSSuggestions
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS suggestions retrieved", response)
+}
+
+// HandleValidateDNS godoc
+// @Summary Check whether a DNS IP swap is safe
+// @Description oldIP and newIP must differ. Finds the DNS forwarder whose dns-servers is
+// @Description exactly oldIP, reads its role (Domestic/Foreign/VPN) from its name, and rejects
+// @Description newIP outright if it's already used by any DNS forwarder. If newIP matches one
+// @Description of the hardcoded IPs from GET /api/dns/suggest for the old forwarder's own type,
+// @Description it is trusted as suitable immediately, skipping the DOMAddList lookup below.
+// @Description Otherwise checks whether newIP is a member of the DOMAddList firewall address
+// @Description list, first confirming DOMAddList itself looks healthy (over 1000 entries, or
+// @Description its newest entry is under a month old). A Domestic forwarder is suitable to
+// @Description update only if newIP is in DOMAddList; a Foreign/VPN forwarder is suitable to
+// @Description update only if newIP is NOT in DOMAddList.
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param oldIP query string true "Current DNS forwarder IP"
+// @Param newIP query string true "Candidate replacement IP"
+// @Success 200 {object} Response{data=DNSCheckResponse}
+// @Failure 400 {object} Response
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 422 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/validate [get].
+func HandleValidateDNS(c echo.Context) error {
+	oldIP := c.QueryParam("oldIP")
+	newIP := c.QueryParam("newIP")
+	if oldIP == "" || newIP == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "oldIP and newIP are both required", nil)
+	}
+	if oldIP == newIP {
+		return ErrorResponse(c, http.StatusBadRequest, "oldIP and newIP cannot be the same", nil)
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	forwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: oldIP})
+	if err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search DNS forwarders", err)
+	}
+	if len(forwarders) == 0 {
+		return ErrorResponse(c, http.StatusNotFound,
+			fmt.Sprintf("Old IP %s not found in DNS forwarders (type: %s)", oldIP, dnsForwarderTypeUnknown), nil)
+	}
+
+	oldIPType := strings.TrimSpace(forwarders[0].Name)
+	if oldIPType != dnsForwarderTypeDomestic && oldIPType != dnsForwarderTypeForeign && oldIPType != dnsForwarderTypeVPN {
+		return ErrorResponse(c, http.StatusInternalServerError,
+			fmt.Sprintf("DNS forwarder for %s has an unrecognized type in its name: %q", oldIP, forwarders[0].Name), nil)
+	}
+
+	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: newIP})
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search DNS forwarders", err)
+	}
+	if len(newIPForwarders) > 0 {
+		return ErrorResponse(c, http.StatusConflict,
+			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", newIP, newIPForwarders[0].Name), nil)
+	}
+
+	if oldIPType == dnsForwarderTypeDomestic && isKnownDNSSuggestion(newIP, domesticDNSSuggestions) {
+		return SuccessResponse(c, http.StatusOK, "DNS forwarder IP check complete", DNSCheckResponse{
+			OldIP: oldIP, NewIP: newIP, OldIPType: oldIPType, Suitable: true,
+		})
+	}
+	if oldIPType != dnsForwarderTypeDomestic && isKnownDNSSuggestion(newIP, foreignDNSSuggestions) {
+		return SuccessResponse(c, http.StatusOK, "DNS forwarder IP check complete", DNSCheckResponse{
+			OldIP: oldIP, NewIP: newIP, OldIPType: oldIPType, Suitable: true,
+		})
+	}
+
+	domesticItems, err := client.ListFirewallAddressListItems(routeros.FirewallAddressListFilter{ListName: domesticAddressListName})
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search "+domesticAddressListName, err)
+	}
+
+	if err := checkDomesticAddressListHealth(domesticItems); err != nil {
+		// A stale/missing DOMAddList isn't a server failure, just an inconclusive
+		// check, so this is reported as 422 rather than 500.
+		return ErrorResponse(c, http.StatusUnprocessableEntity, err.Error(), nil)
+	}
+
+	matches, err := routeros.FilterAddressListByContainment(domesticItems, newIP)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search "+domesticAddressListName, err)
+	}
+	newIPIsDomestic := len(matches) > 0
+
+	response := DNSCheckResponse{
+		OldIP:     oldIP,
+		NewIP:     newIP,
+		OldIPType: oldIPType,
+	}
+
+	switch {
+	case oldIPType == dnsForwarderTypeDomestic && newIPIsDomestic:
+		response.Suitable = true
+	case oldIPType == dnsForwarderTypeDomestic && !newIPIsDomestic:
+		response.Suitable = false
+		response.Message = fmt.Sprintf("New IP %s is not a domestic IP", newIP)
+	case oldIPType != dnsForwarderTypeDomestic && newIPIsDomestic:
+		response.Suitable = false
+		response.Message = fmt.Sprintf("New IP %s is a domestic IP and not suitable to set for %s", newIP, oldIPType)
+	default: // oldIPType is Foreign/VPN and newIP is not domestic
+		response.Suitable = true
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP check complete", response)
+}
+
+// HandleChangeDNS godoc
+// @Summary Change a DNS server IP across /ip/dns, DNS forwarders, /ip/route and netwatch
+// @Description Runs the same guard checks as GET /api/dns/validate that don't depend on the
+// @Description old IP's forwarder type (oldIp and newIp must differ, and newIp must not
+// @Description already be used by any DNS forwarder), then replaces oldIp with newIp in the
+// @Description /ip/dns servers list, in the dns-servers list of every DNS forwarder that
+// @Description contains it (a forwarder may hold more than one IP), in every /ip/route entry
+// @Description whose dst-address is oldIp, in every /ip/route entry whose gateway is oldIp, and
+// @Description in every /tool/netwatch probe whose host is oldIp.
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param body body ChangeDNSRequest true "IP change to apply"
+// @Success 200 {object} Response{data=DNSChangeResponse}
+// @Failure 400 {object} Response
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/change [post].
+func HandleChangeDNS(c echo.Context) error {
+	var req ChangeDNSRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+	}
+	if req.OldIP == "" || req.NewIP == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "oldIp and newIp are both required", nil)
+	}
+	if req.OldIP == req.NewIP {
+		return ErrorResponse(c, http.StatusBadRequest, "oldIp and newIp cannot be the same", nil)
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: req.NewIP})
+	if err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search DNS forwarders", err)
+	}
+	if len(newIPForwarders) > 0 {
+		return ErrorResponse(c, http.StatusConflict,
+			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", req.NewIP, newIPForwarders[0].Name), nil)
+	}
+
+	info, err := client.GetDNSInfo()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to get DNS info", err)
+	}
+	if !slices.Contains(info.Servers, req.OldIP) {
+		return ErrorResponse(c, http.StatusNotFound,
+			fmt.Sprintf("Old IP %s not found in /ip/dns servers", req.OldIP), nil)
+	}
+
+	newServers := make([]string, len(info.Servers))
+	for i, server := range info.Servers {
+		if server == req.OldIP {
+			newServers[i] = req.NewIP
+		} else {
+			newServers[i] = server
+		}
+	}
+
+	serversStr := strings.Join(newServers, ",")
+	if err := client.UpdateDNSConfig(routeros.DNSUpdateConfig{Servers: &serversStr}); err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update DNS configuration", err)
+	}
+
+	forwarders, err := client.ListDNSForwarders()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+	}
+
+	updatedForwarders := make([]string, 0)
+	for i := range forwarders {
+		forwarder := &forwarders[i]
+		if !slices.Contains(forwarder.DNSServers, req.OldIP) {
+			continue
+		}
+
+		newForwarderServers := make([]string, len(forwarder.DNSServers))
+		for j, server := range forwarder.DNSServers {
+			if server == req.OldIP {
+				newForwarderServers[j] = req.NewIP
+			} else {
+				newForwarderServers[j] = server
+			}
+		}
+
+		if err := client.SetDNSForwarderServers(forwarder.ID, strings.Join(newForwarderServers, ",")); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err)
+		}
+		updatedForwarders = append(updatedForwarders, forwarder.Name)
+	}
+
+	dstAddressRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{DstAddress: req.OldIP})
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by dst-address", err)
+	}
+	updatedDstAddressRoutes := make([]string, 0, len(dstAddressRoutes))
+	for i := range dstAddressRoutes {
+		route := &dstAddressRoutes[i]
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{DstAddress: req.NewIP}); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s dst-address", route.ID), err)
+		}
+		updatedDstAddressRoutes = append(updatedDstAddressRoutes, route.ID)
+	}
+
+	gatewayRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Gateway: req.OldIP})
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by gateway", err)
+	}
+	updatedGatewayRoutes := make([]string, 0, len(gatewayRoutes))
+	for i := range gatewayRoutes {
+		route := &gatewayRoutes[i]
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{Gateway: req.NewIP}); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s gateway", route.ID), err)
+		}
+		updatedGatewayRoutes = append(updatedGatewayRoutes, route.ID)
+	}
+
+	netwatchProbes, err := client.ListNetwatch(routeros.NetwatchFilter{Host: &req.OldIP})
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list netwatch probes", err)
+	}
+	updatedNetwatchProbes := make([]string, 0, len(netwatchProbes))
+	for i := range netwatchProbes {
+		probe := &netwatchProbes[i]
+		if _, err := client.UpdateNetwatch(probe.ID, routeros.UpdateNetwatchParams{Host: &req.NewIP}); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update netwatch probe %s", probe.ID), err)
+		}
+		updatedNetwatchProbes = append(updatedNetwatchProbes, probe.ID)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP changed successfully", DNSChangeResponse{
+		OldIP:                   req.OldIP,
+		NewIP:                   req.NewIP,
+		Servers:                 newServers,
+		UpdatedForwarders:       updatedForwarders,
+		UpdatedDstAddressRoutes: updatedDstAddressRoutes,
+		UpdatedGatewayRoutes:    updatedGatewayRoutes,
+		UpdatedNetwatchProbes:   updatedNetwatchProbes,
+	})
+}
+
+// dnsResetServers, dnsResetDOHServer and dnsResetForwarders define the fixed
+// state GET /api/dns/reset restores /ip/dns and /ip/dns/forwarders to.
+var (
+	dnsResetServers   = "4.2.2.2,217.218.127.127,4.2.2.1"
+	dnsResetDOHServer = "https://cloudflare-dns.com/dns-query"
+
+	dnsResetForwarders = []struct {
+		Name       string
+		DNSServers string
+		Domestic   bool
+	}{
+		{Name: dnsForwarderTypeDomestic, DNSServers: "217.218.127.127", Domestic: true},
+		{Name: dnsForwarderTypeForeign, DNSServers: "4.2.2.1"},
+		{Name: "General", DNSServers: "4.2.2.2,217.218.127.127,4.2.2.1"},
+		{Name: dnsForwarderTypeVPN, DNSServers: "4.2.2.2"},
+	}
+
+	// CheckIP routes, identified by comment, and the gateway each is reset to.
+	dnsResetCheckIPRoutes = []struct {
+		Comment  string
+		Gateway  string
+		Domestic bool
+	}{
+		{Comment: "CheckIP-Route-to-Domestic-Domestic Link", Gateway: "217.218.127.127", Domestic: true},
+		{Comment: "CheckIP-Route-to-Foreign-Foreign Link", Gateway: "4.2.2.1"},
+		{Comment: "CheckIP-Route-to-VPN-Client", Gateway: "4.2.2.2"},
+	}
+
+	// Domestic/Foreign/VPN link routes, identified by comment, whose
+	// dst-address is reset unless it's the default route (0.0.0.0/0).
+	dnsResetRouteDstAddresses = []struct {
+		Comment    string
+		DstAddress string
+		Domestic   bool
+	}{
+		{Comment: "Route-to-Domestic-Domestic Link", DstAddress: "217.218.127.127", Domestic: true},
+		{Comment: "Route-to-Foreign-Foreign Link", DstAddress: "4.2.2.1"},
+		{Comment: "Route-to-VPN-Client", DstAddress: "4.2.2.2"},
+	}
+
+	// Failover netwatch probes, identified by comment, and the host each is reset to.
+	dnsResetNetwatchProbes = []struct {
+		Comment  string
+		Host     string
+		Domestic bool
+	}{
+		{Comment: "Failover Netwatch - Domestic Link", Host: "217.218.127.127", Domestic: true},
+		{Comment: "Failover Netwatch - Foreign Link", Host: "4.2.2.1"},
+		{Comment: "Failover Netwatch - VPN-Client", Host: "4.2.2.2"},
+	}
+)
+
+// defaultRouteDstAddress is RouterOS's dst-address for a default route, which
+// dnsResetRouteDstAddresses must never overwrite.
+const defaultRouteDstAddress = "0.0.0.0/0"
+
+// wanDomesticLinkComment is the /interface comment marking the router's
+// domestic WAN link. Reset steps tagged Domestic in the tables above only run
+// when an interface with this comment exists.
+const wanDomesticLinkComment = "WAN - Domestic Link"
+
+// HandleResetDNS godoc
+// @Summary Reset all DNS-related settings to their default configuration
+// @Description Replaces /ip/dns's servers with 4.2.2.2, 217.218.127.127 and 4.2.2.1, sets its
+// @Description DoH server to https://cloudflare-dns.com/dns-query with certificate verification
+// @Description disabled, removes every existing /ip/dns/forwarders entry, and recreates exactly
+// @Description four, each with certificate verification disabled: Domestic (217.218.127.127),
+// @Description Foreign (4.2.2.1), General (4.2.2.2, 217.218.127.127, 4.2.2.1) and VPN (4.2.2.2).
+// @Description Also resets the gateway of every /ip/route entry commented CheckIP-Route-to-
+// @Description Domestic-Domestic Link to 217.218.127.127, CheckIP-Route-to-Foreign-Foreign Link
+// @Description to 4.2.2.1, and CheckIP-Route-to-VPN-Client to 4.2.2.2. And, unless its
+// @Description dst-address is already the default route (0.0.0.0/0), resets the dst-address of
+// @Description every /ip/route entry commented Route-to-Domestic-Domestic Link to
+// @Description 217.218.127.127, Route-to-Foreign-Foreign Link to 4.2.2.1, and
+// @Description Route-to-VPN-Client to 4.2.2.2. Also resets the host of every /tool/netwatch
+// @Description probe commented "Failover Netwatch - Domestic Link" to 217.218.127.127,
+// @Description "Failover Netwatch - Foreign Link" to 4.2.2.1, and "Failover Netwatch -
+// @Description VPN-Client" to 4.2.2.2. All Domestic-related creations and changes above (the
+// @Description Domestic forwarder, and the Domestic CheckIP route, dst-address route and
+// @Description netwatch probe) are skipped entirely, and any existing Domestic forwarder is left
+// @Description in place, unless an /interface entry commented "WAN - Domestic Link" exists.
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Success 200 {object} Response{data=DNSResetResponse}
+// @Failure 401 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/reset [post].
+func HandleResetDNS(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	hasDomesticLink, err := client.InterfaceExistsWithComment(wanDomesticLinkComment)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to check for domestic WAN interface", err)
+	}
+
+	verifyDOHCert := false
+	if err := client.UpdateDNSConfig(routeros.DNSUpdateConfig{
+		Servers:       &dnsResetServers,
+		DOHServer:     &dnsResetDOHServer,
+		VerifyDOHCert: &verifyDOHCert,
+	}); err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to reset DNS configuration", err)
+	}
+
+	existingForwarders, err := client.ListDNSForwarders()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+	}
+	for i := range existingForwarders {
+		if !hasDomesticLink && existingForwarders[i].Name == dnsForwarderTypeDomestic {
+			continue
+		}
+		if err := client.RemoveDNSForwarder(existingForwarders[i].ID); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to remove DNS forwarder %q", existingForwarders[i].Name), err)
+		}
+	}
+
+	createdForwarders := make([]DNSForwarderResult, 0, len(dnsResetForwarders))
+	for _, forwarder := range dnsResetForwarders {
+		if !hasDomesticLink && forwarder.Domestic {
+			continue
+		}
+		id, err := client.AddDNSForwarder(forwarder.Name, forwarder.DNSServers, false)
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to create DNS forwarder %q", forwarder.Name), err)
+		}
+		createdForwarders = append(createdForwarders, DNSForwarderResult{
+			ID:         id,
+			Name:       forwarder.Name,
+			DNSServers: strings.Split(forwarder.DNSServers, ","),
+		})
+	}
+
+	updatedCheckIPRoutes := make([]string, 0, len(dnsResetCheckIPRoutes))
+	for _, route := range dnsResetCheckIPRoutes {
+		if !hasDomesticLink && route.Domestic {
+			continue
+		}
+		matches, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Comment: route.Comment})
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to search IP routes with comment %q", route.Comment), err)
+		}
+		for i := range matches {
+			if err := client.UpdateIPRoute(matches[i].ID, routeros.IPRouteConfig{Gateway: route.Gateway}); err != nil {
+				return ErrorResponse(c, http.StatusInternalServerError,
+					fmt.Sprintf("Failed to update gateway for route %q", route.Comment), err)
+			}
+			updatedCheckIPRoutes = append(updatedCheckIPRoutes, matches[i].ID)
+		}
+	}
+
+	updatedRouteDstAddresses := make([]string, 0, len(dnsResetRouteDstAddresses))
+	for _, route := range dnsResetRouteDstAddresses {
+		if !hasDomesticLink && route.Domestic {
+			continue
+		}
+		matches, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Comment: route.Comment})
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to search IP routes with comment %q", route.Comment), err)
+		}
+		for i := range matches {
+			if matches[i].DstAddress == defaultRouteDstAddress {
+				continue
+			}
+			if err := client.UpdateIPRoute(matches[i].ID, routeros.IPRouteConfig{DstAddress: route.DstAddress}); err != nil {
+				return ErrorResponse(c, http.StatusInternalServerError,
+					fmt.Sprintf("Failed to update dst-address for route %q", route.Comment), err)
+			}
+			updatedRouteDstAddresses = append(updatedRouteDstAddresses, matches[i].ID)
+		}
+	}
+
+	updatedNetwatchProbes := make([]string, 0, len(dnsResetNetwatchProbes))
+	for _, probe := range dnsResetNetwatchProbes {
+		if !hasDomesticLink && probe.Domestic {
+			continue
+		}
+		matches, err := client.ListNetwatch(routeros.NetwatchFilter{Comment: &probe.Comment})
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to search netwatch probes with comment %q", probe.Comment), err)
+		}
+		for i := range matches {
+			if _, err := client.UpdateNetwatch(matches[i].ID, routeros.UpdateNetwatchParams{Host: &probe.Host}); err != nil {
+				return ErrorResponse(c, http.StatusInternalServerError,
+					fmt.Sprintf("Failed to update host for netwatch probe %q", probe.Comment), err)
+			}
+			updatedNetwatchProbes = append(updatedNetwatchProbes, matches[i].ID)
+		}
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS settings reset successfully", DNSResetResponse{
+		Servers:                  strings.Split(dnsResetServers, ","),
+		DOHServer:                dnsResetDOHServer,
+		Forwarders:               createdForwarders,
+		UpdatedCheckIPRoutes:     updatedCheckIPRoutes,
+		UpdatedRouteDstAddresses: updatedRouteDstAddresses,
+		UpdatedNetwatchProbes:    updatedNetwatchProbes,
+	})
+}
+
+// domesticAddressListFreshWindow is how recently DOMAddList must have gained an
+// entry, when it's too small to be trusted on size alone.
+const domesticAddressListFreshWindow = 30 * 24 * time.Hour
+
+// domesticAddressListMinHealthySize is the entry count above which DOMAddList
+// is trusted regardless of how long ago it was last updated: a list this large
+// can only have come from a real import, not a stale or empty leftover.
+const domesticAddressListMinHealthySize = 1000
+
+// checkDomesticAddressListHealth reports whether DOMAddList looks like a live,
+// recently populated list rather than a stale or missing one: either it has
+// more than domesticAddressListMinHealthySize entries, or its most recently
+// created entry is within domesticAddressListFreshWindow. Checking the newest
+// entry rather than a positionally "last" one, since RouterOS does not
+// guarantee print order reflects insertion order once entries have been
+// removed and .id slots reused. Takes an already-fetched slice rather than a
+// client, so a caller that also needs the raw items (e.g. to run a
+// containment check against them) fetches DOMAddList only once.
+func checkDomesticAddressListHealth(items []routeros.FirewallAddressListItem) error {
+	if len(items) > domesticAddressListMinHealthySize {
+		return nil
+	}
+
+	var newest time.Time
+	for i := range items {
+		created, ok := parseRouterOSTimestamp(items[i].CreationTime)
+		if ok && created.After(newest) {
+			newest = created
+		}
+	}
+
+	if newest.IsZero() || time.Since(newest) > domesticAddressListFreshWindow {
+		return fmt.Errorf("%s address list seems outdated or not existing", domesticAddressListName)
+	}
+
+	return nil
+}
+
+// parseRouterOSTimestamp parses an absolute RouterOS timestamp such as a
+// creation-time value. RouterOS's wire format for these varies by version and
+// locale, so several known layouts are tried.
+func parseRouterOSTimestamp(value string) (time.Time, bool) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"Jan/02/2006 15:04:05",
+	}
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, true
+		}
+	}
+
+	return time.Time{}, false
 }
 
 func validateDNSServers(servers string) error {

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -15,6 +15,161 @@ type UpdateDNSRequest struct {
 	DOHServer *string `json:"dohServer" description:"DoH server URL (e.g., 'https://dns.google/dns-query'). Set to empty string to clear."`
 }
 
+// dnsForwarderType names the three recognized DNS forwarder roles, carried in
+// a forwarder's name.
+const (
+	dnsForwarderTypeDomestic = "Domestic"
+	dnsForwarderTypeForeign  = "Foreign"
+	dnsForwarderTypeVPN      = "VPN"
+	dnsForwarderTypeUnknown  = "Unknown"
+
+	domesticAddressListName = "DOMAddList"
+)
+
+// DNSCheckResponse is the response for GET /api/dns/validate.
+type DNSCheckResponse struct {
+	OldIP     string `json:"oldIp"`
+	NewIP     string `json:"newIp"`
+	OldIPType string `json:"oldIpType" example:"Domestic"`
+	Suitable  bool   `json:"suitable"`
+	Message   string `json:"message,omitempty"`
+}
+
+// ChangeDNSRequest is the request body for POST /api/dns/change.
+type ChangeDNSRequest struct {
+	OldIP string `json:"oldIp"`
+	NewIP string `json:"newIp"`
+}
+
+// DNSChangeResponse is the response for POST /api/dns/change.
+type DNSChangeResponse struct {
+	OldIP                   string   `json:"oldIp"`
+	NewIP                   string   `json:"newIp"`
+	Servers                 []string `json:"servers"`
+	UpdatedForwarders       []string `json:"updatedForwarders"`
+	UpdatedDstAddressRoutes []string `json:"updatedDstAddressRoutes"`
+	UpdatedGatewayRoutes    []string `json:"updatedGatewayRoutes"`
+	UpdatedNetwatchProbes   []string `json:"updatedNetwatchProbes"`
+}
+
+// DNSForwarderResult describes one DNS forwarder created by POST /api/dns/reset.
+type DNSForwarderResult struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	DNSServers []string `json:"dnsServers"`
+}
+
+// DNSResetResponse is the response for POST /api/dns/reset.
+type DNSResetResponse struct {
+	Servers                  []string             `json:"servers"`
+	DOHServer                string               `json:"dohServer"`
+	Forwarders               []DNSForwarderResult `json:"forwarders"`
+	UpdatedCheckIPRoutes     []string             `json:"updatedCheckIpRoutes"`
+	UpdatedRouteDstAddresses []string             `json:"updatedRouteDstAddresses"`
+	UpdatedNetwatchProbes    []string             `json:"updatedNetwatchProbes"`
+}
+
+// dnsSuggestTypeDomestic and dnsSuggestTypeForeign are the accepted values for
+// the optional "type" query param on GET /api/dns/suggest, compared
+// case-insensitively against the caller's input.
+const (
+	dnsSuggestTypeDomestic = "domestic"
+	dnsSuggestTypeForeign  = "foreign"
+)
+
+// DNSSuggestion is a single suggested DNS server IP with a short description
+// of who operates it.
+type DNSSuggestion struct {
+	IP          string `json:"ip"`
+	Description string `json:"description"`
+}
+
+// DNSSuggestResponse is the response for GET /api/dns/suggest. Domestic and/or
+// Foreign is omitted when the "type" query param restricts the result to the
+// other group.
+type DNSSuggestResponse struct {
+	Domestic []DNSSuggestion `json:"domestic,omitempty"`
+	Foreign  []DNSSuggestion `json:"foreign,omitempty"`
+}
+
+// domesticDNSSuggestions lists known-good domestic (Iranian) DNS server IPs.
+var domesticDNSSuggestions = []DNSSuggestion{
+	{IP: "10.202.10.10", Description: "Shatel DNS"},
+	{IP: "10.202.10.11", Description: "Shatel DNS"},
+	{IP: "10.202.10.202", Description: "Shatel DNS"},
+	{IP: "10.202.10.102", Description: "Shatel DNS"},
+	{IP: "5.202.100.101", Description: "Iranian ISP"},
+	{IP: "37.156.145.229", Description: "Iranian ISP"},
+	{IP: "37.156.145.21", Description: "Iranian ISP"},
+	{IP: "46.224.1.42", Description: "Iranian ISP"},
+	{IP: "78.157.42.100", Description: "Iranian ISP"},
+	{IP: "78.157.42.101", Description: "Iranian ISP"},
+	{IP: "80.191.40.41", Description: "Iranian ISP"},
+	{IP: "81.91.144.116", Description: "Iranian ISP"},
+	{IP: "91.99.101.12", Description: "Iranian ISP"},
+	{IP: "91.245.229.1", Description: "Iranian ISP"},
+	{IP: "92.119.56.162", Description: "Iranian ISP"},
+	{IP: "178.22.122.100", Description: "Asiatech DNS"},
+	{IP: "185.51.200.2", Description: "Shatel DNS"},
+	{IP: "185.51.200.10", Description: "Shatel DNS"},
+	{IP: "185.51.200.50", Description: "Shatel DNS"},
+	{IP: "185.55.225.25", Description: "Iranian ISP"},
+	{IP: "185.55.226.26", Description: "Iranian ISP"},
+	{IP: "185.97.117.187", Description: "Iranian ISP"},
+	{IP: "185.113.59.253", Description: "Iranian ISP"},
+	{IP: "185.161.112.33", Description: "Iranian ISP"},
+	{IP: "185.161.112.34", Description: "Iranian ISP"},
+	{IP: "185.186.242.161", Description: "Iranian ISP"},
+	{IP: "185.187.84.15", Description: "Iranian ISP"},
+	{IP: "185.231.182.126", Description: "Iranian ISP"},
+	{IP: "194.36.174.161", Description: "Iranian ISP"},
+	{IP: "194.225.62.80", Description: "Iranian ISP"},
+	{IP: "194.225.73.141", Description: "Iranian ISP"},
+	{IP: "213.176.123.5", Description: "Iranian ISP"},
+	{IP: "217.218.155.155", Description: "Iranian ISP"},
+	{IP: "2.188.21.130", Description: "Iranian ISP"},
+	{IP: "2.188.21.131", Description: "Iranian ISP"},
+	{IP: "2.188.21.132", Description: "Iranian ISP"},
+	{IP: "2.189.44.44", Description: "Iranian ISP"},
+}
+
+// foreignDNSSuggestions lists known-good foreign (international) DNS server IPs.
+var foreignDNSSuggestions = []DNSSuggestion{
+	{IP: "1.1.1.1", Description: "Cloudflare Primary"},
+	{IP: "1.0.0.1", Description: "Cloudflare Secondary"},
+	{IP: "8.8.8.8", Description: "Google Primary"},
+	{IP: "8.8.4.4", Description: "Google Secondary"},
+	{IP: "4.2.2.1", Description: "Level3 DNS"},
+	{IP: "4.2.2.2", Description: "Level3 DNS"},
+	{IP: "4.2.2.3", Description: "Level3 DNS"},
+	{IP: "4.2.2.4", Description: "Level3 DNS"},
+	{IP: "9.9.9.9", Description: "Quad9 DNS"},
+	{IP: "149.112.112.112", Description: "Quad9 DNS"},
+	{IP: "208.67.222.222", Description: "OpenDNS"},
+	{IP: "208.67.220.220", Description: "OpenDNS"},
+	{IP: "8.26.56.26", Description: "Google Secondary"},
+	{IP: "8.20.247.20", Description: "Google Secondary"},
+	{IP: "64.6.64.6", Description: "Verisign Public DNS"},
+	{IP: "64.6.65.6", Description: "Verisign Public DNS"},
+	{IP: "84.200.69.80", Description: "DNS.Watch"},
+	{IP: "84.200.70.40", Description: "DNS.Watch"},
+	{IP: "8.26.56.26", Description: "Comodo Secure DNS"},
+	{IP: "8.20.247.20", Description: "Comodo Secure DNS"},
+	{IP: "94.140.14.14", Description: "AdGuard DNS"},
+	{IP: "94.140.15.15", Description: "AdGuard DNS"},
+}
+
+// isKnownDNSSuggestion reports whether ip is one of the hardcoded suggestions
+// in the given list.
+func isKnownDNSSuggestion(ip string, suggestions []DNSSuggestion) bool {
+	for i := range suggestions {
+		if suggestions[i].IP == ip {
+			return true
+		}
+	}
+	return false
+}
+
 func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse {
 	if info == nil {
 		return nil

--- a/backend/internal/handler/net.go
+++ b/backend/internal/handler/net.go
@@ -40,20 +40,20 @@ func HandleGetNetStatus(c echo.Context) error {
 			Host:   items[i].Host,
 			Status: string(items[i].Status),
 			Since:  items[i].Since,
-			Type:   resolveNetwatchHostType(items[i].Host),
+			Type:   resolveNetwatchCommentType(items[i].Comment),
 		}
 	}
 
 	return SuccessResponse(c, http.StatusOK, "Network status retrieved", response)
 }
 
-func resolveNetwatchHostType(host string) NetwatchHostType {
-	switch host {
-	case "4.2.2.1":
+func resolveNetwatchCommentType(comment string) NetwatchHostType {
+	switch comment {
+	case "Failover Netwatch - Foreign Link":
 		return NetwatchHostTypeForeign
-	case "4.2.2.2":
+	case "Failover Netwatch - VPN-Client":
 		return NetwatchHostTypeVPN
-	case "217.218.127.127":
+	case "Failover Netwatch - Domestic Link":
 		return NetwatchHostTypeDomestic
 	default:
 		return ""

--- a/backend/internal/handler/route.go
+++ b/backend/internal/handler/route.go
@@ -25,12 +25,12 @@ func HandleGetForeignGateway(c echo.Context) error {
 		return err
 	}
 
-	filters := map[string]string{
-		"comment":       "Route-to-VPN-Client",
-		"routing-table": "main",
+	filter := routeros.IPRouteFilter{
+		Comment:      "Route-to-VPN-Client",
+		RoutingTable: "main",
 	}
 
-	routes, err := client.ListIPRoutesWithFilters(filters)
+	routes, err := client.ListIPRoutesWithFilters(filter)
 	if err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve foreign gateway route", err)
 	}
@@ -74,11 +74,11 @@ func HandleUpdateForeignGateway(c echo.Context) error {
 		return ErrorResponse(c, http.StatusBadRequest, "Gateway is required", nil)
 	}
 
-	filters := map[string]string{
-		"comment": "Route-to-VPN-Client",
+	filter := routeros.IPRouteFilter{
+		Comment: "Route-to-VPN-Client",
 	}
 
-	routes, err := client.ListIPRoutesWithFilters(filters)
+	routes, err := client.ListIPRoutesWithFilters(filter)
 	if err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve routes", err)
 	}

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1892,10 +1892,9 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		task.mu.Unlock()
 	}
 
-	ovpnServerName := "ovpn-server-" + timestamp
-	caName := "cert-ca-" + ovpnServerName
-	serverName := "cert-server-" + ovpnServerName
-	clientName := "cert-client-" + ovpnServerName
+	caName := "cert-ca-" + timestamp
+	serverName := "cert-server-" + timestamp
+	clientName := "cert-client-" + timestamp
 
 	updateTask(5, "Creating CA certificate")
 	caCertParams := routeros.AddCertificateParams{

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -89,6 +89,10 @@ func RegisterRoutes(e *echo.Echo) {
 	dnsGroup.Use(middleware.RouterOSAuth)
 	dnsGroup.GET("/info", handler.HandleGetDNSInfo)
 	dnsGroup.PUT("/info", handler.HandleUpdateDNS)
+	dnsGroup.GET("/suggest", handler.HandleSuggestDNS)
+	dnsGroup.GET("/validate", handler.HandleValidateDNS)
+	dnsGroup.POST("/change", handler.HandleChangeDNS)
+	dnsGroup.POST("/reset", handler.HandleResetDNS)
 
 	vpnGroup := e.Group("/api/vpn")
 	vpnGroup.Use(middleware.RouterOSAuth)

--- a/backend/internal/template/l2tp_client.tmpl
+++ b/backend/internal/template/l2tp_client.tmpl
@@ -58,9 +58,11 @@ add dst-address="0.0.0.0/0" gateway="l2tp-client-L2TP-Client" routing-table="to-
 add check-gateway=ping dst-address="4.2.2.2" gateway="l2tp-client-L2TP-Client" routing-table="to-VPN" \
 distance=1 target-scope="11" comment="Route-to-VPN-Client"
 add dst-address="4.2.2.2" gateway="l2tp-client-L2TP-Client" routing-table="main" scope="10" comment="Route-to-VPN-Client"
+add check-gateway=ping dst-address="0.0.0.0/0" gateway="4.2.2.2" routing-table="main" \
+distance="1" target-scope="11" comment="CheckIP-Route-to-VPN-Client"
 add comment=Blackhole blackhole disabled=no distance=99 dst-address=0.0.0.0/0 gateway="" routing-table="to-VPN-L2TP-Client"
 add comment="Route-to-Foreign-Foreign Link 1" distance=1 dst-address=192.168.100.0/24 gateway=100.64.0.1 routing-table="to-VPN-L2TP-Client"
 
 /tool netwatch
 add host="4.2.2.2" interval=5s timeout=500ms ignore-initial-down=no ignore-initial-up=yes start-delay=0ms startup-delay=0s \
-up-script="/ip route enable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " down-script="/ip route disable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " comment="Failover Netwatch - L2TP-Client"
+up-script="/ip route enable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " down-script="/ip route disable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " comment="Failover Netwatch - VPN-Client"

--- a/backend/internal/template/wg_client.tmpl
+++ b/backend/internal/template/wg_client.tmpl
@@ -73,4 +73,4 @@ add comment="Route-to-Foreign-Foreign Link 1" distance=1 dst-address=192.168.100
 /tool netwatch
 add host="4.2.2.2" interval=5s timeout=500ms \
 ignore-initial-down=no ignore-initial-up=yes start-delay=0ms startup-delay=0s \
-up-script="/ip route enable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " down-script="/ip route disable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " comment="Failover Netwatch - wg-client"
+up-script="/ip route enable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " down-script="/ip route disable [find comment=\"CheckIP-Route-to-VPN-Client\"]; " comment="Failover Netwatch - VPN-Client"

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -14,8 +14,20 @@ type DNSInfo struct {
 
 // DNSUpdateConfig represents DNS configuration to update.
 type DNSUpdateConfig struct {
-	Servers   *string
-	DOHServer *string
+	Servers       *string
+	DOHServer     *string
+	VerifyDOHCert *bool
+}
+
+// DNSForwarder represents a named DNS forwarder from /ip/dns/forwarders,
+// referenced by name from a matching /ip/dns/static forward-to entry.
+type DNSForwarder struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	DNSServers    []string `json:"dnsServers"`
+	DOHServers    []string `json:"dohServers"`
+	VerifyDOHCert bool     `json:"verifyDohCert"`
+	Comment       string   `json:"comment"`
 }
 
 // GetDNSInfo retrieves DNS configuration from RouterOS.
@@ -45,7 +57,15 @@ func (c *Client) UpdateDNSConfig(config DNSUpdateConfig) error {
 	}
 
 	if config.DOHServer != nil {
-		args = append(args, "=use-doh-server="+*config.DOHServer, "=verify-doh-cert=no", "=allow-remote-requests=yes")
+		args = append(args, "=use-doh-server="+*config.DOHServer, "=allow-remote-requests=yes")
+	}
+
+	if config.VerifyDOHCert != nil {
+		if *config.VerifyDOHCert {
+			args = append(args, "=verify-doh-cert=yes")
+		} else {
+			args = append(args, "=verify-doh-cert=no")
+		}
 	}
 
 	if len(args) == 0 {
@@ -58,6 +78,139 @@ func (c *Client) UpdateDNSConfig(config DNSUpdateConfig) error {
 	}
 
 	return nil
+}
+
+// ListDNSForwarders retrieves every named DNS forwarder from /ip/dns/forwarders.
+func (c *Client) ListDNSForwarders() ([]DNSForwarder, error) {
+	results, err := c.GetAll("/ip/dns/forwarders")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list DNS forwarders: %w", err)
+	}
+
+	forwarders := make([]DNSForwarder, 0, len(results))
+	for _, result := range results {
+		forwarders = append(forwarders, DNSForwarder{
+			ID:            result[".id"],
+			Name:          result["name"],
+			DNSServers:    parseStringList(result["dns-servers"]),
+			DOHServers:    parseStringList(result["doh-servers"]),
+			VerifyDOHCert: result["verify-doh-cert"] != "no",
+			Comment:       result["comment"],
+		})
+	}
+
+	return forwarders, nil
+}
+
+// SetDNSForwarderServers replaces the dns-servers value of the DNS forwarder
+// identified by id (its RouterOS .id).
+func (c *Client) SetDNSForwarderServers(id, dnsServers string) error {
+	if id == "" {
+		return fmt.Errorf("DNS forwarder ID is required")
+	}
+
+	_, err := c.Set("/ip/dns/forwarders", "=.id="+id, "=dns-servers="+dnsServers)
+	if err != nil {
+		return fmt.Errorf("failed to update DNS forwarder %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// AddDNSForwarder creates a new /ip/dns/forwarders entry and returns its
+// RouterOS .id, explicitly setting verify-doh-cert since RouterOS defaults it
+// to yes if omitted.
+func (c *Client) AddDNSForwarder(name, dnsServers string, verifyDOHCert bool) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("DNS forwarder name is required")
+	}
+	if dnsServers == "" {
+		return "", fmt.Errorf("DNS forwarder dns-servers is required")
+	}
+
+	verifyStr := "no"
+	if verifyDOHCert {
+		verifyStr = "yes"
+	}
+
+	id, err := c.Add("/ip/dns/forwarders", "=name="+name, "=dns-servers="+dnsServers, "=verify-doh-cert="+verifyStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to add DNS forwarder %s: %w", name, err)
+	}
+
+	return id, nil
+}
+
+// RemoveDNSForwarder deletes the /ip/dns/forwarders entry identified by id
+// (its RouterOS .id).
+func (c *Client) RemoveDNSForwarder(id string) error {
+	if id == "" {
+		return fmt.Errorf("DNS forwarder ID is required")
+	}
+
+	_, err := c.Remove("/ip/dns/forwarders", "=.id="+id)
+	if err != nil {
+		return fmt.Errorf("failed to remove DNS forwarder %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// DNSForwarderFilter represents filter criteria for querying DNS forwarders.
+// If all fields are empty/nil, every forwarder is returned. DNSServers and
+// DOHServers match a forwarder whose corresponding list contains exactly the
+// given value, not a substring or partial-list match, since RouterOS
+// ?= filters compare the whole property value.
+type DNSForwarderFilter struct {
+	ID            string // Filter by item ID (RouterOS internal .id)
+	Name          string // Filter by forwarder name
+	DNSServers    string // Filter by exact dns-servers value (e.g. "1.1.1.1,8.8.8.8")
+	DOHServers    string // Filter by exact doh-servers value
+	VerifyDOHCert *bool  // Filter by verify-doh-cert (true/false, nil for any)
+}
+
+// FindDNSForwarders retrieves DNS forwarders matching the given filter criteria.
+func (c *Client) FindDNSForwarders(filter DNSForwarderFilter) ([]DNSForwarder, error) {
+	args := make([]string, 0)
+
+	if filter.ID != "" {
+		args = append(args, "?=.id="+filter.ID)
+	}
+	if filter.Name != "" {
+		args = append(args, "?=name="+filter.Name)
+	}
+	if filter.DNSServers != "" {
+		args = append(args, "?=dns-servers="+filter.DNSServers)
+	}
+	if filter.DOHServers != "" {
+		args = append(args, "?=doh-servers="+filter.DOHServers)
+	}
+	if filter.VerifyDOHCert != nil {
+		verifyStr := "no"
+		if *filter.VerifyDOHCert {
+			verifyStr = "yes"
+		}
+		args = append(args, "?=verify-doh-cert="+verifyStr)
+	}
+
+	results, err := c.GetAll("/ip/dns/forwarders", args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find DNS forwarders: %w", err)
+	}
+
+	forwarders := make([]DNSForwarder, 0, len(results))
+	for _, result := range results {
+		forwarders = append(forwarders, DNSForwarder{
+			ID:            result[".id"],
+			Name:          result["name"],
+			DNSServers:    parseStringList(result["dns-servers"]),
+			DOHServers:    parseStringList(result["doh-servers"]),
+			VerifyDOHCert: result["verify-doh-cert"] != "no",
+			Comment:       result["comment"],
+		})
+	}
+
+	return forwarders, nil
 }
 
 func parseStringList(value string) []string {

--- a/backend/pkg/routeros/firewall.go
+++ b/backend/pkg/routeros/firewall.go
@@ -2,6 +2,7 @@ package routeros
 
 import (
 	"fmt"
+	"net"
 )
 
 // FirewallFilterRule represents a firewall filter rule configuration.
@@ -109,11 +110,12 @@ type MangleRuleConfig struct {
 
 // FirewallAddressListItem represents an entry in a firewall address list.
 type FirewallAddressListItem struct {
-	ID       string
-	List     string
-	Address  string
-	Disabled bool
-	Comment  string
+	ID           string
+	List         string
+	Address      string
+	Disabled     bool
+	Comment      string
+	CreationTime string // raw RouterOS creation-time value; format varies by version
 }
 
 // FirewallAddressListFilter represents filter criteria for querying firewall address list items.
@@ -449,15 +451,113 @@ func (c *Client) ListFirewallAddressListItems(filter FirewallAddressListFilter) 
 	items := make([]FirewallAddressListItem, 0, len(results))
 	for _, result := range results {
 		items = append(items, FirewallAddressListItem{
-			ID:       result[".id"],
-			List:     result["list"],
-			Address:  result["address"],
-			Disabled: result["disabled"] == "true",
-			Comment:  result["comment"],
+			ID:           result[".id"],
+			List:         result["list"],
+			Address:      result["address"],
+			Disabled:     result["disabled"] == "true",
+			Comment:      result["comment"],
+			CreationTime: result["creation-time"],
 		})
 	}
 
 	return items, nil
+}
+
+// FindFirewallAddressListEntries returns every /ip/firewall/address-list entry
+// whose address contains target, matching the semantics of the RouterOS CLI's
+// "(target in address)" query, e.g. "print where list=DOMAddList (<ip> in
+// address)". ListName scopes the search to one list; an empty listName
+// searches all lists, matching print with no list= filter. Target may be a
+// single address or a CIDR range; in the latter case an entry matches only if
+// it fully contains that range, not merely overlaps it, mirroring the CLI's
+// "in" operator.
+//
+// The RouterOS binary API has no "in" query word (only =, >, < and the #
+// logical operators, per MikroTik's API documentation), so this fetches
+// candidate entries via the ordinary list= filter and evaluates containment
+// in Go. Callers that already have the list's items from another call (e.g. to
+// check its size or freshness) should use FilterAddressListByContainment
+// directly instead, to avoid fetching the same list twice.
+func (c *Client) FindFirewallAddressListEntries(listName, target string) ([]FirewallAddressListItem, error) {
+	if target == "" {
+		return nil, fmt.Errorf("target address is required")
+	}
+
+	items, err := c.ListFirewallAddressListItems(FirewallAddressListFilter{ListName: listName})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list firewall address list items: %w", err)
+	}
+
+	return FilterAddressListByContainment(items, target)
+}
+
+// FilterAddressListByContainment returns every item in items whose Address
+// contains target, using the same containment semantics as
+// FindFirewallAddressListEntries. It performs no RouterOS calls of its own,
+// so callers that also need other information about the same list (e.g. its
+// size or the newest entry's creation time) can fetch once via
+// ListFirewallAddressListItems and reuse that result here.
+func FilterAddressListByContainment(items []FirewallAddressListItem, target string) ([]FirewallAddressListItem, error) {
+	if target == "" {
+		return nil, fmt.Errorf("target address is required")
+	}
+
+	targetNet, err := parseAddressOrCIDR(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid target address %s: %w", target, err)
+	}
+
+	matches := make([]FirewallAddressListItem, 0)
+	for i := range items {
+		entryNet, err := parseAddressOrCIDR(items[i].Address)
+		if err != nil {
+			continue
+		}
+
+		if !cidrContains(entryNet, targetNet) {
+			continue
+		}
+
+		matches = append(matches, items[i])
+	}
+
+	return matches, nil
+}
+
+// parseAddressOrCIDR parses value as a CIDR range, or as a single address
+// widened to its narrowest CIDR (/32 for IPv4, /128 for IPv6) if it has no
+// "/" of its own.
+func parseAddressOrCIDR(value string) (*net.IPNet, error) {
+	if _, ipNet, err := net.ParseCIDR(value); err == nil {
+		return ipNet, nil
+	}
+
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return nil, fmt.Errorf("not a valid address or CIDR")
+	}
+
+	if ip4 := ip.To4(); ip4 != nil {
+		return &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}, nil
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}, nil
+}
+
+// cidrContains reports whether contained is fully inside container: container
+// must be the same address family, have a prefix at least as broad, and
+// contain contained's network address.
+func cidrContains(container, contained *net.IPNet) bool {
+	containerOnes, containerBits := container.Mask.Size()
+	containedOnes, containedBits := contained.Mask.Size()
+
+	if containerBits != containedBits {
+		return false // different address families (IPv4 vs IPv6)
+	}
+	if containedOnes < containerOnes {
+		return false // contained is a broader range than container, can't fit inside it
+	}
+
+	return container.Contains(contained.IP)
 }
 
 // AddFirewallAddressListItem adds a new item to a firewall address list.

--- a/backend/pkg/routeros/interface.go
+++ b/backend/pkg/routeros/interface.go
@@ -354,6 +354,21 @@ func (c *Client) GetInterface(name string) (*InterfaceInfo, error) {
 	return &parsed, nil
 }
 
+// InterfaceExistsWithComment reports whether any /interface entry has exactly
+// the given comment.
+func (c *Client) InterfaceExistsWithComment(comment string) (bool, error) {
+	if comment == "" {
+		return false, fmt.Errorf("comment is required")
+	}
+
+	results, err := c.GetAll("/interface", "?=comment="+comment)
+	if err != nil {
+		return false, fmt.Errorf("failed to search interfaces by comment %s: %w", comment, err)
+	}
+
+	return len(results) > 0, nil
+}
+
 func parseInterfaceInfo(result map[string]string) InterfaceInfo {
 	return InterfaceInfo{
 		ID:               result[".id"],

--- a/backend/pkg/routeros/ip.go
+++ b/backend/pkg/routeros/ip.go
@@ -172,41 +172,57 @@ func (c *Client) ListIPRoutes() ([]IPRouteInfo, error) {
 	return routes, nil
 }
 
-// ListIPRoutesWithFilters lists IP routes with optional filtering.
-// Supported filter keys: dst-address, gateway, distance, disabled, dynamic, check-gateway, scope, target-scope, routing-table, comment.
-func (c *Client) ListIPRoutesWithFilters(filters map[string]string) ([]IPRouteInfo, error) {
+// IPRouteFilter represents filter criteria for querying IP routes. Fields are
+// RouterOS wire-format strings (e.g. Disabled/Dynamic as "true"/"false"), not
+// parsed types, since they're passed straight through to a ?= query argument;
+// an empty field is omitted from the query.
+type IPRouteFilter struct {
+	DstAddress   string
+	Gateway      string
+	Distance     string
+	Disabled     string
+	Dynamic      string
+	CheckGateway string
+	Scope        string
+	TargetScope  string
+	RoutingTable string
+	Comment      string
+}
+
+// ListIPRoutesWithFilters lists IP routes matching the given filter criteria.
+// If all filter fields are empty, returns every route.
+func (c *Client) ListIPRoutesWithFilters(filter IPRouteFilter) ([]IPRouteInfo, error) {
 	args := []string{}
 
-	// Build filter arguments based on provided filters
-	if dstAddr, ok := filters["dst-address"]; ok && dstAddr != "" {
-		args = append(args, "?=dst-address="+dstAddr)
+	if filter.DstAddress != "" {
+		args = append(args, "?=dst-address="+filter.DstAddress)
 	}
-	if gateway, ok := filters["gateway"]; ok && gateway != "" {
-		args = append(args, "?=gateway="+gateway)
+	if filter.Gateway != "" {
+		args = append(args, "?=gateway="+filter.Gateway)
 	}
-	if distance, ok := filters["distance"]; ok && distance != "" {
-		args = append(args, "?=distance="+distance)
+	if filter.Distance != "" {
+		args = append(args, "?=distance="+filter.Distance)
 	}
-	if disabled, ok := filters["disabled"]; ok && disabled != "" {
-		args = append(args, "?=disabled="+disabled)
+	if filter.Disabled != "" {
+		args = append(args, "?=disabled="+filter.Disabled)
 	}
-	if dynamic, ok := filters["dynamic"]; ok && dynamic != "" {
-		args = append(args, "?=dynamic="+dynamic)
+	if filter.Dynamic != "" {
+		args = append(args, "?=dynamic="+filter.Dynamic)
 	}
-	if checkGateway, ok := filters["check-gateway"]; ok && checkGateway != "" {
-		args = append(args, "?=check-gateway="+checkGateway)
+	if filter.CheckGateway != "" {
+		args = append(args, "?=check-gateway="+filter.CheckGateway)
 	}
-	if scope, ok := filters["scope"]; ok && scope != "" {
-		args = append(args, "?=scope="+scope)
+	if filter.Scope != "" {
+		args = append(args, "?=scope="+filter.Scope)
 	}
-	if targetScope, ok := filters["target-scope"]; ok && targetScope != "" {
-		args = append(args, "?=target-scope="+targetScope)
+	if filter.TargetScope != "" {
+		args = append(args, "?=target-scope="+filter.TargetScope)
 	}
-	if routingTable, ok := filters["routing-table"]; ok && routingTable != "" {
-		args = append(args, "?=routing-table="+routingTable)
+	if filter.RoutingTable != "" {
+		args = append(args, "?=routing-table="+filter.RoutingTable)
 	}
-	if comment, ok := filters["comment"]; ok && comment != "" {
-		args = append(args, "?=comment="+comment)
+	if filter.Comment != "" {
+		args = append(args, "?=comment="+filter.Comment)
 	}
 
 	results, err := c.GetAll("/ip/route", args...)


### PR DESCRIPTION
* Closes #454

## feat(be): Add DNS validate/change/reset/suggest endpoints

Adds a set of DNS management endpoints for safely swapping a DNS server IP
across every place it's referenced on the router, plus a full-system DNS
reset. Also generalizes `ListIPRoutesWithFilters` to a typed filter and fixes
a few naming inconsistencies discovered along the way.

### New endpoints (`/api/dns/*`)

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/api/dns/suggest` | Curated list of domestic/foreign DNS server IPs, each with a short description |
| `GET` | `/api/dns/validate` | Checks whether swapping a DNS forwarder's IP is safe |
| `POST` | `/api/dns/change` | Performs the swap everywhere it's referenced |
| `POST` | `/api/dns/reset` | Resets all DNS-related router state to a known-good default |

#### `GET /api/dns/suggest`

Static data — 37 domestic (Iranian ISP/Shatel/Asiatech) and 18 foreign
(Cloudflare, Google, Level3, Quad9, OpenDNS, Verisign, DNS.Watch, Comodo,
AdGuard) DNS IPs, each with a description. Optional `type=domestic|foreign`
query param (case-insensitive) restricts the response to one group; an
unrecognized value is rejected with `400`.

Known data wrinkle carried over from the source list as given: `8.26.56.26`
and `8.20.247.20` appear twice under two different labels ("Google
Secondary" and "Comodo Secure DNS") — kept as provided rather than
deduplicated, since those two IPs are in fact Comodo's, not Google's.

#### `GET /api/dns/validate?oldIP=&newIP=`

Determines whether replacing `oldIP` with `newIP` is safe, without changing
anything. Order of checks:

1. `oldIP`/`newIP` required and must differ (`400`).
2. `oldIP` must match a DNS forwarder's `dns-servers` exactly; its role
   (`Domestic`/`Foreign`/`VPN`) is read from the forwarder's **name** (`404`
   if not found; `500` if the name isn't one of those three).
3. `newIP` must not already be in use by another forwarder (`409`).
4. **Fast path:** if `newIP` is one of the hardcoded suggestions from
   `/api/dns/suggest` matching the old forwarder's own type (a domestic
   suggestion for a `Domestic` forwarder, a foreign suggestion for a
   `Foreign`/`VPN` forwarder), it's trusted immediately — `suitable: true`,
   skipping the `DOMAddList` lookup entirely.
5. Otherwise, checks `DOMAddList` (the domestic-subnet firewall address
   list) for health first — over 1000 entries, or its newest entry's
   `creation-time` under a month old — reporting `422` if neither holds
   (stale/missing list, not a server error). Then checks whether `newIP` is
   contained in `DOMAddList` (IP or CIDR containment, not exact match) to
   decide suitability: a `Domestic` forwarder is suitable only if `newIP` is
   in the list; `Foreign`/`VPN` only if it isn't.

#### `POST /api/dns/change` `{oldIp, newIp}`

Runs the same `oldIp != newIp` / `newIp` not already in use checks, then
propagates the swap everywhere:

- `/ip/dns`'s `servers` list (`404` if `oldIp` isn't present there)
- every DNS forwarder's `dns-servers` list containing `oldIp` (a forwarder
  may hold more than one IP — only the matching entry is replaced)
- every `/ip/route` entry whose `dst-address` or `gateway` is `oldIp`
- every `/tool/netwatch` probe whose `host` is `oldIp`

Response reports what was touched: `servers`, `updatedForwarders`,
`updatedDstAddressRoutes`, `updatedGatewayRoutes`, `updatedNetwatchProbes`.
No rollback on partial failure — a failure partway through leaves earlier
steps already applied.

#### `POST /api/dns/reset`

Resets DNS-related state to a fixed known-good configuration:

1. `/ip/dns`: `servers` → `4.2.2.2,217.218.127.127,4.2.2.1`, DoH server →
   `https://cloudflare-dns.com/dns-query`, `verify-doh-cert=no`.
2. Removes every existing `/ip/dns/forwarders` entry, recreates exactly
   four (`verify-doh-cert=no` on each): `Domestic` → `217.218.127.127`,
   `Foreign` → `4.2.2.1`, `General` →
   `4.2.2.2,217.218.127.127,4.2.2.1`, `VPN` → `4.2.2.2`.
3. Resets the gateway of `/ip/route` entries commented
   `CheckIP-Route-to-{Domestic-Domestic Link,Foreign-Foreign Link,VPN-Client}`
   to the matching IP.
4. Resets the `dst-address` of `/ip/route` entries commented
   `Route-to-{Domestic-Domestic Link,Foreign-Foreign Link,VPN-Client}` to
   the matching IP — **unless** the route's `dst-address` is already
   `0.0.0.0/0` (the default route is never touched).
5. Resets the `host` of `/tool/netwatch` probes commented
   `Failover Netwatch - {Domestic Link,Foreign Link,VPN-Client}` to the
   matching IP.

**Guard:** before any of the above runs, checks whether an `/interface`
entry commented `WAN - Domestic Link` exists. If it doesn't, every
Domestic-tagged action is skipped — the `Domestic` forwarder is neither
removed (if it already exists) nor recreated, and the Domestic `CheckIP`
route, `Route-to-*` route, and netwatch probe are left untouched. Foreign
and VPN items, and the general `/ip/dns` reset, proceed regardless.

Response reports every resource touched:
`servers`, `dohServer`, `forwarders`, `updatedCheckIpRoutes`,
`updatedRouteDstAddresses`, `updatedNetwatchProbes`.

This is destructive and has no dry-run or backup step — calling it discards
the current DNS forwarder configuration unconditionally (aside from the
Domestic guard above).

### `pkg/routeros` additions

- **`dns.go`**: `DNSForwarder.Comment`; `DNSForwarderFilter` +
  `FindDNSForwarders`; `AddDNSForwarder` (now takes `verifyDOHCert bool`,
  since RouterOS defaults `verify-doh-cert` to `yes` if omitted);
  `RemoveDNSForwarder`; `SetDNSForwarderServers`; `DNSUpdateConfig` gained
  `VerifyDOHCert *bool` (previously hardcoded to `no` whenever a DoH server
  was set — now independently settable, so existing callers must pass it
  explicitly to get the old behavior).
- **`firewall.go`**: `FirewallAddressListItem.CreationTime`;
  `FindFirewallAddressListEntries` (CIDR/IP containment search — RouterOS's
  binary API has no `in` query word, so this fetches via `list=` and
  evaluates containment in Go); `FilterAddressListByContainment` (pure
  function factored out of the above so a caller needing both a list's raw
  items and a containment check — like `/validate`'s health check — fetches
  once, not twice).
- **`ip.go`**: `ListIPRoutesWithFilters` changed from
  `map[string]string` to a typed `IPRouteFilter` struct (all ten filter
  keys as named fields).
- **`interface.go`**: `InterfaceExistsWithComment`.

### Other fixes bundled in

- **`route.go`**: two call sites updated for the `IPRouteFilter` signature
  change.
- **`net.go`**: `resolveNetwatchHostType(host string)` renamed to
  `resolveNetwatchCommentType(comment string)` and now classifies a
  netwatch probe's domestic/foreign/VPN type by its **comment**
  (`Failover Netwatch - {Domestic Link,Foreign Link,VPN-Client}`) instead
  of its current `host` IP — a probe's host is expected to change (that's
  what `/api/dns/change` and `/api/dns/reset` do to it), so classifying by
  the stable comment instead of the mutable IP is more correct.
- **`vpn.go`**: fixed OpenVPN server cert names
  (`cert-ca-`/`cert-server-`/`cert-client-`) to use `timestamp` directly
  instead of re-deriving from `ovpnServerName`, avoiding a doubled prefix.
- **`l2tp_client.tmpl`** / **`wg_client.tmpl`**: normalized the VPN-client
  netwatch probe's comment to `Failover Netwatch - VPN-Client` (was
  `Failover Netwatch - L2TP-Client` / `Failover Netwatch - wg-client`) so
  it matches the naming convention `/api/dns/reset` and `/api/net/status`
  now depend on; `l2tp_client.tmpl` also gained the matching
  `CheckIP-Route-to-VPN-Client` route, which was missing.