### PR TITLE
feat(be): Added ad-block feature

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,11 @@ const (
 	dnsDefaultDomesticIP = "217.218.127.127"
 	dnsDefaultForeignIP  = "1.1.1.1"
 	dnsDefaultVPNIP      = "1.0.0.1"
+
+	// Cloudflare Family DNS IPs applied by POST /api/dns/family: Primary to
+	// the Foreign forwarder, Secondary to the VPN forwarder.
+	dnsFamilyPrimaryIP   = "1.1.1.3"
+	dnsFamilySecondaryIP = "1.0.0.3"
 
 	defaultRouteDstAddress = "0.0.0.0/0"
 	wanDomesticLinkComment = "WAN - Domestic Link"
@@ -61,7 +67,8 @@ func HandleGetDNSInfo(c echo.Context) error {
 // HandleListDNSForwarders godoc
 // @Summary List DNS forwarders
 // @Description Lists every /ip/dns/forwarders entry except "General", with its name, IP
-// @Description address(es) and comment.
+// @Description address(es) and comment. If any of the forwarder's IPs is a known suggestion
+// @Description from GET /api/dns/suggest, its description is included too.
 // @Tags DNS
 // @Accept json
 // @Produce json
@@ -90,10 +97,24 @@ func HandleListDNSForwarders(c echo.Context) error {
 		if forwarders[i].Name == "General" {
 			continue
 		}
+
+		description := ""
+		for _, ip := range forwarders[i].DNSServers {
+			if d := dnsSuggestionDescription(ip, domesticDNSSuggestions); d != "" {
+				description = d
+				break
+			}
+			if d := dnsSuggestionDescription(ip, foreignDNSSuggestions); d != "" {
+				description = d
+				break
+			}
+		}
+
 		items = append(items, DNSForwarderListItem{
-			Name:    forwarders[i].Name,
-			IP:      strings.Join(forwarders[i].DNSServers, ","),
-			Comment: forwarders[i].Comment,
+			Name:        forwarders[i].Name,
+			IP:          strings.Join(forwarders[i].DNSServers, ","),
+			Description: description,
+			Comment:     forwarders[i].Comment,
 		})
 	}
 
@@ -352,31 +373,68 @@ func HandleChangeDNS(c echo.Context) error {
 		return err
 	}
 
-	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: req.NewIP})
+	result, err := changeDNSIP(client, req.OldIP, req.NewIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP changed successfully", result)
+}
+
+// dnsChangeStepError carries the HTTP status/message a caller of
+// changeDNSIP should respond with for a failure at one of its steps.
+type dnsChangeStepError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *dnsChangeStepError) Error() string { return e.message }
+func (e *dnsChangeStepError) Unwrap() error { return e.err }
+
+// respondDNSChangeStepError translates an error from changeDNSIP into an
+// echo response, preserving the specific status/message dnsChangeStepError
+// carries, and falling back to a generic 500 for anything else.
+func respondDNSChangeStepError(c echo.Context, err error) error {
+	var stepErr *dnsChangeStepError
+	if errors.As(err, &stepErr) {
+		return ErrorResponse(c, stepErr.status, stepErr.message, stepErr.err)
+	}
+	return ErrorResponse(c, http.StatusInternalServerError, "Failed to change DNS IP", err)
+}
+
+// changeDNSIP replaces oldIP with newIP across /ip/dns servers, the
+// dns-servers list of every DNS forwarder that contains it, the "DNS"
+// firewall address list, every dst-nat NAT rule whose to-addresses is oldIP,
+// every /ip/route entry whose dst-address or gateway is oldIP, and every
+// /tool/netwatch probe whose host is oldIP. Callers must ensure oldIP and
+// newIP differ before calling.
+func changeDNSIP(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
+	newIPForwarders, err := client.FindDNSForwarders(routeros.DNSForwarderFilter{DNSServers: newIP})
 	if err != nil {
 		if IsCredentialError(err) {
-			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+			return nil, &dnsChangeStepError{http.StatusUnauthorized, "Invalid RouterOS credentials", err}
 		}
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to search DNS forwarders", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to search DNS forwarders", err}
 	}
 	if len(newIPForwarders) > 0 {
-		return ErrorResponse(c, http.StatusConflict,
-			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", req.NewIP, newIPForwarders[0].Name), nil)
+		return nil, &dnsChangeStepError{http.StatusConflict,
+			fmt.Sprintf("New IP %s is already used by DNS forwarder %q", newIP, newIPForwarders[0].Name), nil}
 	}
 
 	info, err := client.GetDNSInfo()
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to get DNS info", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to get DNS info", err}
 	}
