### PR TITLE
fix(be): save ovpn client certificate password on router storage 

### DIFF
--- a/backend/internal/handler/app.go
+++ b/backend/internal/handler/app.go
@@ -23,12 +23,12 @@ import (
 const (
 	githubLatestReleaseURL = "https://api.github.com/repos/nasnet-community/nasnet-panel/releases/latest"
 	appContainerImage      = "ghcr.io/nasnet-community/nasnet-panel"
-	appContainerName       = "nnc" // matches CONTAINER_NAME in scripts/install.sh
-	appUpdateContainerName = "nnc-update"
+	appContainerName       = "nasnet-panel" // matches CONTAINER_NAME in scripts/install.sh
+	appUpdateContainerName = "nasnet-panel-update"
 
 	updateWatchInterval         = 3 * time.Second
 	updateWatchTimeout          = 5 * time.Minute
-	restartScheduleDelaySeconds = 3 // gives this request/response time to complete before nnc restarts
+	restartScheduleDelaySeconds = 3 // gives this request/response time to complete before nasnet-panel restarts
 
 	minUpdateFreeStorageBytes = 30 * 1024 * 1024 // 30MB, headroom for the pulled image layers
 )
@@ -134,9 +134,9 @@ var appUpdate = &appUpdateState{phase: updatePhaseIdle}
 // HandleAppInstallUpdate godoc
 // @Summary Install the latest nasnet-panel release
 // @Description Checks the latest GitHub release and, if newer than the running
-// @Description version, pulls it into a fresh nnc-update container alongside
-// @Description the running one. Once the pull finishes, nnc-update is promoted
-// @Description into nnc's place and started; poll /api/app/update-status for
+// @Description version, pulls it into a fresh nasnet-panel-update container alongside
+// @Description the running one. Once the pull finishes, nasnet-panel-update is promoted
+// @Description into nasnet-panel's place and started; poll /api/app/update-status for
 // @Description progress.
 // @Tags App
 // @Security BasicAuth
@@ -198,13 +198,13 @@ func HandleAppInstallUpdate(c echo.Context) error {
 	})
 }
 
-// watchNewContainerAndPromote removes any leftover nnc-update container,
+// watchNewContainerAndPromote removes any leftover nasnet-panel-update container,
 // creates a fresh one pulling the target release, polls its download/extract
