### PR TITLE
feat(fe): disable enabling SSTP server when already enabled

### DIFF
--- a/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Cable, Globe, Info, KeyRound, Shield, TriangleAlert } from 'lucide-react';
 import {
   Button,
@@ -44,11 +44,12 @@ const POLL_INTERVAL_MS = 1000;
 
 interface Props {
   creds: VPNCredentials | null;
+  sstpEnabled: boolean;
   onCancel: () => void;
   onCreated: () => void;
 }
 
-export function AddVpnServerDialog({ creds, onCancel, onCreated }: Props) {
+export function AddVpnServerDialog({ creds, sstpEnabled, onCancel, onCreated }: Props) {
   const [type, setType] = useState<AddVpnServerType>('openvpn');
 
   return (
@@ -65,7 +66,12 @@ export function AddVpnServerDialog({ creds, onCancel, onCreated }: Props) {
         {type === 'openvpn' ? (
           <OvpnServerForm creds={creds} onCancel={onCancel} onCreated={onCreated} />
         ) : type === 'sstp' ? (
-          <SstpServerForm creds={creds} onCancel={onCancel} onCreated={onCreated} />
+          <SstpServerForm
+            creds={creds}
+            sstpEnabled={sstpEnabled}
+            onCancel={onCancel}
+            onCreated={onCreated}
+          />
         ) : (
           <WireguardServerForm creds={creds} onCancel={onCancel} onCreated={onCreated} />
         )}
@@ -218,10 +224,19 @@ function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
   );
 }
 
-function InlineAlert({ tone, children }: { tone: 'info' | 'danger'; children: ReactNode }) {
+function InlineAlert({
+  tone,
+  id,
+  children,
+}: {
+  tone: 'info' | 'danger';
+  id?: string;
+  children: ReactNode;
+}) {
   const Icon = tone === 'danger' ? TriangleAlert : Info;
   return (
     <div
+      id={id}
       className={`${styles.alert} ${tone === 'danger' ? styles.alertDanger : styles.alertInfo}`}
       role={tone === 'danger' ? 'alert' : undefined}
     >
@@ -231,7 +246,12 @@ function InlineAlert({ tone, children }: { tone: 'info' | 'danger'; children: Re
   );
 }
 
-function SstpServerForm({ creds, onCancel, onCreated }: FormProps) {
+interface SstpFormProps extends FormProps {
+  sstpEnabled: boolean;
+}
+
+function SstpServerForm({ creds, sstpEnabled, onCancel, onCreated }: SstpFormProps) {
+  const alertId = useId();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [taskId, setTaskId] = useState<string | null>(null);
@@ -311,9 +331,10 @@ function SstpServerForm({ creds, onCancel, onCreated }: FormProps) {
 
   return (
     <FieldStack>
-      <InlineAlert tone="info">
-        Enabling SSTP issues a server certificate, starts the SSTP server on port 4433 and adds a
-        firewall rule accepting inbound connections. Existing VPN users can sign in over SSTP.
+      <InlineAlert tone="info" id={alertId}>
+        {sstpEnabled
+          ? 'The SSTP server is already enabled on this router. Disable it from the VPN servers list before enabling it again.'
+          : 'Enabling SSTP issues a server certificate, starts the SSTP server on port 4433 and adds a firewall rule accepting inbound connections. Existing VPN users can sign in over SSTP.'}
       </InlineAlert>
       {error ? <InlineAlert tone="danger">{error}</InlineAlert> : null}
       <FieldRow>

--- a/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
@@ -287,7 +287,7 @@ function SstpServerForm({ creds, sstpEnabled, onCancel, onCreated }: SstpFormPro
     return () => poll.cancel();
   }, [taskId]);
 
-  const canSubmit = !!creds && !submitting;
+  const canSubmit = !!creds && !submitting && !sstpEnabled;
 
   const submit = async () => {
     if (!canSubmit || !creds) return;
@@ -341,8 +341,17 @@ function SstpServerForm({ creds, sstpEnabled, onCancel, onCreated }: SstpFormPro
         <Button variant="ghost" onClick={onCancel} disabled={submitting}>
           Cancel
         </Button>
-        <Button variant="success" onClick={submit} disabled={!canSubmit}>
-          {submitting ? 'Enabling…' : 'Enable SSTP server'}
+        <Button
+          variant="success"
+          onClick={submit}
+          disabled={!canSubmit}
+          aria-describedby={sstpEnabled ? alertId : undefined}
+        >
+          {sstpEnabled
+            ? 'SSTP server already enabled'
+            : submitting
+              ? 'Enabling…'
+              : 'Enable SSTP server'}
         </Button>
       </FieldRow>
     </FieldStack>

--- a/frontend/src/routes/vpn/sections/ServersSection.tsx
+++ b/frontend/src/routes/vpn/sections/ServersSection.tsx
@@ -42,6 +42,8 @@ export function ServersSection({ creds, servers, onChanged }: Props) {
   const [pendingDisable, setPendingDisable] = useState<VPNServer | null>(null);
   const [disableSubmitting, setDisableSubmitting] = useState(false);
 
+  const sstpEnabled = servers.some((s) => s.protocol === 'sstp' && s.running);
+
   const onCreated = () => {
     toast.notify({ title: 'VPN server created', tone: 'success' });
     setAdding(false);
@@ -150,7 +152,12 @@ export function ServersSection({ creds, servers, onChanged }: Props) {
         </div>
       </Card>
       {adding ? (
-        <AddVpnServerDialog creds={creds} onCancel={() => setAdding(false)} onCreated={onCreated} />
+        <AddVpnServerDialog
+          creds={creds}
+          sstpEnabled={sstpEnabled}
+          onCancel={() => setAdding(false)}
+          onCreated={onCreated}
+        />
       ) : null}
       {editingWg && editingWg.protocol === 'wireguard' ? (
         <EditWgInterfaceDialog

--- a/frontend/tests/e2e/36-sstp-already-enabled.spec.ts
+++ b/frontend/tests/e2e/36-sstp-already-enabled.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from './fixtures';
+
+const ROUTER_ID = 'rtr_sstp_enabled';
+
+const envelope = <T>(data: T) => JSON.stringify({ status: 200, message: 'OK', data });
+
+const SSTP_ENABLED = {
+  enabled: true,
+  port: 4433,
+  protocol: 'tcp',
+  localIp: '10.20.0.1',
+  localIpPool: 'sstp-local-pool',
+  remoteIp: '10.20.0.2-10.20.0.50',
+  remoteIpPool: 'sstp-pool',
+};
+
+const seedSession = (routerId: string) => {
+  try {
+    const key = 'nasnet-panel.session-credentials.v1';
+    const raw = window.sessionStorage.getItem(key);
+    const map = (raw ? JSON.parse(raw) : {}) as Record<
+      string,
+      { username: string; password: string }
+    >;
+    map[routerId] = { username: 'admin', password: 'test' };
+    window.sessionStorage.setItem(key, JSON.stringify(map));
+  } catch {
+    /* ignore */
+  }
+};
+
+test.describe('SSTP already enabled', () => {
+  test('blocks enabling SSTP again when the server is already running', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'SSTP Router', host: '10.0.0.31' });
+    await context.addInitScript(seedSession, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: SSTP_ENABLED,
+        }),
+      });
+    });
+
+    let posted = false;
+    await context.route('**/api/vpn/sstp/server', async (route) => {
+      if (route.request().method() === 'POST') {
+        posted = true;
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: envelope({ taskId: 'sstp-task-blocked', status: 'running' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Add server' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog
+      .getByRole('radiogroup', { name: 'VPN server type' })
+      .getByRole('radio', { name: 'SSTP' })
+      .click();
+
+    const action = dialog.getByRole('button', { name: 'SSTP server already enabled' });
+    await expect(action).toBeVisible();
+    await expect(action).toBeDisabled();
+    await expect(dialog.getByRole('button', { name: 'Enable SSTP server' })).toHaveCount(0);
+    await expect(dialog).toContainText('The SSTP server is already enabled on this router.');
+
+    await expect(action).toHaveAccessibleDescription(
+      /The SSTP server is already enabled on this router\./,
+    );
+
+    expect(posted).toBe(false);
+  });
+
+  test('offers the enable action when SSTP is not enabled yet', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'SSTP Router', host: '10.0.0.31' });
+    await context.addInitScript(seedSession, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: { ...SSTP_ENABLED, enabled: false },
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Add server' }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog
+      .getByRole('radiogroup', { name: 'VPN server type' })
+      .getByRole('radio', { name: 'SSTP' })
+      .click();
+
+    await expect(dialog.getByRole('button', { name: 'Enable SSTP server' })).toBeEnabled();
+    await expect(dialog).toContainText('Enabling SSTP issues a server certificate');
+  });
+});


### PR DESCRIPTION
Closes #620

## Summary

- add VPN server dialog now reads the live SSTP state instead of relying on a backend rejection
- enable action is disabled and relabelled when SSTP is already running, with the reason wired up as its accessible description
- e2e coverage for both the already-enabled and not-yet-enabled states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from attempting to enable SSTP when it is already active.
  * Added clear status messaging and updated action text for already-enabled SSTP servers.
  * Preserved the enable option and certificate guidance when SSTP is not yet configured.

* **Accessibility**
  * Improved alert accessibility with optional identifiers.

* **Tests**
  * Added end-to-end coverage for enabled and unenabled SSTP server states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->