### PR TITLE
feat(fe): claim a free VPN from the L2TP add client dialog

### DIFF
--- a/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedClaimDialog.tsx
+++ b/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedClaimDialog.tsx
@@ -5,16 +5,21 @@ import { Button, Dialog, useToast } from '@nasnet/ui';
 import { fetchNasnetVpnCredentials } from '../../../../api';
 import { useSession } from '../../../../state/SessionContext';
 import { useRouter } from '../../../../state/RouterStoreContext';
-import type { Action } from '../../state';
 import styles from './HyperSpeedClaimDialog.module.scss';
+
+export interface ClaimedVpnCredentials {
+  server: string;
+  username: string;
+  password: string;
+}
 
 interface Props {
   open: boolean;
   onClose: () => void;
-  dispatch: React.Dispatch<Action>;
+  onClaimed: (creds: ClaimedVpnCredentials) => void;
 }
 
-export function HyperSpeedClaimDialog({ open, onClose, dispatch }: Props) {
+export function HyperSpeedClaimDialog({ open, onClose, onClaimed }: Props) {
   const { id: routerId } = useParams<{ id: string }>();
   const { getCredentials } = useSession();
   const router = useRouter(routerId);
@@ -36,9 +41,7 @@ export function HyperSpeedClaimDialog({ open, onClose, dispatch }: Props) {
     setLoading(true);
     try {
       const data = await fetchNasnetVpnCredentials({ host, ...creds });
-      dispatch({ type: 'setField', field: 'l2tpServer', value: data.server });
-      dispatch({ type: 'setField', field: 'l2tpUsername', value: data.username });
-      dispatch({ type: 'setField', field: 'l2tpPassword', value: data.password });
+      onClaimed({ server: data.server, username: data.username, password: data.password });
       toast.notify({
         title: 'Free VPN credentials applied',
         description: data.expiryDate ? `Valid until ${data.expiryDate}.` : undefined,

--- a/frontend/src/routes/easy-config/steps/ipmask/IpMaskL2tpFields.tsx
+++ b/frontend/src/routes/easy-config/steps/ipmask/IpMaskL2tpFields.tsx
@@ -87,7 +87,11 @@ export function IpMaskL2tpFields({ state, dispatch }: Props) {
       <HyperSpeedClaimDialog
         open={claimOpen}
         onClose={() => setClaimOpen(false)}
-        dispatch={dispatch}
+        onClaimed={(creds) => {
+          dispatch({ type: 'setField', field: 'l2tpServer', value: creds.server });
+          dispatch({ type: 'setField', field: 'l2tpUsername', value: creds.username });
+          dispatch({ type: 'setField', field: 'l2tpPassword', value: creds.password });
+        }}
       />
     </FieldStack>
   );

--- a/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
@@ -364,6 +364,8 @@ function L2tpFields({ draft, set, errors, touched, markTouched, onClaimed }: L2t
           </div>
           {touched.connectTo && errors.connectTo ? <FormError>{errors.connectTo}</FormError> : null}
         </Label>
+      </FieldRow>
+      <FieldRow>
         <Label>
           <span>User</span>
           <Input
@@ -377,8 +379,6 @@ function L2tpFields({ draft, set, errors, touched, markTouched, onClaimed }: L2t
           />
           {touched.user && errors.user ? <FormError>{errors.user}</FormError> : null}
         </Label>
-      </FieldRow>
-      <FieldRow>
         <Label>
           <span>Password</span>
           <PasswordInput
@@ -391,6 +391,8 @@ function L2tpFields({ draft, set, errors, touched, markTouched, onClaimed }: L2t
           />
           {touched.password && errors.password ? <FormError>{errors.password}</FormError> : null}
         </Label>
+      </FieldRow>
+      <FieldRow>
         <Label>
           <span>IPsec secret</span>
           <PasswordInput

--- a/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnClientDialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Cable, Globe, KeyRound, Shield } from 'lucide-react';
+import { Cable, Globe, KeyRound, Shield, Sparkles } from 'lucide-react';
 import {
   Button,
   Dialog,
@@ -14,6 +14,10 @@ import {
   Textarea,
 } from '@nasnet/ui';
 import { VpnTypeTilePicker, type VpnTypeTile } from './VpnTypeTilePicker';
+import {
+  HyperSpeedClaimDialog,
+  type ClaimedVpnCredentials,
+} from '../../easy-config/steps/ipmask/HyperSpeedClaimDialog';
 import type {
   AddL2TPClientRequest,
   CreateWireguardClientRequest,
@@ -243,6 +247,14 @@ export function AddVpnClientDialog({
             errors={errors}
             touched={touched}
             markTouched={markTouched}
+            onClaimed={(creds) =>
+              setDraft((d) => ({
+                ...d,
+                connectTo: creds.server,
+                user: creds.username,
+                password: creds.password,
+              }))
+            }
           />
         ) : null}
 
@@ -319,23 +331,37 @@ interface L2tpFieldsProps {
   errors: Record<string, string | null>;
   touched: Record<string, boolean>;
   markTouched: (key: string) => void;
+  onClaimed: (creds: ClaimedVpnCredentials) => void;
 }
 
-function L2tpFields({ draft, set, errors, touched, markTouched }: L2tpFieldsProps) {
+function L2tpFields({ draft, set, errors, touched, markTouched, onClaimed }: L2tpFieldsProps) {
+  const [claimOpen, setClaimOpen] = useState(false);
   return (
     <>
       <FieldRow>
         <Label>
           <span>Connect to</span>
-          <Input
-            value={draft.connectTo}
-            onChange={(e) => set('connectTo', e.target.value)}
-            onBlur={() => markTouched('connectTo')}
-            placeholder="192.168.1.1"
-            aria-label="Connect to"
-            autoComplete="off"
-            aria-invalid={touched.connectTo && !!errors.connectTo}
-          />
+          <div style={{ display: 'flex', gap: 'var(--space-xs)' }}>
+            <Input
+              value={draft.connectTo}
+              onChange={(e) => set('connectTo', e.target.value)}
+              onBlur={() => markTouched('connectTo')}
+              placeholder="192.168.1.1"
+              aria-label="Connect to"
+              autoComplete="off"
+              aria-invalid={touched.connectTo && !!errors.connectTo}
+              style={{ flex: 1 }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setClaimOpen(true)}
+              style={{ whiteSpace: 'nowrap' }}
+            >
+              <Sparkles size={16} strokeWidth={2} />
+              Claim free VPN
+            </Button>
+          </div>
           {touched.connectTo && errors.connectTo ? <FormError>{errors.connectTo}</FormError> : null}
         </Label>
         <Label>
@@ -377,6 +403,11 @@ function L2tpFields({ draft, set, errors, touched, markTouched }: L2tpFieldsProp
           />
         </Label>
       </FieldRow>
+      <HyperSpeedClaimDialog
+        open={claimOpen}
+        onClose={() => setClaimOpen(false)}
+        onClaimed={onClaimed}
+      />
     </>
   );
 }

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -412,4 +412,70 @@ test.describe('WAN tab', () => {
     });
     await expect(page.getByRole('cell', { name: 'mask-one', exact: true })).toBeVisible();
   });
+
+  test('claims a free VPN into the L2TP add dialog', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'WAN Router', host: '10.0.0.10' });
+    await setSessionCreds(context, ROUTER_ID);
+    await setupWanRoutes(context, blankState());
+
+    let claimCalls = 0;
+    await context.route('**/api/wizard/vpn', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      claimCalls += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          server: 'free.nasnet.example',
+          username: 'free-user',
+          password: 'free-pass',
+          expiryDate: '2026-01-01',
+        }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    await newClientButton(page).click();
+    const dialog = page.getByRole('dialog').first();
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Claim free VPN' }).click();
+
+    const claimDialog = page.getByRole('dialog', { name: /Hyper Speed VPN/ });
+    await expect(claimDialog).toBeVisible();
+    await claimDialog.getByRole('button', { name: 'Claim a free VPN' }).click();
+
+    await expect.poll(() => claimCalls).toBe(1);
+    await expect(claimDialog).toBeHidden();
+    await expect(dialog.getByLabel('Connect to')).toHaveValue('free.nasnet.example');
+    await expect(dialog.getByLabel('User')).toHaveValue('free-user');
+    await expect(dialog.getByLabel('Password', { exact: true })).toHaveValue('free-pass');
+  });
+
+  test('the claim button is hidden for WireGuard clients', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'WAN Router', host: '10.0.0.10' });
+    await setSessionCreds(context, ROUTER_ID);
+    await setupWanRoutes(context, blankState());
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    await newClientButton(page).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('button', { name: 'Claim free VPN' })).toBeVisible();
+
+    await dialog.getByRole('radio', { name: 'WireGuard' }).click();
+    await expect(dialog.getByRole('button', { name: 'Claim free VPN' })).toBeHidden();
+  });
 });

--- a/frontend/tests/e2e/24-wan-tab-crud.spec.ts
+++ b/frontend/tests/e2e/24-wan-tab-crud.spec.ts
@@ -478,4 +478,35 @@ test.describe('WAN tab', () => {
     await dialog.getByRole('radio', { name: 'WireGuard' }).click();
     await expect(dialog.getByRole('button', { name: 'Claim free VPN' })).toBeHidden();
   });
+
+  test('the claim button shares a full-width row with the connect-to field', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'WAN Router', host: '10.0.0.10' });
+    await setSessionCreds(context, ROUTER_ID);
+    await setupWanRoutes(context, blankState());
+    await page.goto(`/router/${ROUTER_ID}/wan`);
+
+    await newClientButton(page).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const connectTo = dialog.getByLabel('Connect to');
+    const claim = dialog.getByRole('button', { name: 'Claim free VPN' });
+    const user = dialog.getByLabel('User');
+
+    const connectToBox = await connectTo.boundingBox();
+    const claimBox = await claim.boundingBox();
+    const userBox = await user.boundingBox();
+    if (!connectToBox || !claimBox || !userBox) throw new Error('missing layout boxes');
+
+    expect(Math.abs(connectToBox.y - claimBox.y)).toBeLessThan(connectToBox.height / 2);
+    expect(claimBox.x).toBeGreaterThan(connectToBox.x + connectToBox.width - 1);
+    expect(connectToBox.width).toBeGreaterThan(claimBox.width);
+    expect(userBox.y).toBeGreaterThan(connectToBox.y + connectToBox.height);
+  });
 });


### PR DESCRIPTION
Closes #634

- Claim free VPN button in the L2TP branch of the add VPN client dialog on the WAN page
- reuses the existing free VPN promo dialog, now reporting credentials through a callback
- claimed server, username and password prefill the new client form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Claim free VPN” option when configuring L2TP VPN clients.
  - Claimed HyperSpeed VPN credentials now automatically populate the server, username, and password fields.
  - The claim option is unavailable when WireGuard is selected.

- **Tests**
  - Added end-to-end coverage for successful credential claiming and protocol-specific availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->