### PR TITLE
feat(fe): confirm making a DHCP lease static

### DIFF
--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -65,6 +65,7 @@ export function DHCPPage() {
   const [ethernetRates, setEthernetRates] = useState<Record<string, string>>({});
   const [busyMac, setBusyMac] = useState<string | null>(null);
   const [leaseToRemove, setLeaseToRemove] = useState<DhcpLease | null>(null);
+  const [leaseToMakeStatic, setLeaseToMakeStatic] = useState<DhcpLease | null>(null);
   const inFlightRef = useRef(false);
 
   const reload = useCallback(
@@ -137,33 +138,32 @@ export function DHCPPage() {
     return () => window.clearInterval(interval);
   }, [reload]);
 
-  const handleMakeStatic = useCallback(
-    async (lease: DhcpLease) => {
-      if (!id) return;
-      const creds = getCredentials(id);
-      const host = router?.host;
-      if (!creds || !host) return;
-      setBusyMac(lease.macAddress);
-      try {
-        await makeDhcpLeaseStatic({ host, ...creds }, lease.macAddress);
-        toast.notify({
-          title: 'Lease made static',
-          description: `${lease.address} · ${lease.macAddress}`,
-          tone: 'success',
-        });
-        await reload();
-      } catch (err) {
-        toast.notify({
-          title: 'Failed to make lease static',
-          description: errorMessage(err, 'Unknown error'),
-          tone: 'danger',
-        });
-      } finally {
-        setBusyMac(null);
-      }
-    },
-    [id, router?.host, getCredentials, reload, toast],
-  );
+  const handleMakeStatic = useCallback(async () => {
+    const lease = leaseToMakeStatic;
+    if (!id || !lease) return;
+    const creds = getCredentials(id);
+    const host = router?.host;
+    if (!creds || !host) return;
+    setBusyMac(lease.macAddress);
+    setLeaseToMakeStatic(null);
+    try {
+      await makeDhcpLeaseStatic({ host, ...creds }, lease.macAddress);
+      toast.notify({
+        title: 'Lease made static',
+        description: `${lease.address} · ${lease.macAddress}`,
+        tone: 'success',
+      });
+      await reload();
+    } catch (err) {
+      toast.notify({
+        title: 'Failed to make lease static',
+        description: errorMessage(err, 'Unknown error'),
+        tone: 'danger',
+      });
+    } finally {
+      setBusyMac(null);
+    }
+  }, [id, router?.host, getCredentials, leaseToMakeStatic, reload, toast]);
 
   const handleRemove = useCallback(async () => {
     const lease = leaseToRemove;
@@ -254,9 +254,7 @@ export function DHCPPage() {
             <Button
               size="sm"
               variant="secondary"
-              onClick={() => {
-                handleMakeStatic(r);
-              }}
+              onClick={() => setLeaseToMakeStatic(r)}
               disabled={busyMac === r.macAddress}
               aria-label={`Make static ${r.macAddress}`}
               title="Make static"
@@ -420,6 +418,20 @@ export function DHCPPage() {
         destructive
         onConfirm={handleRemove}
         onCancel={() => setLeaseToRemove(null)}
+      />
+
+      <ConfirmDialog
+        open={!!leaseToMakeStatic}
+        title="Make DHCP lease static"
+        description={
+          leaseToMakeStatic
+            ? `Make the lease for ${leaseToMakeStatic.address} (${leaseToMakeStatic.macAddress}) static? The client will keep this address.`
+            : undefined
+        }
+        confirmLabel="Make static"
+        cancelLabel="Cancel"
+        onConfirm={handleMakeStatic}
+        onCancel={() => setLeaseToMakeStatic(null)}
       />
     </Stack>
   );

--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -387,7 +387,7 @@ export function DHCPPage() {
 
       <Card data-testid="dhcp-leases">
         <CardHeader>
-          <CardTitle>Leases</CardTitle>
+          <CardTitle>DHCP Leases</CardTitle>
           <CardDescription>Active DHCP leases issued to clients on the LAN.</CardDescription>
         </CardHeader>
         {leases.error ? <div className={styles.errorBanner}>{leases.error}</div> : null}

--- a/frontend/tests/e2e/19-dhcp-page.spec.ts
+++ b/frontend/tests/e2e/19-dhcp-page.spec.ts
@@ -53,4 +53,55 @@ test.describe('LAN page (DHCP + port diagram)', () => {
     await expect(page.getByTestId('port-ether2')).toHaveAttribute('data-status', 'up');
     await expect(page.getByTestId('port-ether2')).toHaveAttribute('aria-label', /ether2.*up/i);
   });
+
+  test('asks for confirmation before making a lease static', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDhcpBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({
+      id: 'rtr_static',
+      name: 'Static Router',
+      host: '10.10.10.3',
+      model: 'hAP ax3',
+    });
+    await mockOverviewBackend({ id: 'rtr_static', model: 'hAP ax3' });
+    await mockDhcpBackend({ id: 'rtr_static' });
+
+    const makeStaticCalls: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/dhcp/leases/make-static')) {
+        makeStaticCalls.push(req.url());
+      }
+    });
+
+    await page.goto('/router/rtr_static/lan');
+
+    const leases = page.getByTestId('dhcp-leases');
+    await expect(leases.getByRole('heading', { name: 'DHCP Leases' })).toBeVisible();
+
+    const makeStaticButton = leases.getByRole('button', {
+      name: 'Make static AA:BB:CC:DD:EE:01',
+    });
+
+    await makeStaticButton.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('Make DHCP lease static');
+    await expect(dialog).toContainText('192.168.88.101');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    expect(makeStaticCalls).toHaveLength(0);
+
+    await makeStaticButton.click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Make static', exact: true })
+      .click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    await expect.poll(() => makeStaticCalls.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Closes #623

## Summary

- LAN page leases card is now titled "DHCP Leases"
- making a lease static asks for confirmation first
- e2e coverage for the heading and both confirm outcomes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before converting a dynamic DHCP lease to static.
  * Users can cancel the action without sending a request.
  * Renamed the leases section to “DHCP Leases.”

* **Tests**
  * Added coverage verifying confirmation, cancellation, and successful lease conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->