### PR TITLE
feat(installer): restart prompts, optional password, RouterOS update and cleanup

### DIFF
--- a/graphical-installer/README.md
+++ b/graphical-installer/README.md
@@ -10,13 +10,14 @@ The engine (`internal/install/engine.go`) runs these in order, with rollback on 
 
 1. Connect to router
 2. Check system
-3. Enable container device-mode
-4. Download image
-5. Upload to router
-6. Configure network
-7. Deploy container
-8. Start and health check
-9. LAN baseline
+3. Update RouterOS, when the router runs below the required version
+4. Enable container device-mode
+5. Download image
+6. Upload to router
+7. Configure network
+8. Deploy container
+9. Start and health check
+10. LAN baseline
 
 Uninstall reverses the container, network config, and uploaded files.
 

--- a/graphical-installer/app.go
+++ b/graphical-installer/app.go
@@ -89,8 +89,8 @@ func (a *App) start(opts install.Options, uninstall bool) error {
 	if a.running {
 		return errors.New("an operation is already running")
 	}
-	if opts.Host == "" || opts.Password == "" {
-		return errors.New("router IP and password are required")
+	if opts.Host == "" {
+		return errors.New("router IP is required")
 	}
 	ctx, cancel := context.WithCancel(a.ctx)
 	a.running = true
@@ -145,6 +145,9 @@ func (a *App) events(ctx context.Context) install.Events {
 		DeviceModeTick: func(remaining int, routerState string) {
 			runtime.EventsEmit(a.ctx, "install:device-mode-tick", map[string]any{"remaining": remaining, "state": routerState})
 		},
+		DeviceModeDone: func() {
+			runtime.EventsEmit(a.ctx, "install:device-mode-done", nil)
+		},
 		StoragePrompt: func(choices []install.StorageChoice) string {
 			runtime.EventsEmit(a.ctx, "install:storage", map[string]any{"choices": choices})
 			select {
@@ -168,6 +171,9 @@ func (a *App) events(ctx context.Context) install.Events {
 		},
 		RebootTick: func(elapsed int, routerState string) {
 			runtime.EventsEmit(a.ctx, "install:reboot-tick", map[string]any{"elapsed": elapsed, "state": routerState})
+		},
+		RebootDone: func() {
+			runtime.EventsEmit(a.ctx, "install:reboot-done", nil)
 		},
 		Done: func(urls []string, note string) {
 			runtime.EventsEmit(a.ctx, "install:done", map[string]any{"urls": urls, "note": note})

--- a/graphical-installer/frontend/dist/app.js
+++ b/graphical-installer/frontend/dist/app.js
@@ -2,6 +2,11 @@
   'use strict';
 
   var PANEL_READY_DELAY_MS = 3000;
+  var DEVICE_LEAD_ASK = 'After you press Proceed, within 120 seconds do one of the following:';
+  var DEVICE_LEAD_WAIT = 'Within 120 seconds do one of the following:';
+  var REBOOT_LEAD_ASK = 'Use the MODE button while the router is powered on:';
+  var REBOOT_LEAD_WAIT =
+    'If the router does not come back on its own, restart it with the MODE button while it is powered on:';
 
   var App = null;
   var tarPath = '';
@@ -42,6 +47,26 @@
     $(prefix + '-button-caption').textContent = ax2
       ? 'hAP ax2, MODE button on top of the case'
       : 'hAP ax3, MODE button on the front panel next to the USB port';
+  }
+
+  function setDeviceWaiting(waiting) {
+    $('device-lead').textContent = waiting ? DEVICE_LEAD_WAIT : DEVICE_LEAD_ASK;
+    $('device-wait').classList.toggle('hidden', !waiting);
+    $('device-actions').classList.toggle('hidden', waiting);
+  }
+
+  function setRebootWaiting(waiting) {
+    $('reboot-lead').textContent = waiting ? REBOOT_LEAD_WAIT : REBOOT_LEAD_ASK;
+    $('reboot-ask').classList.toggle('hidden', waiting);
+    $('reboot-wait').classList.toggle('hidden', !waiting);
+    $('reboot-actions').classList.toggle('hidden', waiting);
+  }
+
+  function hideModals() {
+    hide('modal-device');
+    hide('modal-reboot');
+    hide('modal-storage');
+    stopRebootTimer();
   }
 
   function startRebootTimer() {
@@ -109,8 +134,7 @@
     $('btn-back').addEventListener('click', backToForm);
     $('btn-again').addEventListener('click', backToForm);
     $('btn-device-ok').addEventListener('click', function () {
-      hide('device-ask');
-      show('device-wait');
+      setDeviceWaiting(true);
       App.ConfirmDeviceMode(true);
     });
     $('btn-device-no').addEventListener('click', function () {
@@ -127,8 +151,7 @@
       App.ConfirmStorage('');
     });
     $('btn-reboot-ok').addEventListener('click', function () {
-      hide('reboot-ask');
-      show('reboot-wait');
+      setRebootWaiting(true);
       startRebootTimer();
       App.ConfirmReboot(true);
     });
@@ -189,14 +212,9 @@
 
   function startFlow(uninstall) {
     var host = val('host');
-    var password = $('password').value;
     showFormError('');
     if (!host) {
       showFormError('Router IP is required.');
-      return;
-    }
-    if (!password) {
-      showFormError('Router password is required.');
       return;
     }
     var source = document.querySelector('input[name="source"]:checked').value;
@@ -281,10 +299,7 @@
     clearTimeout(panelReadyTimer);
     setFormBusy(false);
     hide('view-run');
-    hide('modal-device');
-    hide('modal-reboot');
-    hide('modal-storage');
-    stopRebootTimer();
+    hideModals();
     show('view-form');
   }
 
@@ -305,13 +320,8 @@
     if (status === 'success' || status === 'failed' || status === 'skipped') {
       li.querySelector('.step-bar').classList.add('hidden');
     }
-    if (id === 'device-mode' && status !== 'running') {
-      hide('modal-device');
-    }
-    if (id === 'check' && status !== 'running') {
-      hide('modal-reboot');
-      hide('modal-storage');
-      stopRebootTimer();
+    if (status !== 'running') {
+      hideModals();
     }
   }
 
@@ -320,10 +330,7 @@
     show('run-error');
     hide('btn-cancel');
     show('btn-back');
-    hide('modal-device');
-    hide('modal-reboot');
-    hide('modal-storage');
-    stopRebootTimer();
+    hideModals();
   }
 
   function appendLog(line) {
@@ -381,9 +388,12 @@
 
     window.runtime.EventsOn('install:device-mode', function () {
       applyButtonImage('device');
-      show('device-ask');
-      hide('device-wait');
+      setDeviceWaiting(false);
       show('modal-device');
+    });
+
+    window.runtime.EventsOn('install:device-mode-done', function () {
+      hide('modal-device');
     });
 
     window.runtime.EventsOn('install:device-mode-tick', function (data) {
@@ -396,8 +406,7 @@
         $('reboot-reason').textContent = data.reason;
       }
       applyButtonImage('reboot');
-      show('reboot-ask');
-      hide('reboot-wait');
+      setRebootWaiting(false);
       show('modal-reboot');
     });
 
@@ -427,10 +436,15 @@
       if (data && data.reason) {
         $('reboot-reason').textContent = data.reason;
       }
-      hide('reboot-ask');
-      show('reboot-wait');
+      applyButtonImage('reboot');
+      setRebootWaiting(true);
       show('modal-reboot');
       startRebootTimer();
+    });
+
+    window.runtime.EventsOn('install:reboot-done', function () {
+      hide('modal-reboot');
+      stopRebootTimer();
     });
 
     window.runtime.EventsOn('install:reboot-tick', function (data) {
@@ -442,9 +456,7 @@
     window.runtime.EventsOn('install:done', function (data) {
       running = false;
       hide('btn-cancel');
-      hide('modal-device');
-      hide('modal-reboot');
-      stopRebootTimer();
+      hideModals();
       $('done-note').textContent = data.note || '';
       var urlsEl = $('done-urls');
       urlsEl.innerHTML = '';

--- a/graphical-installer/frontend/dist/index.html
+++ b/graphical-installer/frontend/dist/index.html
@@ -213,28 +213,22 @@
       <div id="modal-device" class="modal hidden">
         <div class="modal-box">
           <h3>Physical confirmation required</h3>
-          <div id="device-ask">
-            <p>RouterOS requires physical confirmation to enable container mode.</p>
-            <p>After you press Proceed, within 120 seconds do one of the following:</p>
-            <ol>
-              <li>
-                If your router has a reset/mode button: press it briefly while the router is powered
-                on.
-              </li>
-              <li>
-                If your router has no button (x86 / CHR): perform a cold power-cycle (unplug power,
-                plug back in).
-              </li>
-            </ol>
-            <figure class="figure">
-              <img id="device-button-img" src="hap_ax3_button.jpg" alt="" />
-              <figcaption id="device-button-caption"></figcaption>
-            </figure>
-            <div class="actions">
-              <button id="btn-device-ok" class="primary">Proceed</button>
-              <button id="btn-device-no">Abort</button>
-            </div>
-          </div>
+          <p>RouterOS requires physical confirmation to enable container mode.</p>
+          <p id="device-lead">After you press Proceed, within 120 seconds do one of the following:</p>
+          <ol>
+            <li>
+              If your router has a reset/mode button: press it briefly while the router is powered
+              on.
+            </li>
+            <li>
+              If your router has no button (x86 / CHR): perform a cold power-cycle (unplug power,
+              plug back in).
+            </li>
+          </ol>
+          <figure class="figure">
+            <img id="device-button-img" src="hap_ax3_button.jpg" alt="" />
+            <figcaption id="device-button-caption"></figcaption>
+          </figure>
           <div id="device-wait" class="hidden">
             <p><span class="spinner"></span> Waiting for physical confirmation...</p>
             <p class="mono">
@@ -242,32 +236,22 @@
               <span id="device-state">online</span>
             </p>
           </div>
+          <div id="device-actions" class="actions">
+            <button id="btn-device-ok" class="primary">Proceed</button>
+            <button id="btn-device-no">Abort</button>
+          </div>
         </div>
       </div>
 
       <div id="modal-reboot" class="modal hidden">
         <div class="modal-box">
           <h3>Router restart required</h3>
+          <p id="reboot-reason">
+            The container package is now enabled, and the router has to restart before it can run
+            containers.
+          </p>
           <div id="reboot-ask">
-            <p id="reboot-reason">
-              The container package is now enabled, and the router has to restart before it can run
-              containers.
-            </p>
             <p>Restart the router yourself, then confirm below.</p>
-            <p>Use the MODE button while the router is powered on:</p>
-            <figure class="figure">
-              <img id="reboot-button-img" src="hap_ax3_button.jpg" alt="" />
-              <figcaption id="reboot-button-caption"></figcaption>
-            </figure>
-            <p>
-              On other models, use System &gt; Reboot in Winbox or WebFig, or unplug the power and
-              plug it back in.
-            </p>
-            <p>The installer waits for the router to come back and carries on by itself.</p>
-            <div class="actions">
-              <button id="btn-reboot-ok" class="primary">I restarted the router</button>
-              <button id="btn-reboot-no">Abort</button>
-            </div>
           </div>
           <div id="reboot-wait" class="hidden">
             <p><span class="spinner"></span> Waiting for the router to come back...</p>
@@ -275,6 +259,20 @@
               <span id="reboot-elapsed">0</span>s elapsed, router is
               <span id="reboot-state">restarting</span>
             </p>
+          </div>
+          <p id="reboot-lead">Use the MODE button while the router is powered on:</p>
+          <figure class="figure">
+            <img id="reboot-button-img" src="hap_ax3_button.jpg" alt="" />
+            <figcaption id="reboot-button-caption"></figcaption>
+          </figure>
+          <p>
+            On other models, use System &gt; Reboot in Winbox or WebFig, or unplug the power and
+            plug it back in.
+          </p>
+          <p>The installer waits for the router to come back and carries on by itself.</p>
+          <div id="reboot-actions" class="actions">
+            <button id="btn-reboot-ok" class="primary">I restarted the router</button>
+            <button id="btn-reboot-no">Abort</button>
           </div>
         </div>
       </div>

--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -43,6 +43,7 @@ const (
 	minROSMajor       = 7
 	minROSMinor       = 24
 	deviceModeTimeout = 120 * time.Second
+	updateTimeout     = 10 * time.Minute
 	startTimeout      = 120 * time.Second
 	baselineTimeout   = 30 * time.Second
 	rebootSettle      = 15 * time.Second
@@ -90,10 +91,12 @@ type Events struct {
 	SysInfo          func(info SystemInfo)
 	DeviceModePrompt func() bool
 	DeviceModeTick   func(remaining int, routerState string)
+	DeviceModeDone   func()
 	RebootNotice     func(reason string)
 	StoragePrompt    func(choices []StorageChoice) string
 	RebootPrompt     func(reason string) bool
 	RebootTick       func(elapsed int, routerState string)
+	RebootDone       func()
 	Done             func(urls []string, note string)
 }
 
@@ -144,6 +147,7 @@ func InstallStepList() []StepInfo {
 	return []StepInfo{
 		{ID: "connect", Title: "Connect to router"},
 		{ID: "check", Title: "Check system"},
+		{ID: "update-ros", Title: "Update RouterOS"},
 		{ID: "device-mode", Title: "Enable container support"},
 		{ID: "download", Title: "Download image"},
 		{ID: "upload", Title: "Upload to router"},
@@ -167,6 +171,7 @@ func (e *Engine) Run() error {
 	steps := []step{
 		{"connect", e.stepConnect},
 		{"check", e.stepCheck},
+		{"update-ros", e.stepUpdateROS},
 		{"device-mode", e.stepDeviceMode},
 		{"download", e.stepDownload},
 		{"upload", e.stepUpload},
@@ -180,6 +185,7 @@ func (e *Engine) Run() error {
 		e.doRollback()
 	}
 	if err == nil {
+		e.removeContainerFiles(false)
 		e.finish()
 	}
 	if e.cl != nil {
@@ -300,6 +306,27 @@ func (e *Engine) removeObj(label, path, selector string) {
 		return
 	}
 	_, _ = e.cl.RunRaw(fmt.Sprintf("%s/remove [find %s]", path, selector), 15*time.Second)
+}
+
+func (e *Engine) removeContainerFiles(includeImageDir bool) {
+	if e.opts.DryRun {
+		e.log("[dry-run] would remove leftover %s-*.tar files from the router", assetPrefix)
+		return
+	}
+	e.log("removing leftover %s-*.tar files from the router", assetPrefix)
+	_, _ = e.cl.RunRaw(fmt.Sprintf(`/file/remove [find where name~"(^|/)%s-[^/]*\.tar$"]`, assetPrefix), 30*time.Second)
+	if !includeImageDir {
+		return
+	}
+	if e.exists("/container", "name="+containerName) || e.exists("/container", "name="+legacyContainerName) {
+		return
+	}
+	dir := e.storage.path(containerImagesDir)
+	if !e.exists("/file", fmt.Sprintf("name=%q", dir)) {
+		return
+	}
+	e.log("removing the stale container image directory %s", dir)
+	_, _ = e.cl.RunRaw(fmt.Sprintf("/file/remove [find name=%q]", dir), 60*time.Second)
 }
 
 func (e *Engine) removeRemoteFile(name string) {

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -906,7 +906,11 @@ func (e *Engine) stepBaseline() error {
 		e.removeRemoteFile(lanBaselineRsc)
 		return nil
 	}
-	if !e.baselineTookEffect() {
+	applied, err := e.baselineTookEffect()
+	if err != nil {
+		return err
+	}
+	if !applied {
 		e.log("LAN baseline did not move the LAN to %s, the panel stays on %s", lanBridgeIP, e.opts.Host)
 		e.note = "not applied, panel stays on the router address"
 		return nil
@@ -916,12 +920,12 @@ func (e *Engine) stepBaseline() error {
 	return nil
 }
 
-func (e *Engine) baselineTookEffect() bool {
+func (e *Engine) baselineTookEffect() (bool, error) {
 	deadline := time.Now().Add(baselineTimeout)
 	unreachable := false
 	for time.Now().Before(deadline) {
 		if err := e.sleep(3 * time.Second); err != nil {
-			return true
+			return false, err
 		}
 		if _, err := e.cl.RunRaw(":put ok", 8*time.Second); err != nil {
 			if rerr := e.cl.Reconnect(); rerr != nil {
@@ -931,20 +935,20 @@ func (e *Engine) baselineTookEffect() bool {
 		}
 		unreachable = false
 		if e.baselineLANReady() {
-			return true
+			return true, nil
 		}
 	}
 	if unreachable {
 		e.log("router no longer answers on %s, the new LAN is taking over", e.opts.Host)
-		return true
+		return true, nil
 	}
-	if e.exists("/ip/address", fmt.Sprintf("address~%q", "^"+lanBridgeIP)) {
+	if e.exists("/ip/address", fmt.Sprintf("address~%q interface=%q", "^"+lanBridgeIP, lanBridge)) {
 		e.log("%s is up but has no member ports, the LAN did not move", lanBridge)
 	}
-	return false
+	return false, nil
 }
 
 func (e *Engine) baselineLANReady() bool {
-	return e.exists("/ip/address", fmt.Sprintf("address~%q", "^"+lanBridgeIP)) &&
+	return e.exists("/ip/address", fmt.Sprintf("address~%q interface=%q", "^"+lanBridgeIP, lanBridge)) &&
 		e.exists("/interface/bridge/port", fmt.Sprintf("bridge=%q", lanBridge))
 }

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -60,7 +60,7 @@ func (e *Engine) stepCheck() error {
 		return err
 	}
 	if versionBelow(e.sys.Version, minROSMajor, minROSMinor) {
-		return fmt.Errorf("RouterOS %s is too old, %d.%d or newer is required. Update the router (System > Packages > Check For Updates), then run the installer again", e.sys.Version, minROSMajor, minROSMinor)
+		e.log("RouterOS %s is below %d.%d, the installer updates the router first", e.sys.Version, minROSMajor, minROSMinor)
 	}
 	if e.sys.FreeMB < minFreeMB {
 		return fmt.Errorf("free memory %d MB below threshold %d MB", e.sys.FreeMB, minFreeMB)
@@ -84,8 +84,134 @@ func (e *Engine) stepCheck() error {
 	if err := e.verifyStorageWritable(st); err != nil {
 		return err
 	}
+	e.removeContainerFiles(true)
 
 	e.note = fmt.Sprintf("%s, RouterOS %s, %d MB free, storage %s", e.sys.Arch, e.sys.Version, e.sys.FreeMB, st.label())
+	return nil
+}
+
+func (e *Engine) stepUpdateROS() error {
+	if !versionBelow(e.sys.Version, minROSMajor, minROSMinor) {
+		e.note = "RouterOS " + e.sys.Version
+		return errSkipped
+	}
+	if e.opts.DryRun {
+		e.log("[dry-run] check for updates, download RouterOS, then restart the router")
+		e.note = "dry-run, not updated"
+		return errSkipped
+	}
+
+	e.log("RouterOS %s is below %d.%d, checking the router update channel", e.sys.Version, minROSMajor, minROSMinor)
+	latest, channel, err := e.availableROSUpdate()
+	if err != nil {
+		return err
+	}
+	if versionBelow(latest, minROSMajor, minROSMinor) {
+		return fmt.Errorf("the router is on the %s update channel, which only offers RouterOS %s, and %d.%d or newer is required. The installer cannot go forward. Switch the router to a channel that carries %d.%d under System > Packages > Check For Updates, update it, then run the installer again",
+			channel, latest, minROSMajor, minROSMinor, minROSMajor, minROSMinor)
+	}
+
+	e.log("downloading RouterOS %s from the %s channel", latest, channel)
+	if out, err := e.cl.RunChecked("/system/package/update/download", 60*time.Second); err != nil {
+		return fmt.Errorf("could not start the RouterOS download: %w (%s)", err, strings.TrimSpace(out))
+	}
+	if err := e.waitForUpdateDownload(); err != nil {
+		return err
+	}
+
+	if !e.ev.RebootPrompt(fmt.Sprintf("RouterOS %s has been downloaded, and the router has to restart to install it.", latest)) {
+		return errors.New("router restart declined by user")
+	}
+	if err := e.waitForReboot(); err != nil {
+		return err
+	}
+	if err := e.refreshVersion(); err != nil {
+		return err
+	}
+	if versionBelow(e.sys.Version, minROSMajor, minROSMinor) {
+		return fmt.Errorf("the router restarted but still runs RouterOS %s, and %d.%d or newer is required. Update it from System > Packages in WebFig or Winbox, then run the installer again", e.sys.Version, minROSMajor, minROSMinor)
+	}
+	e.note = "updated to RouterOS " + e.sys.Version
+	return nil
+}
+
+func (e *Engine) availableROSUpdate() (string, string, error) {
+	if _, err := e.cl.RunChecked("/system/package/update/check-for-updates", 90*time.Second); err != nil {
+		return "", "", fmt.Errorf("could not reach the MikroTik update server: %w. Check the router internet connection and DNS, then run the installer again", err)
+	}
+	var latest, channel string
+	deadline := time.Now().Add(30 * time.Second)
+	for latest == "" && time.Now().Before(deadline) {
+		out, err := e.cl.RunRaw(`:put ("C=" . [/system/package/update/get channel]); :put ("L=" . [/system/package/update/get latest-version])`, 30*time.Second)
+		if err != nil {
+			return "", "", fmt.Errorf("could not read /system/package/update: %w", err)
+		}
+		for _, line := range strings.Split(out, "\n") {
+			key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+			if !ok {
+				continue
+			}
+			switch key {
+			case "C":
+				channel = strings.TrimSpace(value)
+			case "L":
+				latest = strings.TrimSpace(value)
+			}
+		}
+		if latest == "" {
+			if err := e.sleep(3 * time.Second); err != nil {
+				return "", "", err
+			}
+		}
+	}
+	if latest == "" {
+		return "", "", errors.New("the router did not report an available RouterOS version. Check its internet connection and DNS, then run the installer again")
+	}
+	if channel == "" {
+		channel = "current"
+	}
+	return latest, channel, nil
+}
+
+func (e *Engine) waitForUpdateDownload() error {
+	deadline := time.Now().Add(updateTimeout)
+	last := ""
+	for time.Now().Before(deadline) {
+		if err := e.sleep(5 * time.Second); err != nil {
+			return err
+		}
+		out, err := e.cl.RunRaw(":put [/system/package/update/get status]", 15*time.Second)
+		if err != nil {
+			continue
+		}
+		status := strings.TrimSpace(out)
+		if status != "" && status != last {
+			e.log("update status: %s", status)
+			last = status
+		}
+		lower := strings.ToLower(status)
+		switch {
+		case strings.Contains(lower, "reboot"), strings.Contains(lower, "downloaded"):
+			return nil
+		case strings.Contains(lower, "error"), strings.Contains(lower, "fail"):
+			return fmt.Errorf("the RouterOS download failed: %s", status)
+		}
+	}
+	return fmt.Errorf("the RouterOS update did not finish downloading within %s", updateTimeout)
+}
+
+func (e *Engine) refreshVersion() error {
+	out, err := e.cl.RunRaw(":put [/system/resource/get version]", 20*time.Second)
+	if err != nil {
+		return fmt.Errorf("could not read the RouterOS version after the restart: %w", err)
+	}
+	version := strings.TrimSpace(out)
+	if version == "" {
+		return errors.New("the router did not report its RouterOS version after the restart")
+	}
+	e.sys.Version = version
+	e.ev.SysInfo(e.sys)
+	e.log("router is running RouterOS %s", version)
 	return nil
 }
 
@@ -106,13 +232,13 @@ func (e *Engine) installContainerPackage() error {
 	}
 	local := filepath.Join(outDir, name)
 	e.log("downloading %s", url)
-	if _, err := e.download(url, local, "check"); err != nil {
+	if _, err := e.download(url, local, "device-mode"); err != nil {
 		return fmt.Errorf("could not download the container package for RouterOS %s (%s): %w. Install it via WebFig/Winbox (System > Packages) instead", e.sys.Version, e.sys.Arch, err)
 	}
 
 	e.log("uploading %s to the router", name)
 	if err := e.cl.Upload(local, name, func(done, total int64) {
-		e.ev.Progress("check", float64(done)*100/float64(total),
+		e.ev.Progress("device-mode", float64(done)*100/float64(total),
 			fmt.Sprintf("%s / %s", humanBytes(done), humanBytes(total)))
 	}); err != nil {
 		return fmt.Errorf("could not upload the container package: %w", err)
@@ -261,6 +387,7 @@ func (e *Engine) restartRouter(reason string, cmds ...string) error {
 }
 
 func (e *Engine) waitForReboot() error {
+	defer e.ev.RebootDone()
 	e.log("waiting for the router to restart")
 	e.cl.Close()
 	if err := e.sleep(rebootSettle); err != nil {
@@ -288,7 +415,9 @@ func (e *Engine) waitForReboot() error {
 }
 
 func (e *Engine) stepDeviceMode() error {
-	if err := e.enableDeviceMode(); err != nil {
+	err := e.enableDeviceMode()
+	e.ev.DeviceModeDone()
+	if err != nil {
 		return err
 	}
 	if err := e.ensureContainerPackage(); err != nil {
@@ -778,7 +907,7 @@ func (e *Engine) stepBaseline() error {
 		return nil
 	}
 	if !e.baselineTookEffect() {
-		e.log("LAN baseline did not bring up %s, the panel stays on %s", lanBridgeIP, e.opts.Host)
+		e.log("LAN baseline did not move the LAN to %s, the panel stays on %s", lanBridgeIP, e.opts.Host)
 		e.note = "not applied, panel stays on the router address"
 		return nil
 	}
@@ -788,23 +917,34 @@ func (e *Engine) stepBaseline() error {
 }
 
 func (e *Engine) baselineTookEffect() bool {
-	probe := fmt.Sprintf(`:put [:len [/ip/address/find address~"^%s"]]`, lanBridgeIP)
 	deadline := time.Now().Add(baselineTimeout)
+	unreachable := false
 	for time.Now().Before(deadline) {
 		if err := e.sleep(3 * time.Second); err != nil {
 			return true
 		}
-		out, err := e.cl.RunRaw(probe, 8*time.Second)
-		if err != nil {
+		if _, err := e.cl.RunRaw(":put ok", 8*time.Second); err != nil {
 			if rerr := e.cl.Reconnect(); rerr != nil {
-				e.log("router no longer answers on %s, the new LAN is taking over", e.opts.Host)
-				return true
+				unreachable = true
+				continue
 			}
-			continue
 		}
-		if v := strings.TrimSpace(out); v != "" && v != "0" {
+		unreachable = false
+		if e.baselineLANReady() {
 			return true
 		}
 	}
+	if unreachable {
+		e.log("router no longer answers on %s, the new LAN is taking over", e.opts.Host)
+		return true
+	}
+	if e.exists("/ip/address", fmt.Sprintf("address~%q", "^"+lanBridgeIP)) {
+		e.log("%s is up but has no member ports, the LAN did not move", lanBridge)
+	}
 	return false
+}
+
+func (e *Engine) baselineLANReady() bool {
+	return e.exists("/ip/address", fmt.Sprintf("address~%q", "^"+lanBridgeIP)) &&
+		e.exists("/interface/bridge/port", fmt.Sprintf("bridge=%q", lanBridge))
 }


### PR DESCRIPTION
## Summary

- Restart prompts show the router button instructions and photo in both the manual and automatic paths, and close once the step finishes
- Router password is optional now, so routers with no password install cleanly
- Routers below the required RouterOS version are updated and asked to restart, and the installer stops when the release channel cannot reach that version
- Leftover container tars and stale image directories are cleared before and after the install
- Finish screen links to whichever LAN address is actually serving the panel instead of assuming the new bridge took over


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The installer automatically updates outdated RouterOS versions before enabling container support.
  * Installation progress now reports device-mode and reboot completion.
  * LAN verification confirms bridge configuration and handles router reconnections more reliably.
* **Bug Fixes**
  * Improved reporting for RouterOS update failures and download progress.
  * Startup validation now requires only the router IP.
* **Improvements**
  * Successful installations clean up temporary image files and stale container data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->