### PR TITLE
chore(installer): stamp a build version into the desktop installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+    env:
+      APP_VERSION: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v6
 
@@ -240,6 +242,9 @@ jobs:
       - name: Stage LAN baseline script
         run: cp scripts/nasnet-lan-baseline.rsc graphical-installer/assets/
 
+      - name: Stamp Windows version resource
+        run: scripts/installer-windows-resource.sh "$APP_VERSION" "${{ github.run_number }}"
+
       - name: Build Windows installer
         working-directory: graphical-installer
         run: |
@@ -247,7 +252,7 @@ jobs:
           mkdir -p dist
           GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w -H windowsgui" \
+            -ldflags "-s -w -H windowsgui -X nasnet-panel-installer/internal/buildinfo.Version=$APP_VERSION" \
             -o dist/nasnet-panel-installer-windows-amd64.exe .
           ( cd dist && sha256sum nasnet-panel-installer-windows-amd64.exe > nasnet-panel-installer-windows-amd64.exe.sha256 )
 
@@ -266,6 +271,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      APP_VERSION: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v6
 
@@ -284,18 +291,19 @@ jobs:
           mkdir -p dist
           # Wails v2.13 references UTType without linking its framework
           export CGO_LDFLAGS="-framework UniformTypeIdentifiers"
+          LDFLAGS="-s -w -X nasnet-panel-installer/internal/buildinfo.Version=$APP_VERSION"
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w" -o dist/installer-arm64 .
+            -ldflags "$LDFLAGS" -o dist/installer-arm64 .
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w" -o dist/installer-amd64 .
+            -ldflags "$LDFLAGS" -o dist/installer-amd64 .
           lipo -create -output dist/nasnet-panel-installer dist/installer-arm64 dist/installer-amd64
           APP="dist/Nasnet Panel Installer.app"
           mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
           cp darwin/Info.plist "$APP/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${GITHUB_REF_NAME#v}" \
-            -c "Set :CFBundleVersion ${GITHUB_REF_NAME#v}" "$APP/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${APP_VERSION#v}" \
+            -c "Set :CFBundleVersion ${APP_VERSION#v}" "$APP/Contents/Info.plist"
           cp dist/nasnet-panel-installer "$APP/Contents/MacOS/nasnet-panel-installer"
           ICONSET=dist/appicon.iconset
           mkdir -p "$ICONSET"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -159,8 +159,14 @@ jobs:
           go-version-file: graphical-installer/go.mod
           cache-dependency-path: graphical-installer/go.sum
 
+      - name: Resolve version
+        run: echo "APP_VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
       - name: Stage LAN baseline script
         run: cp scripts/nasnet-lan-baseline.rsc graphical-installer/assets/
+
+      - name: Stamp Windows version resource
+        run: scripts/installer-windows-resource.sh "$APP_VERSION" "${{ github.run_number }}"
 
       - name: Build Windows installer
         working-directory: graphical-installer
@@ -169,7 +175,7 @@ jobs:
           mkdir -p dist
           GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w -H windowsgui" \
+            -ldflags "-s -w -H windowsgui -X nasnet-panel-installer/internal/buildinfo.Version=$APP_VERSION" \
             -o dist/nasnet-panel-installer-windows-amd64.exe .
           ( cd dist && sha256sum nasnet-panel-installer-windows-amd64.exe > nasnet-panel-installer-windows-amd64.exe.sha256 )
 
@@ -195,6 +201,9 @@ jobs:
           go-version-file: graphical-installer/go.mod
           cache-dependency-path: graphical-installer/go.sum
 
+      - name: Resolve version
+        run: echo "APP_VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
       - name: Stage LAN baseline script
         run: cp scripts/nasnet-lan-baseline.rsc graphical-installer/assets/
 
@@ -205,16 +214,19 @@ jobs:
           mkdir -p dist
           # Wails v2.13 references UTType without linking its framework
           export CGO_LDFLAGS="-framework UniformTypeIdentifiers"
+          LDFLAGS="-s -w -X nasnet-panel-installer/internal/buildinfo.Version=$APP_VERSION"
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w" -o dist/installer-arm64 .
+            -ldflags "$LDFLAGS" -o dist/installer-arm64 .
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 \
             go build -trimpath -tags desktop,production \
-            -ldflags "-s -w" -o dist/installer-amd64 .
+            -ldflags "$LDFLAGS" -o dist/installer-amd64 .
           lipo -create -output dist/nasnet-panel-installer dist/installer-arm64 dist/installer-amd64
           APP="dist/Nasnet Panel Installer.app"
           mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
           cp darwin/Info.plist "$APP/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${APP_VERSION#v}" \
+            -c "Set :CFBundleVersion ${APP_VERSION#v}" "$APP/Contents/Info.plist"
           cp dist/nasnet-panel-installer "$APP/Contents/MacOS/nasnet-panel-installer"
           ICONSET=dist/appicon.iconset
           mkdir -p "$ICONSET"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ backend/nasnet-panel-slim
 
 # Generated installer assets (copied from scripts/ at build time)
 graphical-installer/assets/nasnet-lan-baseline.rsc
