### PR TITLE
fix(fe): overview VPN clients View button links to WAN page

### DIFF
--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -576,7 +576,7 @@ export function OverviewTab() {
                 </div>
                 VPN Clients
               </div>
-              <Button variant="secondary" size="sm" onClick={() => navigate(`/router/${id}/vpn`)}>
+              <Button variant="secondary" size="sm" onClick={() => navigate(`/router/${id}/wan`)}>
                 View
               </Button>
             </div>


### PR DESCRIPTION
Closes #603

- VPN clients View button on the overview opened the VPN servers page
- now opens the WAN page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the VPN Clients card’s **View** button to open the router’s WAN page instead of the VPN page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->