### PR TITLE
fix(installer): keep Winbox MAC access and neighbor discovery after the LAN split

### DIFF
--- a/scripts/nasnet-lan-baseline.rsc
+++ b/scripts/nasnet-lan-baseline.rsc
@@ -121,6 +121,13 @@
   :if ([:len [/interface/bridge/port find bridge="LANBridgeSplit"]] = 0) do={
     :log warning "nasnet-panel: LANBridgeSplit has no member ports (single-bridge/AP-mode router); reach the panel at the router's current address until the wizard runs"
   }
+  :log info "nasnet-panel: allowing MAC server and neighbor discovery on all interfaces"
+  :do {
+    /ip/neighbor/discovery-settings set discover-interface-list=all
+    /tool/mac-server set allowed-interface-list=all
+  } on-error={
+    :log warning "nasnet-panel: could not allow MAC server and neighbor discovery, Winbox MAC access may be unavailable"
+  }
   :log info "nasnet-panel: LAN baseline applied, gateway is 192.168.10.1"
 }
 :log info "nasnet-panel: routing container DNS (192.168.50.0/24) to 1.0.0.1"


### PR DESCRIPTION
Closes #652

- Set MAC server and neighbor discovery to all interfaces once the LAN baseline finishes, so Winbox MAC access and discovery survive the bridge split
- Applied inside the baseline block, so it runs only when the split is actually built


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LAN baseline configuration to enable MAC server access and neighbor discovery across network interfaces.
  * Added warnings when the LAN baseline configuration cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->