-	if !slices.Contains(info.Servers, req.OldIP) {
-		return ErrorResponse(c, http.StatusNotFound,
-			fmt.Sprintf("Old IP %s not found in /ip/dns servers", req.OldIP), nil)
+	if !slices.Contains(info.Servers, oldIP) {
+		return nil, &dnsChangeStepError{http.StatusNotFound,
+			fmt.Sprintf("Old IP %s not found in /ip/dns servers", oldIP), nil}
 	}
 
 	newServers := make([]string, len(info.Servers))
 	for i, server := range info.Servers {
-		if server == req.OldIP {
-			newServers[i] = req.NewIP
+		if server == oldIP {
+			newServers[i] = newIP
 		} else {
 			newServers[i] = server
 		}
@@ -384,116 +442,116 @@ func HandleChangeDNS(c echo.Context) error {
 
 	serversStr := strings.Join(newServers, ",")
 	if err := client.UpdateDNSConfig(routeros.DNSUpdateConfig{Servers: &serversStr}); err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update DNS configuration", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to update DNS configuration", err}
 	}
 
 	forwarders, err := client.ListDNSForwarders()
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list DNS forwarders", err}
 	}
 
 	updatedForwarders := make([]string, 0)
 	for i := range forwarders {
 		forwarder := &forwarders[i]
-		if !slices.Contains(forwarder.DNSServers, req.OldIP) {
+		if !slices.Contains(forwarder.DNSServers, oldIP) {
 			continue
 		}
 
 		newForwarderServers := make([]string, len(forwarder.DNSServers))
 		for j, server := range forwarder.DNSServers {
-			if server == req.OldIP {
-				newForwarderServers[j] = req.NewIP
+			if server == oldIP {
+				newForwarderServers[j] = newIP
 			} else {
 				newForwarderServers[j] = server
 			}
 		}
 
 		if err := client.SetDNSForwarderServers(forwarder.ID, strings.Join(newForwarderServers, ",")); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err)
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err}
 		}
 		updatedForwarders = append(updatedForwarders, forwarder.Name)
 	}
 
 	addressListItems, err := client.ListFirewallAddressListItems(routeros.FirewallAddressListFilter{
 		ListName: dnsAddressListName,
-		Address:  req.OldIP,
+		Address:  oldIP,
 	})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS address list items", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list DNS address list items", err}
 	}
 	updatedAddressListItems := make([]string, 0, len(addressListItems))
 	for i := range addressListItems {
 		item := &addressListItems[i]
-		if err := client.UpdateFirewallAddressListItem(item.ID, req.NewIP); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update DNS address list item %s", item.ID), err)
+		if err := client.UpdateFirewallAddressListItem(item.ID, newIP); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS address list item %s", item.ID), err}
 		}
 		updatedAddressListItems = append(updatedAddressListItems, item.ID)
 	}
 
 	natRules, err := client.ListNATRules(routeros.NATRuleFilter{
 		Action:      "dst-nat",
-		ToAddresses: req.OldIP,
+		ToAddresses: oldIP,
 	})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list NAT rules", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list NAT rules", err}
 	}
 	updatedNATRules := make([]string, 0, len(natRules))
 	for i := range natRules {
 		rule := &natRules[i]
-		if err := client.UpdateNATRule(rule.ID, req.NewIP); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update NAT rule %s", rule.ID), err)
+		if err := client.UpdateNATRule(rule.ID, newIP); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update NAT rule %s", rule.ID), err}
 		}
 		updatedNATRules = append(updatedNATRules, rule.ID)
 	}
 
