### PR TITLE
feat(be):Implemented Family DNS feature, added description to DNS list

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,11 @@ const (
 	dnsDefaultDomesticIP = "217.218.127.127"
 	dnsDefaultForeignIP  = "1.1.1.1"
 	dnsDefaultVPNIP      = "1.0.0.1"
+
+	// Cloudflare Family DNS IPs applied by POST /api/dns/family: Primary to
+	// the Foreign forwarder, Secondary to the VPN forwarder.
+	dnsFamilyPrimaryIP   = "1.1.1.3"
+	dnsFamilySecondaryIP = "1.0.0.3"
 
 	defaultRouteDstAddress = "0.0.0.0/0"
 	wanDomesticLinkComment = "WAN - Domestic Link"
@@ -61,7 +67,8 @@ func HandleGetDNSInfo(c echo.Context) error {
 // HandleListDNSForwarders godoc
 // @Summary List DNS forwarders
 // @Description Lists every /ip/dns/forwarders entry except "General", with its name, IP
-// @Description address(es) and comment.
+// @Description address(es) and comment. If any of the forwarder's IPs is a known suggestion
+// @Description from GET /api/dns/suggest, its description is included too.
 // @Tags DNS
 // @Accept json
 // @Produce json
@@ -90,10 +97,24 @@ func HandleListDNSForwarders(c echo.Context) error {
 		if forwarders[i].Name == "General" {
 			continue
 		}
+
+		description := ""
+		for _, ip := range forwarders[i].DNSServers {
+			if d := dnsSuggestionDescription(ip, domesticDNSSuggestions); d != "" {
+				description = d
+				break
+			}
+			if d := dnsSuggestionDescription(ip, foreignDNSSuggestions); d != "" {
+				description = d
+				break
+			}
+		}
+
 		items = append(items, DNSForwarderListItem{
-			Name:    forwarders[i].Name,
-			IP:      strings.Join(forwarders[i].DNSServers, ","),
-			Comment: forwarders[i].Comment,
+			Name:        forwarders[i].Name,
+			IP:          strings.Join(forwarders[i].DNSServers, ","),
+			Description: description,
+			Comment:     forwarders[i].Comment,
 		})
 	}
 
@@ -352,31 +373,68 @@ func HandleChangeDNS(c echo.Context) error {
 		return err
 	}
 
-	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: req.NewIP})
+	result, err := changeDNSIP(client, req.OldIP, req.NewIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP changed successfully", result)
+}
+
+// dnsChangeStepError carries the HTTP status/message a caller of
+// changeDNSIP should respond with for a failure at one of its steps.
+type dnsChangeStepError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *dnsChangeStepError) Error() string { return e.message }
+func (e *dnsChangeStepError) Unwrap() error { return e.err }
+
+// respondDNSChangeStepError translates an error from changeDNSIP into an
+// echo response, preserving the specific status/message dnsChangeStepError
+// carries, and falling back to a generic 500 for anything else.
+func respondDNSChangeStepError(c echo.Context, err error) error {
+	var stepErr *dnsChangeStepError
+	if errors.As(err, &stepErr) {
+		return ErrorResponse(c, stepErr.status, stepErr.message, stepErr.err)
+	}
+	return ErrorResponse(c, http.StatusInternalServerError, "Failed to change DNS IP", err)
+}
+
+// changeDNSIP replaces oldIP with newIP across /ip/dns servers, the
+// dns-servers list of every DNS forwarder that contains it, the "DNS"
+// firewall address list, every dst-nat NAT rule whose to-addresses is oldIP,
+// every /ip/route entry whose dst-address or gateway is oldIP, and every
+// /tool/netwatch probe whose host is oldIP. Callers must ensure oldIP and
+// newIP differ before calling.
+func changeDNSIP(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
+	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: newIP})
 	if err != nil {
 		if IsCredentialError(err) {
-			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+			return nil, &dnsChangeStepError{http.StatusUnauthorized, "Invalid RouterOS credentials", err}
 		}
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search DNS forwarders", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to search DNS forwarders", err}
 	}
 	if len(newIPForwarders) > 0 {
-		return ErrorResponse(c, http.StatusConflict,
-			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", req.NewIP, newIPForwarders[0].Name), nil)
+		return nil, &dnsChangeStepError{http.StatusConflict,
+			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", newIP, newIPForwarders[0].Name), nil}
 	}
 
 	info, err := client.GetDNSInfo()
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to get DNS info", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to get DNS info", err}
 	}
