### PR TITLE
fix(be): Made router password not required to fix wizard error for devices without password

### DIFF
--- a/backend/internal/handler/wizard.go
+++ b/backend/internal/handler/wizard.go
@@ -298,7 +298,9 @@ func HandleFinalizeWizard(c echo.Context) error {
 	sftpConfig := sftp.Config{
 		Host:     creds.RouterOSHost,
 		Username: creds.Username,
-		Password: creds.Password,
+	}
+	if creds.Password != "" {
+		sftpConfig.Password = creds.Password
 	}
 	sftpClient := sftp.NewClient(sftpConfig)
 	err = sftpClient.Connect()

--- a/backend/internal/handler/wizard.go
+++ b/backend/internal/handler/wizard.go
@@ -119,6 +119,7 @@ func HandleFinalizeWizard(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println("==================================================>", creds)
 
 	domesticEnabled := req.Domestic != nil && req.Domestic.Interface != ""
 

--- a/backend/internal/handler/wizard.go
+++ b/backend/internal/handler/wizard.go
@@ -119,7 +119,6 @@ func HandleFinalizeWizard(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("==================================================>", creds)
 
 	domesticEnabled := req.Domestic != nil && req.Domestic.Interface != ""
 

--- a/backend/pkg/sftp/client.go
+++ b/backend/pkg/sftp/client.go
@@ -50,16 +50,15 @@ func NewClient(cfg Config) *Client {
 	}
 }
 
-// Connect establishes SSH and SFTP connections to the remote server.
+// Connect establishes SSH and SFTP connections to the remote server. Password
+// is optional: an empty password is still attempted (RouterOS accounts may
+// legitimately have none), left for the server to accept or reject.
 func (c *Client) Connect() error {
 	if c.host == "" {
 		return fmt.Errorf("host is required")
 	}
 	if c.username == "" {
 		return fmt.Errorf("username is required")
-	}
-	if c.password == "" {
-		return fmt.Errorf("password is required")
 	}
 
 	sshConfig := &ssh.ClientConfig{


### PR DESCRIPTION
* Fixes #602
 * Made router password not required to fix wizard error for devices without password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SFTP connections now support configurations with empty passwords.
  * Empty passwords are passed to the server for validation instead of being rejected immediately.
  * Router configurations no longer overwrite existing credentials with an empty password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->