### PR TITLE
feat(fe): show WireGuard peer count in the VPN servers list

### DIFF
--- a/frontend/src/routes/VPNPage.tsx
+++ b/frontend/src/routes/VPNPage.tsx
@@ -4,6 +4,7 @@ import { Stack, useToast } from '@nasnet/ui';
 import {
   ApiError,
   fetchVPNServersStatus,
+  fetchWireguardPeers,
   listVPNClients,
   listVPNUsers,
   type VPNClient,
@@ -32,6 +33,7 @@ export function VPNPage() {
   const [clients, setClients] = useState<VPNClient[]>([]);
   const [servers, setServers] = useState<VPNServer[]>([]);
   const [users, setUsers] = useState<VPNUserResponse[]>([]);
+  const [peerCounts, setPeerCounts] = useState<Record<string, number>>({});
   const [loaded, setLoaded] = useState(false);
   const peers: VPNPeer[] = [];
 
@@ -51,10 +53,30 @@ export function VPNPage() {
         fetchVPNServersStatus(creds),
         listVPNUsers(creds),
       ]);
+      const mappedServers = mapServersStatusToList(serversStatus, id);
       setClients(rawClients.map((c) => mapClientFromBE(c, id)));
-      setServers(mapServersStatusToList(serversStatus, id));
+      setServers(mappedServers);
       setUsers(rawUsers);
       setLoaded(true);
+      const counted = await Promise.all(
+        mappedServers
+          .filter((s) => s.protocol === 'wireguard')
+          .map(async (s): Promise<[string, number] | null> => {
+            try {
+              const wgPeers = await fetchWireguardPeers(creds, s.name);
+              return [s.id, wgPeers.length];
+            } catch {
+              return null;
+            }
+          }),
+      );
+      setPeerCounts((prev) => {
+        const next = { ...prev };
+        for (const entry of counted) {
+          if (entry) next[entry[0]] = entry[1];
+        }
+        return next;
+      });
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -86,7 +108,7 @@ export function VPNPage() {
         protocols={protocols}
         loading={!loaded}
       />
-      <ServersSection creds={creds} servers={servers} onChanged={reload} />
+      <ServersSection creds={creds} servers={servers} peerCounts={peerCounts} onChanged={reload} />
       <UsersSection creds={creds} users={users} onChanged={reload} />
       {/* <PeersSection routerId={id} peers={peers} servers={servers} onChanged={reload} /> */}
     </Stack>

--- a/frontend/src/routes/vpn/sections/ServersSection.tsx
+++ b/frontend/src/routes/vpn/sections/ServersSection.tsx
@@ -29,10 +29,11 @@ const matches = (s: VPNServer, q: string) =>
 interface Props {
   creds: VPNCredentials | null;
   servers: VPNServer[];
+  peerCounts?: Record<string, number>;
   onChanged: () => void;
 }
 
-export function ServersSection({ creds, servers, onChanged }: Props) {
+export function ServersSection({ creds, servers, peerCounts, onChanged }: Props) {
   const paged = usePagedFilter(servers, matches);
   const toast = useToast();
   const [selected, setSelected] = useState<VPNServer | null>(null);
@@ -176,6 +177,7 @@ export function ServersSection({ creds, servers, onChanged }: Props) {
             onDisable={(s) => setPendingDisable(s)}
             onToggleEnabled={(s) => setPendingToggle(s)}
             canMutate={!!creds}
+            peerCounts={peerCounts}
           />
           <PaginationControls
             page={paged.page}

--- a/frontend/src/routes/vpn/sections/ServersTable.tsx
+++ b/frontend/src/routes/vpn/sections/ServersTable.tsx
@@ -11,6 +11,7 @@ interface Props {
   onDisable?: (server: VPNServer) => void;
   onToggleEnabled?: (server: VPNServer) => void;
   canMutate?: boolean;
+  peerCounts?: Record<string, number>;
 }
 
 const isDeletable = (s: VPNServer) => s.protocol === 'openvpn' || s.protocol === 'wireguard';
@@ -27,6 +28,7 @@ export function ServersTable({
   onDisable,
   onToggleEnabled,
   canMutate = false,
+  peerCounts = {},
 }: Props) {
   return (
     <DataTable
@@ -55,6 +57,21 @@ export function ServersTable({
             const transport = s.transport.toLowerCase();
             const tone = transport === 'tcp' ? 'primary' : transport === 'udp' ? 'info' : 'neutral';
             return <Badge tone={tone}>{`${transport}:${s.listenPort}`}</Badge>;
+          },
+        },
+        {
+          key: 'peers',
+          header: 'Peers',
+          render: (s: VPNServer) => {
+            if (s.protocol !== 'wireguard') return '–';
+            const count = peerCounts[s.id];
+            if (count === undefined) return '–';
+            const label = `${count} ${count === 1 ? 'peer' : 'peers'} on ${s.name}`;
+            return (
+              <Badge tone="neutral" title={label} aria-label={label}>
+                {count}
+              </Badge>
+            );
           },
         },
         {

--- a/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
+++ b/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
@@ -111,6 +111,78 @@ test.describe('VPN servers tab', () => {
     await expect(dialog.getByText('alice123')).toBeVisible();
   });
 
+  test('shows the peer count of a WireGuard server in the servers list', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+    seedCredentials,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'Server Router', host: '10.0.0.20' });
+    await seedCredentials(ROUTER_ID);
+
+    await context.route('**/api/vpn/clients', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: envelope([]) });
+    });
+
+    await context.route('**/api/vpn/servers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope({
+          ovpnServers: [],
+          wireguards: [{ name: 'office-wg', enabled: true, port: 51820, protocol: 'udp' }],
+          pptp: { enabled: true, port: 1723 },
+          l2tp: null,
+          sstp: null,
+        }),
+      });
+    });
+
+    await context.route('**/api/vpn/wireguard/peers/office-wg', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(
+          ['phone', 'laptop', 'tablet'].map((name, i) => ({
+            id: `*${i + 1}`,
+            name,
+            interfaceName: 'office-wg',
+            publicKey: `key-${i + 1}`,
+            endpointAddress: '',
+            endpointPort: 0,
+            currentEndpointAddress: '',
+            currentEndpointPort: 0,
+            allowedAddresses: `10.10.0.${i + 2}/32`,
+            persistentKeepalive: '',
+            lastHandshake: '',
+            rxBytes: 0,
+            txBytes: 0,
+            rx: '0',
+            tx: '0',
+            dynamic: false,
+            disabled: false,
+          })),
+        ),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await expect(page.getByRole('columnheader', { name: 'Peers' })).toBeVisible();
+
+    const wgRow = page.getByRole('row', { name: /office-wg/ });
+    await expect(wgRow.getByLabel('3 peers on office-wg')).toHaveText('3');
+
+    const pptpRow = page.getByRole('row', { name: /PPTP/ });
+    await expect(pptpRow.getByLabel(/peers on/)).toHaveCount(0);
+  });
+
   test('switches server form via type tiles and keeps unsupported types disabled', async ({
     page,
     context,


### PR DESCRIPTION
Closes #639

- adds a Peers column to the VPN servers list showing each WireGuard server's peer count as a badge
- peer counts are fetched per WireGuard server on the existing VPN poll, non-WireGuard rows keep the empty placeholder
- badge carries an accessible label naming the server, covered by an e2e assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Peers** column to the VPN servers list.
  * Displays the number of WireGuard peers for each server, including singular and plural labels.
  * Shows a dash when peer information is unavailable or not applicable.

* **Tests**
  * Added end-to-end coverage verifying peer counts for WireGuard servers and appropriate handling for other VPN protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->