### PR TITLE
feat(fe): pair error reports and reset cards on diagnostics page

### DIFF
--- a/frontend/src/routes/DiagnosticsPage.module.scss
+++ b/frontend/src/routes/DiagnosticsPage.module.scss
@@ -227,18 +227,3 @@
 .actionsSpaced {
   margin-top: var(--space-lg);
 }
-
-.reporting {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-  margin-top: var(--space-lg);
-  padding-top: var(--space-lg);
-  border-top: 1px solid var(--color-border);
-}
-
-.reportingHint {
-  margin: 0;
-  font-size: var(--font-sm);
-  color: var(--color-text-muted);
-}

--- a/frontend/src/routes/DiagnosticsPage.tsx
+++ b/frontend/src/routes/DiagnosticsPage.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Download, FileText, Loader2, MessageCircle, Play, RefreshCw, Wand2 } from 'lucide-react';
+import {
+  Bug,
+  Download,
+  FileText,
+  Loader2,
+  MessageCircle,
+  Play,
+  RefreshCw,
+  Wand2,
+} from 'lucide-react';
 import {
   Button,
   Card,
@@ -9,6 +18,7 @@ import {
   CardTitle,
   ConfirmDialog,
   Inline,
+  SectionGrid,
   Stack,
   Switch,
   useToast,
@@ -297,35 +307,44 @@ export function DiagnosticsPage() {
               )}
             </Button>
           </div>
-          <div className={styles.reporting}>
-            <Switch
-              label="Send error reports"
-              checked={reporting}
-              onChange={(e) => changeReporting(e.currentTarget.checked)}
-            />
-            <p className={styles.reportingHint}>
-              When the panel hits an error, an anonymous report is sent to the Nasnet team so we can
-              fix it. Reports contain the error and the app version, never your router address,
-              credentials, or configuration.
-            </p>
-          </div>
         </Stack>
       </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            <Inline>
-              <Wand2 size={16} aria-hidden /> Reset Configuration
-            </Inline>
-          </CardTitle>
-          <CardDescription>
-            Run the setup wizard again to reset and reconfigure this router from scratch.
-          </CardDescription>
-        </CardHeader>
-        <Button variant="danger" onClick={() => setResetConfirmOpen(true)}>
-          Reset and Reconfigure
-        </Button>
-      </Card>
+      <SectionGrid>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Inline>
+                <Bug size={16} aria-hidden /> Error Reports
+              </Inline>
+            </CardTitle>
+            <CardDescription>
+              Anonymous error reports help the Nasnet team fix bugs, and never include your router
+              address, credentials, or configuration.
+            </CardDescription>
+          </CardHeader>
+          <Switch
+            label="Send error reports"
+            checked={reporting}
+            onChange={(e) => changeReporting(e.currentTarget.checked)}
+          />
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Inline>
+                <Wand2 size={16} aria-hidden /> Reset Configuration
+              </Inline>
+            </CardTitle>
+            <CardDescription>
+              Erase everything currently set up on this router and walk through the setup wizard
+              again from the beginning. This cannot be undone.
+            </CardDescription>
+          </CardHeader>
+          <Button variant="danger" onClick={() => setResetConfirmOpen(true)}>
+            Reset and Reconfigure
+          </Button>
+        </Card>
+      </SectionGrid>
       <ConfirmDialog
         open={resetConfirmOpen}
         title="Reset configuration?"

--- a/frontend/src/ui/primitives/Checkbox.module.scss
+++ b/frontend/src/ui/primitives/Checkbox.module.scss
@@ -42,6 +42,7 @@
 
 .switch {
   appearance: none;
+  margin: 0;
   width: 34px;
   height: 20px;
   border-radius: var(--radius-pill);


### PR DESCRIPTION
<img width="1248" height="369" alt="Screenshot 2026-08-08 at 18 42 37" src="https://github.com/user-attachments/assets/96b8997f-3145-4086-bc3f-b07d89c25189" />


## Summary

- Error reports pulled out of the diagnostics card into its own titled card
- Sits side by side with Reset Configuration in a responsive grid
- Tightened the description copy on both cards