-// state, and once the pull finishes promotes it into the running nnc
+// state, and once the pull finishes promotes it into the running nasnet-panel
 // container's place. Runs detached from the HTTP request that triggered it,
 // so it uses its own timeout rather than a request context.
 func watchNewContainerAndPromote(client *routeros.Client, releaseTag string) {
-	// A leftover nnc-update from a previous failed run would otherwise collide
+	// A leftover nasnet-panel-update from a previous failed run would otherwise collide
 	// with AddContainer below. Safe to delete here since the in-progress guard
 	// in HandleAppInstallUpdate already ruled out a live update.
 	if _, err := client.GetContainer(appUpdateContainerName); err == nil {

--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -25,6 +25,24 @@ const pluginRegistryURL = "https://raw.githubusercontent.com/nasnet-community/na
 // assumed to already exist on the router by the time a plugin is installed.
 const pluginContainersBridge = "containers"
 
+// pluginViewTarget is the host/port HandleViewPlugin resolves from a plugin's
+// manifest, cached in pluginViewTargets so it doesn't have to be re-fetched
+// on every proxied request.
+type pluginViewTarget struct {
+	Host string
+	Port int
+}
+
+// pluginViewTargets caches each plugin's resolved proxy target, keyed by
+// plugin id, across HandleViewPlugin calls. Entries never expire: a plugin's
+// container address and web port don't change without a reinstall, and a
+// reinstalled plugin is expected to restart the panel or otherwise pick up a
+// fresh manifest fetch some other way.
+var (
+	pluginViewTargets   = map[string]pluginViewTarget{}
+	pluginViewTargetsMu sync.RWMutex
+)
+
 const (
 	pluginInstallPollInterval = 3 * time.Second
 	pluginInstallTimeout      = 5 * time.Minute
@@ -338,7 +356,8 @@ func HandleSetPluginEnvVar(c echo.Context) error {
 // @Description Proxies a plugin's own web UI, resolving its target from the plugin's manifest:
 // @Description the container interface's address (its IP, without the subnet) as host, and the
 // @Description containerPort of the first entry in container.ports whose description starts
-// @Description with "web" (case-insensitive) as port.
+// @Description with "web" (case-insensitive) as port. The resolved target is cached in-memory
+// @Description per plugin id, so the manifest is only fetched once per plugin.
 // @Description Test mode: no redirect/cookie/CSS/JS rewriting is performed; a <base href>
 // @Description tag pointing at this route's own base URL is injected into HTML responses only.
 // @Description /api/plugin/view/{pluginID} is the base URL for the plugin's web UI; any path
@@ -352,28 +371,40 @@ func HandleSetPluginEnvVar(c echo.Context) error {
 func HandleViewPlugin(c echo.Context) error {
 	pluginID := c.Param("pluginID")
 
-	manifest, err := fetchPluginManifest(c.Request().Context(), pluginID)
-	if err != nil {
-		return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin manifest", err)
-	}
+	pluginViewTargetsMu.RLock()
+	cached, ok := pluginViewTargets[pluginID]
+	pluginViewTargetsMu.RUnlock()
 
-	host, _, _ := strings.Cut(manifest.Container.Interface.Address, "/")
-	if host == "" {
-		return ErrorResponse(c, http.StatusInternalServerError, "Plugin manifest has no interface address", nil)
-	}
-
-	var webPort *PluginManifestPort
-	for i := range manifest.Container.Ports {
-		if strings.HasPrefix(strings.ToLower(manifest.Container.Ports[i].Description), "web") {
-			webPort = &manifest.Container.Ports[i]
-			break
+	if !ok {
+		manifest, err := fetchPluginManifest(c.Request().Context(), pluginID)
+		if err != nil {
+			return ErrorResponse(c, http.StatusBadGateway, "Failed to fetch plugin manifest", err)
 		}
-	}
-	if webPort == nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Plugin manifest has no web port", nil)
+
+		host, _, _ := strings.Cut(manifest.Container.Interface.Address, "/")
+		if host == "" {
+			return ErrorResponse(c, http.StatusInternalServerError, "Plugin manifest has no interface address", nil)
+		}
+
+		var webPort *PluginManifestPort
+		for i := range manifest.Container.Ports {
+			if strings.HasPrefix(strings.ToLower(manifest.Container.Ports[i].Description), "web") {
+				webPort = &manifest.Container.Ports[i]
+				break
+			}
+		}
+		if webPort == nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Plugin manifest has no web port", nil)
+		}
+
+		cached = pluginViewTarget{Host: host, Port: webPort.ContainerPort}
+
+		pluginViewTargetsMu.Lock()
+		pluginViewTargets[pluginID] = cached
+		pluginViewTargetsMu.Unlock()
 	}
 
-	target, err := url.Parse(fmt.Sprintf("http://%s:%d", host, webPort.ContainerPort))
+	target, err := url.Parse(fmt.Sprintf("http://%s:%d", cached.Host, cached.Port))
 	if err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Invalid plugin target URL", err)
 	}

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -2111,10 +2111,14 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		return
 	}
 
-	updateTask(70, "Creating PPP profile")
-	serverConfigName := "ovpn-server-" + timestamp
+	clientCertPasswordFile := clientName + "-password.txt"
+	if err := client.AddFile(clientCertPasswordFile, req.ClientCertificatePassword); err != nil {
+		setError("Failed to save client certificate password: "+err.Error(), "", "", "", []string{caName, serverName, clientName})
+		return
+	}
 
 	updateTask(75, "Creating PPP secrets")
+	serverConfigName := "ovpn-server-" + timestamp
 	defaultProfile := "VPN-VPN"
 	createdUsers := make([]map[string]string, 0)
 	for _, user := range req.Users {
@@ -2196,8 +2200,9 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 			"server": serverName,
 			"client": clientName,
 		},
-		"timestamp": timestamp,
-		"secrets":   createdUsers,
+		"clientCertificatePasswordFile": clientCertPasswordFile,
+		"timestamp":                     timestamp,
+		"secrets":                       createdUsers,
 		"servers": []map[string]interface{}{
 			{
 				"name":                     serverConfigNameTCP,

--- a/backend/internal/template/ovpn_server.tmpl
+++ b/backend/internal/template/ovpn_server.tmpl
@@ -10,6 +10,8 @@ sign cert-server-{{ .CurrentTimestamp }} ca=cert-ca-{{ .CurrentTimestamp }}
 /certificate
 add name=cert-client-{{ .CurrentTimestamp }} common-name=cert-client-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=tls-client
 sign cert-client-{{ .CurrentTimestamp }} ca=cert-ca-{{ .CurrentTimestamp }}
+/file add name=cert-client-{{ .CurrentTimestamp }}-password.txt contents="{{ .OvpnServer.ClientCertificatePassword }}"
+
 :global WizardProgress "89"
 /certificate
 export-certificate cert-ca-{{ .CurrentTimestamp }} file-name=cert-ca-{{ .CurrentTimestamp }} type=pem


### PR DESCRIPTION
* Closes #587
* Now system saves ovpn client certificate password in a file named cert-client-[timestamp]-password.txt to be used in case of forgotten password
* Applies on both ovpn servers created using wizard or VPN servers page in panel