+graphical-installer/*.syso
 
 # Environment files
 .env

--- a/graphical-installer/README.md
+++ b/graphical-installer/README.md
@@ -54,6 +54,26 @@ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -tags desktop,production \
 Release builds produce a universal binary via `lipo`, wrap it in `Nasnet Panel Installer.app` using
 `darwin/Info.plist`, and package a DMG. See `.github/workflows/release.yml` for the full sequence.
 
+## Versioning
+
+`internal/buildinfo.Version` defaults to `v0.0.0-dev` and is replaced at link time:
+
+```bash
+go build -ldflags "-X nasnet-panel-installer/internal/buildinfo.Version=v1.2.3" .
+```
+
+The UI reads it through `AppVersion` and shows it in the header. CI passes the release tag, or
+`dev-<short sha>` for snapshot builds, and stamps the same value into the macOS bundle
+(`CFBundleShortVersionString`) and the Windows version resource:
+
+```bash
+../scripts/installer-windows-resource.sh v1.2.3 0
+```
+
+That writes `resource_windows_amd64.syso`, which `go build` links into the Windows executable. The
+file is generated and gitignored, so regenerate it whenever you want a local Windows build to carry
+version metadata.
+
 ## Checks
 
 ```bash

--- a/graphical-installer/app.go
+++ b/graphical-installer/app.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"nasnet-panel-installer/internal/buildinfo"
 	"nasnet-panel-installer/internal/install"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -28,6 +29,10 @@ func NewApp() *App {
 
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+}
+
+func (a *App) AppVersion() string {
+	return buildinfo.Version
 }
 
 type ProbeResult struct {

--- a/graphical-installer/frontend/dist/app.js
+++ b/graphical-installer/frontend/dist/app.js
@@ -34,6 +34,13 @@
     App = window.go.main.App;
     bindRuntimeEvents();
     bindUI();
+    showVersion();
+  }
+
+  function showVersion() {
+    App.AppVersion().then(function (v) {
+      $('app-version').textContent = v;
+    });
   }
 
   function bindUI() {

--- a/graphical-installer/frontend/dist/index.html
+++ b/graphical-installer/frontend/dist/index.html
@@ -12,6 +12,7 @@
         <img class="logo" src="logo.png" alt="" />
         <div class="brand">Nasnet Panel</div>
         <div class="subtitle">Installer</div>
+        <div id="app-version" class="app-version"></div>
       </header>
 
       <section id="view-form" class="view">

--- a/graphical-installer/frontend/dist/style.css
+++ b/graphical-installer/frontend/dist/style.css
@@ -86,6 +86,14 @@ header {
   line-height: 1.2;
 }
 
+.app-version {
+  margin-left: auto;
+  align-self: center;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
 .hidden {
   display: none !important;
 }

--- a/graphical-installer/internal/buildinfo/buildinfo.go
+++ b/graphical-installer/internal/buildinfo/buildinfo.go
@@ -1,0 +1,3 @@
+package buildinfo
+
+var Version = "v0.0.0-dev"

--- a/graphical-installer/versioninfo.json
+++ b/graphical-installer/versioninfo.json
@@ -1,0 +1,24 @@
+{
+  "FixedFileInfo": {
+    "FileVersion": { "Major": 0, "Minor": 0, "Patch": 0, "Build": 0 },
+    "ProductVersion": { "Major": 0, "Minor": 0, "Patch": 0, "Build": 0 },
+    "FileFlagsMask": "3f",
+    "FileFlags ": "00",
+    "FileOS": "040004",
+    "FileType": "01",
+    "FileSubType": "00"
+  },
+  "StringFileInfo": {
+    "CompanyName": "Nasnet Community",
+    "FileDescription": "Nasnet Panel Installer",
+    "FileVersion": "0.0.0.0",
+    "InternalName": "nasnet-panel-installer.exe",
+    "LegalCopyright": "Nasnet Community",
+    "OriginalFilename": "nasnet-panel-installer-windows-amd64.exe",
+    "ProductName": "Nasnet Panel Installer",
+    "ProductVersion": "v0.0.0-dev"
+  },
+  "VarFileInfo": {
+    "Translation": { "LangID": "0409", "CharsetID": "04B0" }
+  }
+}

--- a/scripts/installer-windows-resource.sh
+++ b/scripts/installer-windows-resource.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:?usage: installer-windows-resource.sh <version> [build-number]}"
+build="${2:-0}"
+
+numeric="${version#v}"
+numeric="${numeric%%-*}"
+if [[ ! $numeric =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  numeric="0.0.0"
+fi
+IFS=. read -r major minor patch <<<"$numeric"
+
+cd "$(dirname "$0")/../graphical-installer"
+
+go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 \
+  -o resource_windows_amd64.syso \
+  -ver-major "$major" -ver-minor "$minor" -ver-patch "$patch" -ver-build "$build" \
+  -product-ver-major "$major" -product-ver-minor "$minor" -product-ver-patch "$patch" \
+  -product-ver-build "$build" \
+  -file-version "$numeric.$build" \
+  -product-version "$version" \
+  versioninfo.json


### PR DESCRIPTION
Closes #546

- inject the release tag (or dev-<short sha> for snapshots) into the installer at build time
- stamp it into the macOS bundle and the Windows version resource so file properties show a real version
- show the version in the installer header