-	if !slices.Contains(info.Servers, req.OldIP) {
-		return ErrorResponse(c, http.StatusNotFound,
-			fmt.Sprintf("Old IP %s not found in /ip/dns servers", req.OldIP), nil)
+	if !slices.Contains(info.Servers, oldIP) {
+		return nil, &dnsChangeStepError{http.StatusNotFound,
+			fmt.Sprintf("Old IP %s not found in /ip/dns servers", oldIP), nil}
 	}
 
 	newServers := make([]string, len(info.Servers))
 	for i, server := range info.Servers {
-		if server == req.OldIP {
-			newServers[i] = req.NewIP
+		if server == oldIP {
+			newServers[i] = newIP
 		} else {
 			newServers[i] = server
 		}
@@ -384,116 +442,116 @@ func HandleChangeDNS(c echo.Context) error {
 
 	serversStr := strings.Join(newServers, ",")
 	if err := client.UpdateDNSConfig(routeros.DNSUpdateConfig{Servers: &serversStr}); err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update DNS configuration", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to update DNS configuration", err}
 	}
 
 	forwarders, err := client.ListDNSForwarders()
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list DNS forwarders", err}
 	}
 
 	updatedForwarders := make([]string, 0)
 	for i := range forwarders {
 		forwarder := &forwarders[i]
-		if !slices.Contains(forwarder.DNSServers, req.OldIP) {
+		if !slices.Contains(forwarder.DNSServers, oldIP) {
 			continue
 		}
 
 		newForwarderServers := make([]string, len(forwarder.DNSServers))
 		for j, server := range forwarder.DNSServers {
-			if server == req.OldIP {
-				newForwarderServers[j] = req.NewIP
+			if server == oldIP {
+				newForwarderServers[j] = newIP
 			} else {
 				newForwarderServers[j] = server
 			}
 		}
 
 		if err := client.SetDNSForwarderServers(forwarder.ID, strings.Join(newForwarderServers, ",")); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err)
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err}
 		}
 		updatedForwarders = append(updatedForwarders, forwarder.Name)
 	}
 
 	addressListItems, err := client.ListFirewallAddressListItems(routeros.FirewallAddressListFilter{
 		ListName: dnsAddressListName,
-		Address:  req.OldIP,
+		Address:  oldIP,
 	})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS address list items", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list DNS address list items", err}
 	}
 	updatedAddressListItems := make([]string, 0, len(addressListItems))
 	for i := range addressListItems {
 		item := &addressListItems[i]
-		if err := client.UpdateFirewallAddressListItem(item.ID, req.NewIP); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update DNS address list item %s", item.ID), err)
+		if err := client.UpdateFirewallAddressListItem(item.ID, newIP); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS address list item %s", item.ID), err}
 		}
 		updatedAddressListItems = append(updatedAddressListItems, item.ID)
 	}
 
 	natRules, err := client.ListNATRules(routeros.NATRuleFilter{
 		Action:      "dst-nat",
-		ToAddresses: req.OldIP,
+		ToAddresses: oldIP,
 	})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list NAT rules", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list NAT rules", err}
 	}
 	updatedNATRules := make([]string, 0, len(natRules))
 	for i := range natRules {
 		rule := &natRules[i]
-		if err := client.UpdateNATRule(rule.ID, req.NewIP); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update NAT rule %s", rule.ID), err)
+		if err := client.UpdateNATRule(rule.ID, newIP); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update NAT rule %s", rule.ID), err}
 		}
 		updatedNATRules = append(updatedNATRules, rule.ID)
 	}
 