-	dstAddressRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{DstAddress: req.OldIP})
+	dstAddressRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{DstAddress: oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by dst-address", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list IP routes by dst-address", err}
 	}
 	updatedDstAddressRoutes := make([]string, 0, len(dstAddressRoutes))
 	for i := range dstAddressRoutes {
 		route := &dstAddressRoutes[i]
-		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{DstAddress: req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update route %s dst-address", route.ID), err)
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{DstAddress: newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s dst-address", route.ID), err}
 		}
 		updatedDstAddressRoutes = append(updatedDstAddressRoutes, route.ID)
 	}
 
-	gatewayRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Gateway: req.OldIP})
+	gatewayRoutes, err := client.ListIPRoutesWithFilters(routeros.IPRouteFilter{Gateway: oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list IP routes by gateway", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list IP routes by gateway", err}
 	}
 	updatedGatewayRoutes := make([]string, 0, len(gatewayRoutes))
 	for i := range gatewayRoutes {
 		route := &gatewayRoutes[i]
-		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{Gateway: req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update route %s gateway", route.ID), err)
+		if err := client.UpdateIPRoute(route.ID, routeros.IPRouteConfig{Gateway: newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update route %s gateway", route.ID), err}
 		}
 		updatedGatewayRoutes = append(updatedGatewayRoutes, route.ID)
 	}
 
-	netwatchProbes, err := client.ListNetwatch(routeros.NetwatchFilter{Host: &req.OldIP})
+	netwatchProbes, err := client.ListNetwatch(routeros.NetwatchFilter{Host: &oldIP})
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list netwatch probes", err)
+		return nil, &dnsChangeStepError{http.StatusInternalServerError, "Failed to list netwatch probes", err}
 	}
 	updatedNetwatchProbes := make([]string, 0, len(netwatchProbes))
 	for i := range netwatchProbes {
 		probe := &netwatchProbes[i]
-		if _, err := client.UpdateNetwatch(probe.ID, routeros.UpdateNetwatchParams{Host: &req.NewIP}); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to update netwatch probe %s", probe.ID), err)
+		if _, err := client.UpdateNetwatch(probe.ID, routeros.UpdateNetwatchParams{Host: &newIP}); err != nil {
+			return nil, &dnsChangeStepError{http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update netwatch probe %s", probe.ID), err}
 		}
 		updatedNetwatchProbes = append(updatedNetwatchProbes, probe.ID)
 	}
 
-	return SuccessResponse(c, http.StatusOK, "DNS forwarder IP changed successfully", DNSChangeResponse{
-		OldIP:                   req.OldIP,
-		NewIP:                   req.NewIP,
+	return &DNSChangeResponse{
+		OldIP:                   oldIP,
+		NewIP:                   newIP,
 		Servers:                 newServers,
 		UpdatedForwarders:       updatedForwarders,
 		UpdatedDstAddressRoutes: updatedDstAddressRoutes,
@@ -501,7 +559,85 @@ func HandleChangeDNS(c echo.Context) error {
 		UpdatedNetwatchProbes:   updatedNetwatchProbes,
 		UpdatedAddressListItems: updatedAddressListItems,
 		UpdatedNATRules:         updatedNATRules,
+	}, nil
+}
+
+// HandleSetFamilyDNS godoc
+// @Summary Apply Cloudflare Family DNS to the Foreign and VPN forwarders
+// @Description Finds the current DNS server IP of the "Foreign" and "VPN" DNS forwarders, then
+// @Description runs the same change as POST /api/dns/change for each: Foreign's current IP is
+// @Description replaced with the Cloudflare Family Primary IP (1.1.1.3), and VPN's current IP is
+// @Description replaced with the Cloudflare Family Secondary IP (1.0.0.3), across /ip/dns
+// @Description servers, DNS forwarders, the "DNS" firewall address list, dst-nat NAT rules, IP
+// @Description routes, and netwatch probes. A forwarder already set to its target family IP is
+// @Description left unchanged rather than erroring. No request body is required.
+// @Tags DNS
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Success 200 {object} Response{data=DNSFamilyResponse}
+// @Failure 404 {object} Response
+// @Failure 409 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/family [post].
+func HandleSetFamilyDNS(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	forwarders, err := client.ListDNSForwarders()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
+	}
+
+	foreignIP, ok := dnsForwarderCurrentIP(forwarders, dnsForwarderTypeForeign)
+	if !ok {
+		return ErrorResponse(c, http.StatusNotFound, "Foreign DNS forwarder not found or has no server configured", nil)
+	}
+	vpnIP, ok := dnsForwarderCurrentIP(forwarders, dnsForwarderTypeVPN)
+	if !ok {
+		return ErrorResponse(c, http.StatusNotFound, "VPN DNS forwarder not found or has no server configured", nil)
+	}
+
+	foreignResult, err := changeDNSIPOrNoop(client, foreignIP, dnsFamilyPrimaryIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	vpnResult, err := changeDNSIPOrNoop(client, vpnIP, dnsFamilySecondaryIP)
+	if err != nil {
+		return respondDNSChangeStepError(c, err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Cloudflare Family DNS applied successfully", DNSFamilyResponse{
+		Foreign: *foreignResult,
+		VPN:     *vpnResult,
 	})
+}
+
+// dnsForwarderCurrentIP returns the first DNS server IP configured on the
+// DNS forwarder named name, and whether such a forwarder with at least one
+// server was found.
+func dnsForwarderCurrentIP(forwarders []routeros.DNSForwarder, name string) (string, bool) {
+	for i := range forwarders {
+		if strings.TrimSpace(forwarders[i].Name) != name || len(forwarders[i].DNSServers) == 0 {
+			continue
+		}
+		return forwarders[i].DNSServers[0], true
+	}
+	return "", false
+}
+
+// changeDNSIPOrNoop calls changeDNSIP, except when oldIP already equals
+// newIP: RouterOS's own "New IP already used by forwarder" conflict check
+// inside changeDNSIP would otherwise reject re-applying an already-current
+// IP, so that case is treated as a successful no-op instead.
+func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
+	if oldIP == newIP {
+		return &DNSChangeResponse{OldIP: oldIP, NewIP: newIP}, nil
+	}
+	return changeDNSIP(client, oldIP, newIP)
 }
 
 // HandleResetDNS godoc

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -403,6 +403,35 @@ func respondDNSChangeStepError(c echo.Context, err error) error {
 	return ErrorResponse(c, http.StatusInternalServerError, "Failed to change DNS IP", err)
 }
 
+// respondDNSChangeStepErrorWithData behaves like respondDNSChangeStepError,
+// but also includes data in the response body. Used when an earlier step
+// already mutated the router before the one that failed (e.g. the Foreign
+// swap in HandleSetFamilyDNS succeeding before the VPN swap fails), so the
+// caller can see what was actually applied rather than assuming nothing was.
+func respondDNSChangeStepErrorWithData(c echo.Context, err error, data interface{}) error {
+	status := http.StatusInternalServerError
+	message := "Failed to change DNS IP"
+	errText := ""
+
+	var stepErr *dnsChangeStepError
+	if errors.As(err, &stepErr) {
+		status = stepErr.status
+		message = stepErr.message
+		if stepErr.err != nil {
+			errText = cleanErrorMessage(stepErr.err.Error())
+		}
+	} else {
+		errText = cleanErrorMessage(err.Error())
+	}
+
+	return c.JSON(status, Response{
+		Status:  status,
+		Message: message,
+		Data:    data,
+		Error:   errText,
+	})
+}
+
 // changeDNSIP replaces oldIP with newIP across /ip/dns servers, the
 // dns-servers list of every DNS forwarder that contains it, the "DNS"
 // firewall address list, every dst-nat NAT rule whose to-addresses is oldIP,
@@ -570,7 +599,10 @@ func changeDNSIP(client *routeros.Client, oldIP, newIP string) (*DNSChangeRespon
 // @Description replaced with the Cloudflare Family Secondary IP (1.0.0.3), across /ip/dns
 // @Description servers, DNS forwarders, the "DNS" firewall address list, dst-nat NAT rules, IP
 // @Description routes, and netwatch probes. A forwarder already set to its target family IP is
-// @Description left unchanged rather than erroring. No request body is required.
+// @Description left unchanged rather than erroring. No request body is required. If the Foreign
+// @Description swap succeeds but the VPN swap then fails, the error response's data still
+// @Description includes the completed Foreign result, so the caller can see what was actually
+// @Description applied to the router.
 // @Tags DNS
 // @Produce json
 // @Security BasicAuth
@@ -607,7 +639,10 @@ func HandleSetFamilyDNS(c echo.Context) error {
 
 	vpnResult, err := changeDNSIPOrNoop(client, vpnIP, dnsFamilySecondaryIP)
 	if err != nil {
-		return respondDNSChangeStepError(c, err)
+		// Foreign was already changed on the router by this point; report it
+		// alongside the error rather than leaving the caller to assume
+		// nothing was applied.
+		return respondDNSChangeStepErrorWithData(c, err, DNSFamilyResponse{Foreign: *foreignResult})
 	}
 
 	return SuccessResponse(c, http.StatusOK, "Cloudflare Family DNS applied successfully", DNSFamilyResponse{

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -31,6 +31,9 @@ const (
 
 	domesticAddressListFreshWindow    = 30 * 24 * time.Hour
 	domesticAddressListMinHealthySize = 1000
+
+	// The adlist URL POST /api/dns/adblock enables/disables.
+	dnsAdBlockURL = "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
 )
 
 // HandleGetDNSInfo godoc
@@ -62,6 +65,89 @@ func HandleGetDNSInfo(c echo.Context) error {
 
 	response := convertDNSInfoResponse(info)
 	return SuccessResponse(c, http.StatusOK, "DNS information retrieved", response)
+}
+
+// HandleSetAdBlock godoc
+// @Summary Enable or disable the StevenBlack hosts adlist ad-blocker
+// @Description Checks the current status of the /ip/dns/adlist entry whose url is
+// @Description https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts, and returns a
+// @Description conflict error if it's already in the requested state. If enabled is true: enables
+// @Description the entry if it exists, or creates it (with ssl-verify=no) and enables it if it
+// @Description doesn't. If enabled is false: disables the entry if it exists, or does nothing if
+// @Description it doesn't.
+// @Tags DNS
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param body body AdBlockRequest true "Desired ad-block state"
+// @Success 200 {object} Response
+// @Failure 400 {object} Response
+// @Failure 409 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/adblock [post].
+func HandleSetAdBlock(c echo.Context) error {
+	var req AdBlockRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+	}
+
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	adLists, err := client.ListDNSAdLists()
+	if err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS adlist entries", err)
+	}
+
+	var existing *routeros.DNSAdList
+	for i := range adLists {
+		if adLists[i].URL == dnsAdBlockURL {
+			existing = &adLists[i]
+			break
+		}
+	}
+
+	currentlyEnabled := existing != nil && !existing.Disabled
+	if currentlyEnabled == req.Enabled {
+		state := "disabled"
+		if req.Enabled {
+			state = "enabled"
+		}
+		return ErrorResponse(c, http.StatusConflict, "Ad-block is already "+state, nil)
+	}
+
+	if req.Enabled {
+		disabled := false
+		if existing != nil {
+			if err := client.UpdateDNSAdList(existing.ID, routeros.DNSAdListUpdateConfig{Disabled: &disabled}); err != nil {
+				return ErrorResponse(c, http.StatusInternalServerError, "Failed to enable ad-block adlist", err)
+			}
+		} else {
+			sslVerify := false
+			if _, err := client.AddDNSAdList(routeros.AddDNSAdListConfig{
+				URL:       dnsAdBlockURL,
+				SSLVerify: &sslVerify,
+				Disabled:  false,
+			}); err != nil {
+				return ErrorResponse(c, http.StatusInternalServerError, "Failed to create ad-block adlist", err)
+			}
+		}
+	} else if existing != nil {
+		disabled := true
+		if err := client.UpdateDNSAdList(existing.ID, routeros.DNSAdListUpdateConfig{Disabled: &disabled}); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Failed to disable ad-block adlist", err)
+		}
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Ad-block state updated successfully", map[string]interface{}{
+		"enabled": req.Enabled,
+	})
 }
 
 // HandleListDNSForwarders godoc

--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -670,7 +670,17 @@ func dnsForwarderCurrentIP(forwarders []routeros.DNSForwarder, name string) (str
 // IP, so that case is treated as a successful no-op instead.
 func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChangeResponse, error) {
 	if oldIP == newIP {
-		return &DNSChangeResponse{OldIP: oldIP, NewIP: newIP}, nil
+		return &DNSChangeResponse{
+			OldIP:                   oldIP,
+			NewIP:                   newIP,
+			Servers:                 []string{},
+			UpdatedForwarders:       []string{},
+			UpdatedDstAddressRoutes: []string{},
+			UpdatedGatewayRoutes:    []string{},
+			UpdatedNetwatchProbes:   []string{},
+			UpdatedAddressListItems: []string{},
+			UpdatedNATRules:         []string{},
+		}, nil
 	}
 	return changeDNSIP(client, oldIP, newIP)
 }

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -238,8 +238,6 @@ var foreignDNSSuggestions = []DNSSuggestion{
 	{IP: "149.112.112.112", Description: "Quad9 DNS"},
 	{IP: "208.67.222.222", Description: "OpenDNS"},
 	{IP: "208.67.220.220", Description: "OpenDNS"},
-	{IP: "8.26.56.26", Description: "Google Secondary"},
-	{IP: "8.20.247.20", Description: "Google Secondary"},
 	{IP: "64.6.64.6", Description: "Verisign Public DNS"},
 	{IP: "64.6.65.6", Description: "Verisign Public DNS"},
 	{IP: "84.200.69.80", Description: "DNS.Watch"},

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -107,6 +107,11 @@ var (
 	}
 )
 
+// AdBlockRequest is the request body for POST /api/dns/adblock.
+type AdBlockRequest struct {
+	Enabled bool `json:"enabled" example:"true"`
+}
+
 // DNSCheckResponse is the response for GET /api/dns/validate.
 type DNSCheckResponse struct {
 	OldIP     string `json:"oldIp"`

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -21,9 +21,10 @@ type UpdateDNSRequest struct {
 
 // DNSForwarderListItem is one entry in the GET /api/dns/list response.
 type DNSForwarderListItem struct {
-	Name    string `json:"name"`
-	IP      string `json:"ip"`
-	Comment string `json:"comment"`
+	Name        string `json:"name"`
+	IP          string `json:"ip"`
+	Description string `json:"description,omitempty"`
+	Comment     string `json:"comment"`
 }
 
 // dnsForwarderType names the three recognized DNS forwarder roles, carried in
@@ -134,6 +135,12 @@ type DNSChangeResponse struct {
 	UpdatedNATRules         []string `json:"updatedNatRules"`
 }
 
+// DNSFamilyResponse is the response for POST /api/dns/family.
+type DNSFamilyResponse struct {
+	Foreign DNSChangeResponse `json:"foreign"`
+	VPN     DNSChangeResponse `json:"vpn"`
+}
+
 // DNSForwarderResult describes one DNS forwarder created by POST /api/dns/reset.
 type DNSForwarderResult struct {
 	ID         string   `json:"id"`
@@ -221,6 +228,8 @@ var foreignDNSSuggestions = []DNSSuggestion{
 	{IP: "1.0.0.1", Description: "Cloudflare Secondary"},
 	{IP: "8.8.8.8", Description: "Google Primary"},
 	{IP: "8.8.4.4", Description: "Google Secondary"},
+	{IP: "1.1.1.3", Description: "Cloudflare Family Primary"},
+	{IP: "1.0.0.3", Description: "Cloudflare Family Secondary"},
 	{IP: "4.2.2.1", Description: "Level3 DNS"},
 	{IP: "4.2.2.2", Description: "Level3 DNS"},
 	{IP: "4.2.2.3", Description: "Level3 DNS"},
@@ -250,6 +259,17 @@ func isKnownDNSSuggestion(ip string, suggestions []DNSSuggestion) bool {
 		}
 	}
 	return false
+}
+
+// dnsSuggestionDescription returns the description of ip in suggestions, or
+// "" if ip isn't one of them.
+func dnsSuggestionDescription(ip string, suggestions []DNSSuggestion) string {
+	for i := range suggestions {
+		if suggestions[i].IP == ip {
+			return suggestions[i].Description
+		}
+	}
+	return ""
 }
 
 func convertDNSInfoResponse(info *routeros.DNSInfo) *DNSInfoResponse {

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -104,6 +104,7 @@ func RegisterRoutes(e *echo.Echo) {
 	dnsGroup.GET("/suggest", handler.HandleSuggestDNS)
 	dnsGroup.GET("/validate", handler.HandleValidateDNS)
 	dnsGroup.POST("/change", handler.HandleChangeDNS)
+	dnsGroup.POST("/family", handler.HandleSetFamilyDNS)
 	dnsGroup.POST("/reset", handler.HandleResetDNS)
 
 	vpnGroup := e.Group("/api/vpn")

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -105,6 +105,7 @@ func RegisterRoutes(e *echo.Echo) {
 	dnsGroup.GET("/validate", handler.HandleValidateDNS)
 	dnsGroup.POST("/change", handler.HandleChangeDNS)
 	dnsGroup.POST("/family", handler.HandleSetFamilyDNS)
+	dnsGroup.POST("/adblock", handler.HandleSetAdBlock)
 	dnsGroup.POST("/reset", handler.HandleResetDNS)
 
 	vpnGroup := e.Group("/api/vpn")

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -2,6 +2,7 @@ package routeros
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +29,40 @@ type DNSForwarder struct {
 	DOHServers    []string `json:"dohServers"`
 	VerifyDOHCert bool     `json:"verifyDohCert"`
 	Comment       string   `json:"comment"`
+}
+
+// AddDNSAdListConfig represents every field that can be set when creating a
+// new /ip/dns/adlist entry. An adlist is either URL-based (URL) or backed by
+// a locally stored file (File); exactly one of them should be supplied.
+type AddDNSAdListConfig struct {
+	URL       string
+	File      string
+	SSLVerify *bool
+	Disabled  bool
+	Comment   string
+}
+
+// DNSAdList represents an /ip/dns/adlist entry.
+type DNSAdList struct {
+	ID         string `json:"id"`
+	URL        string `json:"url"`
+	File       string `json:"file"`
+	SSLVerify  bool   `json:"sslVerify"`
+	MatchCount int    `json:"matchCount"`
+	NameCount  int    `json:"nameCount"`
+	Disabled   bool   `json:"disabled"`
+	Comment    string `json:"comment"`
+}
+
+// DNSAdListUpdateConfig represents every field that can be changed on an
+// existing /ip/dns/adlist entry via UpdateDNSAdList. Only non-nil fields are
+// applied; everything else on the entry is left as it was.
+type DNSAdListUpdateConfig struct {
+	URL       *string
+	File      *string
+	SSLVerify *bool
+	Disabled  *bool
+	Comment   *string
 }
 
 // GetDNSInfo retrieves DNS configuration from RouterOS.
@@ -139,6 +174,132 @@ func (c *Client) AddDNSForwarder(name, dnsServers string, verifyDOHCert bool) (s
 	}
 
 	return id, nil
+}
+
+// AddDNSAdList creates a new /ip/dns/adlist entry and returns its RouterOS
+// .id.
+func (c *Client) AddDNSAdList(config AddDNSAdListConfig) (string, error) {
+	if config.URL == "" && config.File == "" {
+		return "", fmt.Errorf("either URL or File is required")
+	}
+
+	args := []string{}
+
+	if config.URL != "" {
+		args = append(args, "=url="+config.URL)
+	}
+	if config.File != "" {
+		args = append(args, "=file="+config.File)
+	}
+	if config.SSLVerify != nil {
+		if *config.SSLVerify {
+			args = append(args, "=ssl-verify=yes")
+		} else {
+			args = append(args, "=ssl-verify=no")
+		}
+	}
+	if config.Disabled {
+		args = append(args, "=disabled=yes")
+	} else {
+		args = append(args, "=disabled=no")
+	}
+	if config.Comment != "" {
+		args = append(args, "=comment="+config.Comment)
+	}
+
+	id, err := c.Add("/ip/dns/adlist", args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to add DNS adlist entry: %w", err)
+	}
+
+	return id, nil
+}
+
+// ListDNSAdLists retrieves every /ip/dns/adlist entry from RouterOS.
+func (c *Client) ListDNSAdLists() ([]DNSAdList, error) {
+	results, err := c.GetAll("/ip/dns/adlist")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list DNS adlist entries: %w", err)
+	}
+
+	adLists := make([]DNSAdList, 0, len(results))
+	for _, result := range results {
+		matchCount, _ := strconv.Atoi(result["match-count"])
+		nameCount, _ := strconv.Atoi(result["name-count"])
+
+		adLists = append(adLists, DNSAdList{
+			ID:         result[".id"],
+			URL:        result["url"],
+			File:       result["file"],
+			SSLVerify:  result["ssl-verify"] == "yes",
+			MatchCount: matchCount,
+			NameCount:  nameCount,
+			Disabled:   result["disabled"] == "yes",
+			Comment:    result["comment"],
+		})
+	}
+
+	return adLists, nil
+}
+
+// UpdateDNSAdList updates the /ip/dns/adlist entry identified by id (its
+// RouterOS .id) with the non-nil fields of config.
+func (c *Client) UpdateDNSAdList(id string, config DNSAdListUpdateConfig) error {
+	if id == "" {
+		return fmt.Errorf("DNS adlist ID is required")
+	}
+
+	args := []string{"=.id=" + id}
+
+	if config.URL != nil {
+		args = append(args, "=url="+*config.URL)
+	}
+	if config.File != nil {
+		args = append(args, "=file="+*config.File)
+	}
+	if config.SSLVerify != nil {
+		if *config.SSLVerify {
+			args = append(args, "=ssl-verify=yes")
+		} else {
+			args = append(args, "=ssl-verify=no")
+		}
+	}
+	if config.Disabled != nil {
+		if *config.Disabled {
+			args = append(args, "=disabled=yes")
+		} else {
+			args = append(args, "=disabled=no")
+		}
+	}
+	if config.Comment != nil {
+		args = append(args, "=comment="+*config.Comment)
+	}
+
+	if len(args) == 1 {
+		return fmt.Errorf("no configuration parameters provided")
+	}
+
+	_, err := c.Set("/ip/dns/adlist", args...)
+	if err != nil {
+		return fmt.Errorf("failed to update DNS adlist entry %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// RemoveDNSAdList deletes the /ip/dns/adlist entry identified by id (its
+// RouterOS .id).
+func (c *Client) RemoveDNSAdList(id string) error {
+	if id == "" {
+		return fmt.Errorf("DNS adlist ID is required")
+	}
+
+	_, err := c.Remove("/ip/dns/adlist", "=.id="+id)
+	if err != nil {
+		return fmt.Errorf("failed to remove DNS adlist entry %s: %w", id, err)
+	}
+
+	return nil
 }
 
 // RemoveDNSForwarder deletes the /ip/dns/forwarders entry identified by id

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -231,10 +231,10 @@ func (c *Client) ListDNSAdLists() ([]DNSAdList, error) {
 			ID:         result[".id"],
 			URL:        result["url"],
 			File:       result["file"],
-			SSLVerify:  result["ssl-verify"] == "yes",
+			SSLVerify:  parseRouterOSBool(result["ssl-verify"]),
 			MatchCount: matchCount,
 			NameCount:  nameCount,
-			Disabled:   result["disabled"] == "yes",
+			Disabled:   parseRouterOSBool(result["disabled"]),
 			Comment:    result["comment"],
 		})
 	}


### PR DESCRIPTION
* Closes #619

## Add ad-block feature via RouterOS adlist

### Summary
- Add full CRUD support for RouterOS's `/ip/dns/adlist` (domain-based ad-blocking) in `pkg/routeros/dns.go`: `AddDNSAdList`, `ListDNSAdLists`, `UpdateDNSAdList`, `RemoveDNSAdList`, backed by `AddDNSAdListConfig`, `DNSAdList` and `DNSAdListUpdateConfig`.
- Add `POST /api/dns/adblock` to toggle ad-blocking on/off using the [StevenBlack unified hosts list](https://github.com/StevenBlack/hosts) as the adlist source.

### Details
- `enabled: true` — enables the existing StevenBlack adlist entry if present, otherwise creates it (`ssl-verify=no`) and enables it.
- `enabled: false` — disables the existing entry if present; a no-op if it doesn't exist yet.
- Returns `409 Conflict` if the adlist is already in the requested state (checked via a fresh `ListDNSAdLists` lookup before making any change), so callers can't accidentally issue a redundant toggle.
- The target URL is defined once as a package-level const (`dnsAdBlockURL`) in the handler file rather than inlined.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated API controls for enabling and disabling the StevenBlack ad-blocking list.
  * Added Family DNS configuration for Foreign and VPN forwarders.
  * Added support for managing DNS ad lists, including creation, viewing, updating, and removal.
  * DNS forwarder listings now include descriptions for recognized recommendations.
* **Improvements**
  * DNS changes now report step-specific results, including partial completion when part of an update fails.
  * Repeating an already-applied configuration now returns a successful no-op result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->