### PR TITLE
fix(be): Don't delete default profile when deleting ovpn server

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1985,7 +1985,7 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 				}
 			}
 		}
-		if profileName != "" {
+		if profileName != "" && profileName != "default" {
 			_ = client.RemovePppProfile(profileName)
 		}
 		if poolName != "" {


### PR DESCRIPTION
* Fixes #658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenVPN task rollback now preserves the RouterOS default PPP profile while still cleaning up eligible non-default profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->