### PR TITLE
feat(fe): add profile guidance to the New VPN user modal

### DIFF
--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.module.scss
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.module.scss
@@ -1,0 +1,31 @@
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  line-height: 1.5;
+}
+
+.alertIcon {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.alertInfo {
+  border-color: color-mix(in srgb, var(--color-info) 35%, transparent);
+  background: color-mix(in srgb, var(--color-info) 10%, transparent);
+  color: var(--color-text);
+}
+
+.alertInfo .alertIcon {
+  color: var(--color-info);
+}
+
+.alertDanger {
+  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  color: var(--color-danger);
+}

--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Info, TriangleAlert } from 'lucide-react';
 import {
   Button,
   Dialog,
@@ -22,8 +23,24 @@ import {
   type VPNProfileResponse,
   type VPNUserResponse,
 } from '../../../api';
+import styles from './UserFormDialog.module.scss';
 
 const PREFERRED_PROFILE = 'VPN-VPN';
+
+const PROFILE_HINTS: Record<string, { tone: 'info' | 'danger'; text: string }> = {
+  'VPN-VPN': {
+    tone: 'info',
+    text: 'All of the user’s traffic is routed through the outbound VPN.',
+  },
+  'VPN-Split': {
+    tone: 'info',
+    text: 'Foreign traffic is routed through the outbound VPN and domestic traffic through the domestic link.',
+  },
+  'VPN-Foreign': {
+    tone: 'danger',
+    text: 'All of the user’s traffic is routed through Starlink, which can expose your identity and Starlink usage. Use with caution.',
+  },
+};
 
 interface Draft {
   name: string;
@@ -104,6 +121,8 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
     return options;
   }, [profiles, user?.profile]);
 
+  const profileHint = PROFILE_HINTS[draft.profile];
+
   const errors = useMemo(
     () => ({
       name: draft.name.trim() === '' ? 'Name is required.' : null,
@@ -182,6 +201,30 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
         <FormError role="alert">{loadError}</FormError>
       ) : (
         <FieldStack>
+          <div className={`${styles.alert} ${styles.alertInfo}`}>
+            <Info size={16} aria-hidden className={styles.alertIcon} />
+            <span>
+              VPN users apply to OpenVPN, L2TP and SSTP. For WireGuard, open the WireGuard server
+              and add a peer instead.
+            </span>
+          </div>
+          {profileHint ? (
+            <div
+              className={`${styles.alert} ${
+                profileHint.tone === 'danger' ? styles.alertDanger : styles.alertInfo
+              }`}
+              role={profileHint.tone === 'danger' ? 'alert' : undefined}
+            >
+              {profileHint.tone === 'danger' ? (
+                <TriangleAlert size={16} aria-hidden className={styles.alertIcon} />
+              ) : (
+                <Info size={16} aria-hidden className={styles.alertIcon} />
+              )}
+              <span>
+                <strong>{draft.profile}</strong> {profileHint.text}
+              </span>
+            </div>
+          ) : null}
           <FieldRow>
             <Label>
               <span>Name</span>


### PR DESCRIPTION
Closes #647


Profile | Light | Dark
-- | -- | --
Normal |  <img width="620" height="354" alt="4-other-profile-dark" src="https://github.com/user-attachments/assets/666152a8-32b5-4ac7-8637-9102fcc7f538" /> |  <img width="620" height="354" alt="4-other-profile-light" src="https://github.com/user-attachments/assets/b2ca6f12-8e59-4a5f-b3e4-39388f844f15" />
VPN-VPN |  <img width="620" height="404" alt="1-vpn-vpn-dark" src="https://github.com/user-attachments/assets/76f3d90e-f99c-455d-bba6-dd6d8c868e9e" /> |  <img width="620" height="404" alt="1-vpn-vpn-light" src="https://github.com/user-attachments/assets/19026366-426b-4e21-a9ff-591faa5ff058" />
VPN-Split | <img width="620" height="422" alt="2-vpn-split-dark" src="https://github.com/user-attachments/assets/b55a8fd6-b948-4af0-ac0f-ab2afcf9470e" /> |  <img width="620" height="422" alt="2-vpn-split-light" src="https://github.com/user-attachments/assets/3023d450-061f-4cbf-bf22-24f92625d235" />
VPN-Foreign | <img width="620" height="422" alt="3-vpn-foreign-dark" src="https://github.com/user-attachments/assets/a14dd649-181f-4774-84e2-73cd93a8e70c" /> | <img width="620" height="422" alt="3-vpn-foreign-light" src="https://github.com/user-attachments/assets/29aaf7b2-ef8b-4de2-9248-21a6108d5d1b" />


## Summary

- static note that VPN users cover OpenVPN, L2TP and SSTP, with WireGuard pointed at add-peer on the server
- second alert describes the selected profile, switching to a danger tone for VPN-Foreign to warn about Starlink exposure
- shown in both the create and edit dialogs