### PR TITLE
fix(fe): change free VPN banner text to Nasnet Panel

### DIFF
--- a/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedClaimDialog.tsx
+++ b/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedClaimDialog.tsx
@@ -83,9 +83,9 @@ export function HyperSpeedClaimDialog({ open, onClose, onClaimed }: Props) {
           <span>Available now</span>
         </span>
         <h3 id="hyper-speed-title" className={styles.title}>
-          FREE Hyper Speed VPN powered by NasNet Connect
+          FREE Hyper Speed VPN powered by Nasnet Panel
         </h3>
-        <p className={styles.subtitle}>Optimized for Starlink & built for NasNet Connect users.</p>
+        <p className={styles.subtitle}>Optimized for Starlink & built for Nasnet Panel users.</p>
       </div>
       <div className={styles.body}>
         <ul className={styles.bullets}>

--- a/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedPromoCard.tsx
+++ b/frontend/src/routes/easy-config/steps/ipmask/HyperSpeedPromoCard.tsx
@@ -9,8 +9,8 @@ export function HyperSpeedPromoCard() {
           <span className={styles.badge}>Hot Deal</span>
           <span>Available now</span>
         </span>
-        <h4 className={styles.title}>FREE Hyper Speed VPN powered by NasNet Connect</h4>
-        <p className={styles.subtitle}>Optimized for Starlink & built for NasNet Connect users.</p>
+        <h4 className={styles.title}>FREE Hyper Speed VPN powered by Nasnet Panel</h4>
+        <p className={styles.subtitle}>Optimized for Starlink & built for Nasnet Panel users.</p>
       </div>
       <Tooltip label="Coming soon">
         <button type="button" className={styles.cta} disabled aria-label="Claim your free VPN">


### PR DESCRIPTION
Closes #646

## Summary

- Free VPN banner now reads "Nasnet Panel" instead of "NasNet Connect"
- Covers both the wizard promo card and the claim dialog shown on the WAN page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated HyperSpeed dialog and promotional card branding from “NasNet Connect” to “Nasnet Panel.”
  - Revised related headlines and subtitles to reflect the updated branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->