### PR TITLE
feat(fe): remove unnecessary data from SSTP view modal

### DIFF
--- a/frontend/src/api/vpn.ts
+++ b/frontend/src/api/vpn.ts
@@ -165,21 +165,9 @@ export interface L2tpServerDetailsResponse {
 export interface SstpServerDetailsResponse {
   enabled: boolean;
   port: number;
-  profile: string;
-  auth: string;
   certificate: string;
   verifyClientCertificate: boolean;
   tlsVersion: string;
-  ciphers: string;
-  pfs: string;
-  localAddress: string;
-  remoteAddress: string;
-  useCompression: string;
-  useEncryption: string;
-  onlyOne: string;
-  changeTcpMss: string;
-  dnsServer: string;
-  secrets: L2TPUserSecret[];
 }
 
 export interface WireguardServerDetailsResponse {

--- a/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/ServerDetailsDialog.tsx
@@ -409,21 +409,9 @@ function DetailsBody({
           <SummaryRows server={server} />
           <Row label="Enabled" value={<BoolBadge value={d.enabled} />} />
           {server.listenPort ? null : <Row label="Port" value={d.port} />}
-          <Row label="Auth" value={d.auth} />
-          <Row label="Profile" value={d.profile} />
           <Row label="Certificate" value={d.certificate} />
           <Row label="Verify client cert" value={<BoolBadge value={d.verifyClientCertificate} />} />
           <Row label="TLS version" value={d.tlsVersion} />
-          <Row label="Ciphers" value={d.ciphers} />
-          <Row label="PFS" value={d.pfs} />
-          {server.localIp ? null : <Row label="Local address" value={d.localAddress} />}
-          {server.remoteIp ? null : <Row label="Remote address" value={d.remoteAddress} />}
-          <Row label="DNS server" value={d.dnsServer} />
-          <Row label="Use compression" value={d.useCompression} />
-          <Row label="Use encryption" value={d.useEncryption} />
-          <Row label="Only one" value={d.onlyOne} />
-          <Row label="Change TCP MSS" value={d.changeTcpMss} />
-          <SecretsRow secrets={d.secrets} />
         </DList>
       );
     }

--- a/frontend/tests/e2e/36-vpn-sstp-server.spec.ts
+++ b/frontend/tests/e2e/36-vpn-sstp-server.spec.ts
@@ -310,4 +310,103 @@ test.describe('SSTP server', () => {
       page.getByRole('row', { name: /SSTP/ }).getByRole('button', { name: /disable SSTP/i }),
     ).toHaveCount(0);
   });
+
+  test('shows only the essential fields in the SSTP details dialog', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'SSTP Router', host: '10.0.0.30' });
+    await context.addInitScript(seedSession, ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [],
+          pptp: null,
+          l2tp: null,
+          sstp: SSTP_ENABLED,
+        }),
+      });
+    });
+
+    await context.route('**/api/vpn/sstp/server', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          enabled: true,
+          port: 4433,
+          profile: 'sstp-profile',
+          auth: 'mschap2',
+          certificate: 'sstp-server-cert',
+          verifyClientCertificate: false,
+          tlsVersion: 'only-1.2',
+          ciphers: 'aes256-sha',
+          pfs: 'no',
+          localAddress: '172.30.0.1',
+          remoteAddress: '172.30.0.2-172.30.0.50',
+          useCompression: 'no',
+          useEncryption: 'required',
+          onlyOne: 'yes',
+          changeTcpMss: 'yes',
+          dnsServer: '9.9.9.9',
+          secrets: [{ username: 'carol', password: 'carol123' }],
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    const row = page.getByRole('row', { name: /SSTP/ });
+    await expect(row).toBeVisible();
+    await row.getByRole('cell').first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByText('Enabled', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Port', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Certificate', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('sstp-server-cert')).toBeVisible();
+    await expect(dialog.getByText('Verify client cert', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('TLS version', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('only-1.2')).toBeVisible();
+
+    for (const label of [
+      'Auth',
+      'Profile',
+      'Ciphers',
+      'PFS',
+      'Local address',
+      'Remote address',
+      'DNS server',
+      'Use compression',
+      'Use encryption',
+      'Only one',
+      'Change TCP MSS',
+      'Secrets',
+    ]) {
+      await expect(dialog.getByText(label, { exact: true })).toHaveCount(0);
+    }
+
+    await expect(dialog.getByText('9.9.9.9')).toHaveCount(0);
+    await expect(dialog.getByText('carol', { exact: true })).toHaveCount(0);
+  });
 });

--- a/frontend/tests/e2e/36-vpn-sstp-server.spec.ts
+++ b/frontend/tests/e2e/36-vpn-sstp-server.spec.ts
@@ -381,13 +381,13 @@ test.describe('SSTP server', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
-    await expect(dialog.getByText('Enabled', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('Port', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('Certificate', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('sstp-server-cert')).toBeVisible();
-    await expect(dialog.getByText('Verify client cert', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('TLS version', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('only-1.2')).toBeVisible();
+    const valueOf = (label: string) => dialog.locator(`dt:text-is("${label}") + dd`);
+
+    await expect(valueOf('Enabled')).toHaveText('Yes');
+    await expect(valueOf('Port')).toHaveText('4433');
+    await expect(valueOf('Certificate')).toHaveText('sstp-server-cert');
+    await expect(valueOf('Verify client cert')).toHaveText('No');
+    await expect(valueOf('TLS version')).toHaveText('only-1.2');
 
     for (const label of [
       'Auth',
@@ -408,5 +408,6 @@ test.describe('SSTP server', () => {
 
     await expect(dialog.getByText('9.9.9.9')).toHaveCount(0);
     await expect(dialog.getByText('carol', { exact: true })).toHaveCount(0);
+    await expect(dialog.getByText('carol123', { exact: true })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #636

- SSTP details modal now shows only enabled state, port, certificate, client cert verification and TLS version
- dropped the secrets list and the PPP profile/address/compression rows that do not apply to the SSTP view
- e2e coverage asserts the surviving rows render and the removed ones are gone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified SSTP server details to show essential connection and security information, including the port, certificate, client-certificate verification status, and TLS version.
  * Removed advanced configuration, networking, DNS, compression, encryption, session, and credential details from the details view.
* **Tests**
  * Added coverage confirming essential fields are displayed while sensitive and advanced settings remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->