-	dstAddressRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{DstAddress: req.OldIP})
+	dstAddressRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{DstAddress: oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by dst-address", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list IP routes by dst-address", err}
 	}
 	updatedDstAddressRoutes := make([]string, 0, len(dstAddressRoutes))
 	for i := range dstAddressRoutes {
 		route := &dstAddressRoutes[i]
-		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{DstAddress: req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update route %s dst-address", route.ID), err)
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{DstAddress: newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s dst-address", route.ID), err}
 		}
 		updatedDstAddressRoutes = append(updatedDstAddressRoutes, route.ID)
 	}
 
-	gatewayRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Gateway: req.OldIP})
+	gatewayRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Gateway: oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by gateway", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list IP routes by gateway", err}
 	}
 	updatedGatewayRoutes := make([]string, 0, len(gatewayRoutes))
 	for i := range gatewayRoutes {
 		route := &gatewayRoutes[i]
-		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{Gateway: req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update route %s gateway", route.ID), err)
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{Gateway: newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s gateway", route.ID), err}
 		}
 		updatedGatewayRoutes = append(updatedGatewayRoutes, route.ID)
 	}
 
-	netwatchProbes, err := client.ListNetwatch(routeros.NetwatchFilter{Host: &req.OldIP})
+	netwatchProbes, err := client.ListNetwatch(routeros.NetwatchFilter{Host: &oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list netwatch probes", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list netwatch probes", err}
 	}
 	updatedNetwatchProbes := make([]string, 0, len(netwatchProbes))
 	for i := range netwatchProbes {
 		probe := &netwatchProbes[i]
-		if _, err := client.UpdateNetwatch(probe.ID, routeros.UpdateNetwatchParams{Host: &req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update netwatch probe %s", probe.ID), err)
+		if _, err := client.UpdateNetwatch(probe.ID, routeros.UpdateNetwatchParams{Host: &newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update netwatch probe %s", probe.ID), err}
 		}
 		updatedNetwatchProbes = append(updatedNetwatchProbes, probe.ID)
 	}
 
-	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP changed successfully", DNSChangeResponse{
-		OldIP:                   req.OldIP,
-		NewIP:                   req.NewIP,
+	return &DNSChangeResponse{
+		OldIP:                   oldIP,
+		NewIP:                   newIP,
 		Servers:                 newServers,
 		UpdatedForwarders:       updatedForwarders,
 		UpdatedDstAddressRoutes: updatedDstAddressRoutes,
@@ -501,7 +559,85 @@ func HandleChangeDNS(c echo.Context) error {
 		UpdatedNetwatchProbes:   updatedNetwatchProbes,
 		UpdatedAddressListItems: updatedAddressListItems,
 		UpdatedNATRules:         updatedNATRules,
+	}, nil
+}
+
+// HandleSetFamilyDNS godoc
+// @Summary Apply Cloudflare Family DNS to the Foreign and VPN forwarders
+// @Description Finds the current DNS server IP of the "Foreign" and "VPN" DNS forwarders, then
+// @Description runs the same change as POST /api/dns/change for each: Foreign's current IP is
+// @Description replaced with the Cloudflare Family Primary IP (1.1.1.3), and VPN's current IP is
+// @Description replaced with the Cloudflare Family Secondary IP (1.0.0.3), across /ip/dns
+// @Description servers, DNS forwarders, the "DNS" firewall address list, dst-nat NAT rules, IP
+// @Description routes, and netwatch probes. A forwarder already set to its target family IP is
+// @Description left unchanged rather than erroring. No request body is required.
+// @Tags DNS
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Success 200 {object} Response{data=DNSFamilyResponse}
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/family [post].
+func HandleSetFamilyDNS(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	forwarders, err := client.ListDNSForwarders()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+	}
+
+	foreignIP, ok := dnsForwarderCurrentIP(forwarders, dnsForwarderTypeForeign)
+	if !ok {
+		return ErrorResponse(c, http.StatusNotFound, "Foreign DNS forwarder not found or has no server configured", nil)
+	}
+	vpnIP, ok := dnsForwarderCurrentIP(forwarders, dnsForwarderTypeVPN)
+	if !ok {
+		return ErrorResponse(c, http.StatusNotFound, "VPN DNS forwarder not found or has no server configured", nil)
+	}
+
+	foreignResult, err := changeDNSIPOrNoop(client, foreignIP, dnsFamilyPrimaryIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	vpnResult, err := changeDNSIPOrNoop(client, vpnIP, dnsFamilySecondaryIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Cloudflare Family DNS applied successfully", DNSFamilyResponse{
+		Foreign: *foreignResult,
+		VPN:     *vpnResult,
 	})
+}
+
+// dnsForwarderCurrentIP returns the first DNS server IP configured on the
+// DNS forwarder named name, and whether such a forwarder with at least one
+// server was found.
+func dnsForwarderCurrentIP(forwarders []routeros.DNSForwarder, name string) (string, bool) {
+	for i := range forwarders {
+		if strings.TrimSpace(forwarders[i].Name) != name || len(forwarders[i].DNSServers) == 0 {
+			continue
+		}
+		return forwarders[i].DNSServers[0], true
+	}
+	return "", false
+}
+
+// changeDNSIPOrNoop calls changeDNSIP, except when oldIP already equals
+// newIP: RouterOS's own "New IP already used by forwarder" conflict check
+// inside changeDNSIP would otherwise reject re-applying an already-current
+// IP, so that case is treated as a successful no-op instead.
+func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
+	if oldIP == newIP {
+		return &DNSChangeResponse{OldIP: oldIP, NewIP: newIP}, nil
+	}
+	return changeDNSIP(client, oldIP, newIP)
 }
 
 // HandleResetDNS godoc

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -403,6 +403,35 @@ func respondDNSChangeStepError(c echo.Context, err error) error {
 	return ErrorResponse(c, http.StatusInternalServerError, "Failed to change DNS IP", err)
 }
 
+// respondDNSChangeStepErrorWithData behaves like respondDNSChangeStepError,
+// but also includes data in the response body. Used when an earlier step
+// already mutated the router before the one that failed (e.g. the Foreign
+// swap in HandleSetFamilyDNS succeeding before the VPN swap fails), so the
+// caller can see what was actually applied rather than assuming nothing was.
+func respondDNSChangeStepErrorWithData(c echo.Context, err error, data interface{}) error {
+	status := http.StatusInternalServerError
+	message := "Failed to change DNS IP"
+	errText := ""
+
+	var stepErr *dnsChangeStepError
+	if errors.As(err, &stepErr) {
+		status = stepErr.status
+		message = stepErr.message
+		if stepErr.err != nil {
+			errText = cleanErrorMessage(stepErr.err.Error())
+		}
+	} else {
+		errText = cleanErrorMessage(err.Error())
+	}
+
+	return c.JSON(status, Response{
+		Status:  status,
+		Message: message,
+		Data:    data,
+		Error:   errText,
+	})
+}
+
 // changeDNSIP replaces oldIP with newIP across /ip/dns servers, the
 // dns-servers list of every DNS forwarder that contains it, the "DNS"
 // firewall address list, every dst-nat NAT rule whose to-addresses is oldIP,
@@ -570,7 +599,10 @@ func changeDNSIP(client *routeros.Client, oldIP, newIP string) (*DNSChangeRespon
 // @Description replaced with the Cloudflare Family Secondary IP (1.0.0.3), across /ip/dns
 // @Description servers, DNS forwarders, the "DNS" firewall address list, dst-nat NAT rules, IP
 // @Description routes, and netwatch probes. A forwarder already set to its target family IP is
-// @Description left unchanged rather than erroring. No request body is required.
+// @Description left unchanged rather than erroring. No request body is required. If the Foreign
+// @Description swap succeeds but the VPN swap then fails, the error response's data still
+// @Description includes the completed Foreign result, so the caller can see what was actually
+// @Description applied to the router.
 // @Tags DNS
 // @Produce json
 // @Security BasicAuth
@@ -607,7 +639,10 @@ func HandleSetFamilyDNS(c echo.Context) error {
 
 	vpnResult, err := changeDNSIPOrNoop(client, vpnIP, dnsFamilySecondaryIP)
 	if err != nil {
-		return respondDNSChangeStepError(c, err)
+		// Foreign was already changed on the router by this point; report it
+		// alongside the error rather than leaving the caller to assume
+		// nothing was applied.
+		return respondDNSChangeStepErrorWithData(c, err, DNSFamilyResponse{Foreign: *foreignResult})
 	}
 
 	return SuccessResponse(c, http.StatusOK, "Cloudflare Family DNS applied successfully", DNSFamilyResponse{

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -670,7 +670,17 @@ func dnsForwarderCurrentIP(forwarders []routeros.DNSForwarder, name string) (str
 // IP, so that case is treated as a successful no-op instead.
 func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
 	if oldIP == newIP {
-		return &DNSChangeResponse{OldIP: oldIP, NewIP: newIP}, nil
+		return &DNSChangeResponse{
+			OldIP:                   oldIP,
+			NewIP:                   newIP,
+			Servers:                 []string{},
+			UpdatedForwarders:       []string{},
+			UpdatedDstAddressRoutes: []string{},
+			UpdatedGatewayRoutes:    []string{},
+			UpdatedNetwatchProbes:   []string{},
+			UpdatedAddressListItems: []string{},
+			UpdatedNATRules:         []string{},
+		}, nil
 	}
 	return changeDNSIP(client, oldIP, newIP)
 }

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -238,8 +238,6 @@ var foreignDNSSuggestions = []DNSSuggestion{
 	{IP: "149.112.112.112", Description: "Quad9 DNS"},
 	{IP: "208.67.222.222", Description: "OpenDNS"},
 	{IP: "208.67.220.220", Description: "OpenDNS"},
-	{IP: "8.26.56.26", Description: "Google Secondary"},
-	{IP: "8.20.247.20", Description: "Google Secondary"},
 	{IP: "64.6.64.6", Description: "Verisign Public DNS"},
 	{IP: "64.6.65.6", Description: "Verisign Public DNS"},
 	{IP: "84.200.69.80", Description: "DNS.Watch"},

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -21,9 +21,10 @@ type UpdateDNSRequest struct {
 
 // DNSForwarderListItem is one entry in the GET /api/dns/list response.
 type DNSForwarderListItem struct {
-	Name    string `json:"name"`
-	IP      string `json:"ip"`
-	Comment string `json:"comment"`
+	Name        string `json:"name"`
+	IP          string `json:"ip"`
+	Description string `json:"description,omitempty"`
+	Comment     string `json:"comment"`
 }
 
 // dnsForwarderType names the three recognized DNS forwarder roles, carried in
@@ -134,6 +135,12 @@ type DNSChangeResponse struct {
 	UpdatedNATRules         []string `json:"updatedNatRules"`
 }
 
+// DNSFamilyResponse is the response for POST /api/dns/family.
+type DNSFamilyResponse struct {
+	Foreign DNSChangeResponse `json:"foreign"`
+	VPN     DNSChangeResponse `json:"vpn"`
+}
+
 // DNSForwarderResult describes one DNS forwarder created by POST /api/dns/reset.
 type DNSForwarderResult struct {
 	ID         string   `json:"id"`
@@ -221,6 +228,8 @@ var foreignDNSSuggestions = []DNSSuggestion{
 	{IP: "1.0.0.1", Description: "Cloudflare Secondary"},
 	{IP: "8.8.8.8", Description: "Google Primary"},
 	{IP: "8.8.4.4", Description: "Google Secondary"},
+	{IP: "1.1.1.3", Description: "Cloudflare Family Primary"},
+	{IP: "1.0.0.3", Description: "Cloudflare Family Secondary"},
 	{IP: "4.2.2.1", Description: "Level3 DNS"},
 	{IP: "4.2.2.2", Description: "Level3 DNS"},
 	{IP: "4.2.2.3", Description: "Level3 DNS"},
@@ -250,6 +259,17 @@ func isKnownDNSSuggestion(ip string, suggestions []DNSSuggestion) bool {
 		}
 	}
 	return false
+}
+
+// dnsSuggestionDescription returns the description of ip in suggestions, or
+// "" if ip isn't one of them.
+func dnsSuggestionDescription(ip string, suggestions []DNSSuggestion) string {
+	for i := range suggestions {
+		if suggestions[i].IP == ip {
+			return suggestions[i].Description
+		}
+	}
+	return ""
 }
 
 func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse {

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -104,6 +104,7 @@ func RegisterRoutes(e *echo.Echo) {
 	dnsGroup.GET("/suggest", handler.HandleSuggestDNS)
 	dnsGroup.GET("/validate", handler.HandleValidateDNS)
 	dnsGroup.POST("/change", handler.HandleChangeDNS)
+	dnsGroup.POST("/family", handler.HandleSetFamilyDNS)
 	dnsGroup.POST("/reset", handler.HandleResetDNS)
 
 	vpnGroup := e.Group("/api/vpn")


### PR DESCRIPTION
* Closes #609
### Summary

Extends the DNS handling in `internal/handler/dns.go`/`dns_dto.go` with a new forwarder-listing endpoint, a one-call "apply Cloudflare Family DNS" endpoint, and brings the existing change/reset flows in sync with the router's firewall address-list and NAT rules, which they previously left stale.

### New endpoints

- **`GET /api/dns/list`** — lists every `/ip/dns/forwarders` entry except `"General"`, with `name`, `ip` (comma-joined if multi-value), and `comment`. Each entry's `description` is populated automatically when one of its IPs matches a known suggestion from `domesticDNSSuggestions`/`foreignDNSSuggestions` (e.g. `"Cloudflare Primary"`), left empty otherwise.
- **`POST /api/dns/family`** — applies Cloudflare's Family DNS (malware/adult-content filtering) in one call, no request body: looks up the current server IP of the `"Foreign"` and `"VPN"` forwarders and swaps them to `1.1.1.3` (Family Primary) and `1.0.0.3` (Family Secondary) respectively, running the same full change flow as `/api/dns/change`. Idempotent — a forwarder already on its target family IP is a no-op rather than an error.

### Changed behavior

- **`POST /api/dns/change`** now also updates:
  - matching entries in the `"DNS"` firewall address list
  - matching `dst-nat` NAT rules (by `to-addresses`)

  in addition to the pre-existing `/ip/dns` servers, forwarders, routes, and netwatch probe updates.
- **`POST /api/dns/reset`** now also:
  - clears and recreates the `"DNS"` firewall address list from the reset DNS server IPs
  - updates every `dst-nat` NAT rule tagged `"DNS Split"`/`"DNS VPN"`/`"DNS containers"` to the VPN IP, `"DNS Foreign"` to the Foreign IP, and `"DNS Domestic"` to the Domestic IP

- Added `1.1.1.3` (`"Cloudflare Family Primary"`) and `1.0.0.3` (`"Cloudflare Family Secondary"`) to `GET /api/dns/suggest`'s foreign suggestion list.

### Refactor

- Extracted `HandleChangeDNS`'s full change logic into a reusable `changeDNSIP(client, oldIP, newIP) (*DNSChangeResponse, error)`, with a `dnsChangeStepError` type carrying each step's specific HTTP status/message — now shared between `/api/dns/change` and the new `/api/dns/family`. `HandleChangeDNS` itself is now a thin request-binding wrapper; its response shape and status codes are unchanged.
- Added `pkg/routeros` support this work depended on: `FirewallRuleConfig.InInterfaceList`, `NATRuleFilter`/`ListNATRules`/`UpdateNATRule`, and reused the existing `AddFirewallAddressListItem`/`RemoveFirewallAddressListItem`.

### Cleanup

- Moved several package-level consts (`defaultRouteDstAddress`, `wanDomesticLinkComment`, `domesticAddressListFreshWindow`, `domesticAddressListMinHealthySize`) to the top of `dns.go`, and the `dnsResetForwarder`/`dnsResetCheckIPRoute`/`dnsResetRouteDstAddress`/`dnsResetNetwatchProbe` types (previously anonymous structs) into named types at the top of `dns_dto.go`, per this backend's struct-placement convention.
- Removed a handful of doc comments on unexported identifiers that weren't required by lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cloudflare Family DNS configuration for Foreign and VPN DNS forwarders.
  - Added clear results showing DNS changes for each forwarder type.
  - Added descriptions for DNS suggestions, including Cloudflare Family DNS options.

- **Improvements**
  - DNS updates now provide more specific error reporting across related network settings.
  - Existing Cloudflare Family DNS addresses are recognized and left unchanged.

- **Bug Fixes**
  - Corrected DNS suggestion labels for Comodo addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->