### PR TITLE
fix(fe): show Plugins in the updates page nav

### DIFF
--- a/frontend/src/layout/RouterTabBar.tsx
+++ b/frontend/src/layout/RouterTabBar.tsx
@@ -1,43 +1,9 @@
 import { useNavigate } from 'react-router-dom';
-import {
-  Activity,
-  Cable,
-  CircleHelp,
-  Globe,
-  LayoutGrid,
-  Network,
-  Shield,
-  Wifi,
-} from 'lucide-react';
-import { Tabs, type TabItem } from '@nasnet/ui';
+import { Tabs } from '@nasnet/ui';
 import { useSession } from '../state/SessionContext';
 import { useRouterStore } from '../state/RouterStoreContext';
+import { ROUTER_SECTIONS } from './routerSections';
 import styles from './RouterTabBar.module.scss';
-
-export const ROUTER_TABS: Array<TabItem & { path: string }> = [
-  { id: 'overview', label: 'Overview', path: '', icon: <LayoutGrid size={16} /> },
-  {
-    id: 'internet',
-    label: 'Internet',
-    path: 'internet',
-    icon: <Globe size={16} />,
-  },
-  { id: 'wan', label: 'WAN', path: 'wan', icon: <Cable size={16} /> },
-  { id: 'lan', label: 'LAN', path: 'lan', icon: <Network size={16} /> },
-  { id: 'wireless', label: 'WIFI', path: 'wireless', icon: <Wifi size={16} /> },
-  { id: 'vpn', label: 'VPN Server', path: 'vpn', icon: <Shield size={16} /> },
-  {
-    id: 'diagnostics',
-    label: 'Diagnostics',
-    path: 'diagnostics',
-    icon: <Activity size={16} />,
-  },
-  { id: 'help', label: 'Help', path: 'help', icon: <CircleHelp size={16} /> },
-  // { id: 'dhcp', label: 'DHCP', path: 'dhcp', icon: <Network size={16} /> },
-  // { id: 'dns', label: 'DNS', path: 'dns', icon: <Globe size={16} /> },
-  // { id: 'firewall', label: 'Firewall', path: 'firewall', icon: <Flame size={16} /> },
-  // { id: 'logs', label: 'Logs', path: 'logs', icon: <ScrollText size={16} /> },
-];
 
 export function RouterTabBar({
   routerId,
@@ -63,10 +29,10 @@ export function RouterTabBar({
     <div className={styles.tabBarBand}>
       <div className={styles.tabBarInner}>
         <Tabs
-          items={ROUTER_TABS}
+          items={ROUTER_SECTIONS}
           activeId={activeId ?? ''}
           onChange={(tabId) => {
-            const item = ROUTER_TABS.find((t) => t.id === tabId);
+            const item = ROUTER_SECTIONS.find((t) => t.id === tabId);
             if (!item) return;
             navigate(`/router/${targetId}${item.path ? `/${item.path}` : ''}`);
           }}


### PR DESCRIPTION
Closes #523

## Summary

- Updates page had its own copy of the router section list that had drifted and was missing Plugins
- now renders the shared section list, so both navs stay in sync
