### PR TITLE
feat(fe): align wizard finalize request body with the router contract

### DIFF
--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -413,7 +413,6 @@ export async function fetchNasnetVpnCredentials(
 }
 
 export interface FinalizeWizardInterface {
-  type: 'ether' | 'wifi';
   interface: string;
   ssid?: string;
   password?: string;
@@ -433,6 +432,7 @@ export interface FinalizeWizardWireGuardClient {
 export interface FinalizeWizardWifiAp {
   ssid: string;
   password: string;
+  split: boolean;
 }
 
 export interface FinalizeWizardOvpnUser {

--- a/frontend/src/routes/easy-config/useEasyConfig.ts
+++ b/frontend/src/routes/easy-config/useEasyConfig.ts
@@ -27,9 +27,9 @@ function wanInterface(
   password: string,
 ): FinalizeWizardInterface {
   if (type === 'wireless') {
-    return { type: 'wifi', interface: name, ssid, password };
+    return { interface: name, ssid, password };
   }
-  return { type: 'ether', interface: name };
+  return { interface: name };
 }
 
 function toDefaultName(name: string, interfaces: InterfaceResponse[]): string {
@@ -73,7 +73,11 @@ function buildFinalizePayload(
   }
 
   if (state.wifiEnabled) {
-    payload.wifiAp = { ssid: state.ssid, password: state.wifiPassword };
+    payload.wifiAp = {
+      ssid: state.ssid,
+      password: state.wifiPassword,
+      split: state.wifiSplit,
+    };
   }
 
   if (state.vpnServerEnabled) {

--- a/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
+++ b/frontend/tests/e2e/28-easy-config-apply-progress.spec.ts
@@ -42,9 +42,14 @@ test.describe('Easy-Mode wizard — apply progress', () => {
     const finalizeRequest = page.waitForRequest('**/api/wizard/finalize');
     await stepToApply(page);
 
-    // the finalize payload uses the RouterOS interface type ("ether"), not the UI label
+    // the router derives the interface type from its default name, so the payload omits it
     const body = (await finalizeRequest).postDataJSON();
-    expect(body.foreign).toMatchObject({ type: 'ether', interface: 'ether1' });
+    expect(body.foreign).toEqual({ interface: 'ether1' });
+    expect(body.wifiAp).toEqual({
+      ssid: 'Progress-Net',
+      password: 'longpassword',
+      split: false,
+    });
 
     const bar = page.getByRole('progressbar', { name: /progress/i });
     await expect(bar).toBeVisible();


### PR DESCRIPTION
Closes #524

- stop sending the WAN interface type, the router derives it from the interface default name
- send the Wi-Fi split-band flag in the AP config so the router applies the user's choice
