### PR TITLE
feat(be): save OVPN client certificate password in comment

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -2146,15 +2146,41 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		return
 	}
 
+	ovpnServerComment := "Client Certificate Password: " + req.ClientCertificatePassword
+
 	serverConfigNameTCP := serverConfigName + "-tcp"
-	_, err = client.AddOvpnServer(serverConfigNameTCP, tcpPort, "ip", "tcp", serverName, true, "sha256", "aes256-cbc", "default")
+	_, err = client.AddOvpnServer(routeros.AddOvpnServerConfig{
+		Name:              serverConfigNameTCP,
+		Port:              tcpPort,
+		Mode:              "ip",
+		Protocol:          "tcp",
+		Certificate:       serverName,
+		RequireClientCert: true,
+		Auth:              "sha256",
+		Cipher:            "aes256-cbc",
+		DefaultProfile:    "default",
+		RedirectGateway:   "def1",
+		Comment:           ovpnServerComment,
+	})
 	if err != nil {
 		setError("Failed to create OpenVPN TCP server: "+err.Error(), serverConfigNameTCP, "", "default", []string{caName, serverName, clientName})
 		return
 	}
 
 	serverConfigNameUDP := serverConfigName + "-udp"
-	_, err = client.AddOvpnServer(serverConfigNameUDP, udpPort, "ip", "udp", serverName, true, "sha256", "aes256-cbc", "default")
+	_, err = client.AddOvpnServer(routeros.AddOvpnServerConfig{
+		Name:              serverConfigNameUDP,
+		Port:              udpPort,
+		Mode:              "ip",
+		Protocol:          "udp",
+		Certificate:       serverName,
+		RequireClientCert: true,
+		Auth:              "sha256",
+		Cipher:            "aes256-cbc",
+		DefaultProfile:    "default",
+		RedirectGateway:   "def1",
+		Comment:           ovpnServerComment,
+	})
 	if err != nil {
 		setError("Failed to create OpenVPN UDP server: "+err.Error(), serverConfigNameUDP, "", "default", []string{caName, serverName, clientName})
 		return

--- a/backend/internal/template/ovpn_server.tmpl
+++ b/backend/internal/template/ovpn_server.tmpl
@@ -22,10 +22,10 @@ export-certificate cert-client-{{ .CurrentTimestamp }} file-name=cert-client-{{ 
 add name="ovpn-server-{{ .CurrentTimestamp }}-tcp" default-profile="default" disabled=no \
 port="1194" protocol="tcp" mode="ip" certificate=cert-server-{{ .CurrentTimestamp }} \
 require-client-certificate=yes auth=sha1,md5,sha256,sha384,sha512 cipher=blowfish128,aes128-cbc,aes192-cbc,aes256-cbc,aes128-gcm,aes192-gcm,aes256-gcm \
-redirect-gateway=def1 keepalive-timeout=60
+redirect-gateway=def1 keepalive-timeout=60 comment="Client Certificate Password: {{ .OvpnServer.ClientCertificatePassword }}"
 add name="ovpn-server-{{ .CurrentTimestamp }}-udp" default-profile="default" disabled=no port="1194" protocol="udp" \
 mode="ip" certificate=cert-server-{{ .CurrentTimestamp }} require-client-certificate=yes auth=sha1,md5,sha256,sha384,sha512 cipher=blowfish128,aes128-cbc,aes192-cbc,aes256-cbc,aes128-gcm,aes192-gcm,aes256-gcm \
-redirect-gateway=def1 keepalive-timeout=60
+redirect-gateway=def1 keepalive-timeout=60 comment="Client Certificate Password: {{ .OvpnServer.ClientCertificatePassword }}"
 :global WizardProgress "92"
 /ppp secret{{range .OvpnServer.Users}}
 add name="{{ .Username }}" password="{{ .Password }}" profile=VPN-VPN service=any

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -88,6 +88,32 @@ type OvpnServerInfo struct {
 	Comment           string
 }
 
+// AddOvpnServerConfig represents every field that can be set when creating a
+// new OpenVPN server via AddOvpnServer. Name, Port, Mode, Protocol and
+// Certificate are always sent; every other field is optional and, left at
+// its zero value, is omitted from the request so RouterOS applies its own
+// default for that property.
+type AddOvpnServerConfig struct {
+	Name              string
+	Port              int
+	Mode              string
+	Protocol          string
+	Certificate       string
+	Disabled          bool
+	UserAuthMethod    string
+	Key               string
+	Auth              string
+	Cipher            string
+	RequireClientCert bool
+	RequireEncryption bool
+	KeepAliveTimeout  int
+	DefaultGateway    bool
+	RedirectGateway   string
+	MacAddress        string
+	DefaultProfile    string
+	Comment           string
+}
+
 // OvpnServerUpdateConfig represents every field that can be changed on an
 // existing OpenVPN server via UpdateOvpnServer. Only non-nil fields are
 // applied; everything else on the server is left as it was.
@@ -629,25 +655,55 @@ func (c *Client) GetOvpnServer(idOrName string) (*OvpnServerInfo, error) {
 }
 
 // AddOvpnServer creates a new OpenVPN server configuration.
-func (c *Client) AddOvpnServer(name string, port int, mode, protocol, certificate string, requireClientCert bool, auth, cipher, profile string) (string, error) {
+func (c *Client) AddOvpnServer(config AddOvpnServerConfig) (string, error) {
 	args := []string{
-		"=name=" + name,
-		"=port=" + strconv.Itoa(port),
-		"=mode=" + mode,
-		"=protocol=" + protocol,
-		"=certificate=" + certificate,
-		"=auth=" + auth,
-		"=cipher=" + cipher,
-		"=redirect-gateway=def1",
-		"=disabled=no",
+		"=name=" + config.Name,
+		"=port=" + strconv.Itoa(config.Port),
+		"=mode=" + config.Mode,
+		"=protocol=" + config.Protocol,
+		"=certificate=" + config.Certificate,
 	}
 
-	if profile != "" {
-		args = append(args, "=default-profile="+profile)
+	if config.Disabled {
+		args = append(args, "=disabled=yes")
+	} else {
+		args = append(args, "=disabled=no")
 	}
-
-	if requireClientCert {
+	if config.UserAuthMethod != "" {
+		args = append(args, "=user-auth-method="+config.UserAuthMethod)
+	}
+	if config.Key != "" {
+		args = append(args, "=key="+config.Key)
+	}
+	if config.Auth != "" {
+		args = append(args, "=auth="+config.Auth)
+	}
+	if config.Cipher != "" {
+		args = append(args, "=cipher="+config.Cipher)
+	}
+	if config.RequireClientCert {
 		args = append(args, "=require-client-certificate=true")
+	}
+	if config.RequireEncryption {
+		args = append(args, "=require-encryption=true")
+	}
+	if config.KeepAliveTimeout > 0 {
+		args = append(args, "=keepalive-timeout="+strconv.Itoa(config.KeepAliveTimeout))
+	}
+	if config.DefaultGateway {
+		args = append(args, "=default-gateway=true")
+	}
+	if config.RedirectGateway != "" {
+		args = append(args, "=redirect-gateway="+config.RedirectGateway)
+	}
+	if config.MacAddress != "" {
+		args = append(args, "=mac-address="+config.MacAddress)
+	}
+	if config.DefaultProfile != "" {
+		args = append(args, "=default-profile="+config.DefaultProfile)
+	}
+	if config.Comment != "" {
+		args = append(args, "=comment="+config.Comment)
 	}
 
 	id, err := c.Add("/interface/ovpn-server/server", args...)


### PR DESCRIPTION
* Closes #610
* Saves client certificate password in comment field of open VPN server in wizard and VPN endpoints
* Repalced too many params with struct for AddOvpnServer method in routeros package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenVPN server configurations now support configurable redirect gateway behavior.
  * Client certificate passwords are included in OpenVPN server comments for easier identification.
* **Improvements**
  * OpenVPN TCP and UDP server creation now applies optional settings more consistently.
  * Server enabled or disabled status is communicated explicitly, improving configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->