### PR TITLE
feat(be): Added an endpoint to flush DNS cache 

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -67,6 +67,33 @@ func HandleGetDNSInfo(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "DNS information retrieved", response)
 }
 
+// HandleFlushDNSCache godoc
+// @Summary Clear the RouterOS DNS cache
+// @Description Runs /ip/dns/cache/flush on the RouterOS device
+// @Tags DNS
+// @Produce json
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Success 200 {object} Response
+// @Failure 401 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/dns/cache [delete].
+func HandleFlushDNSCache(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	if err := client.FlushDNSCache(); err != nil {
+		if IsCredentialError(err) {
+			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
+		}
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to flush DNS cache", err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "DNS cache cleared successfully", nil)
+}
+
 // HandleSetAdBlock godoc
 // @Summary Enable or disable the StevenBlack hosts adlist ad-blocker
 // @Description Checks the current status of the /ip/dns/adlist entry whose url is

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -106,6 +106,7 @@ func RegisterRoutes(e *echo.Echo) {
 	dnsGroup.POST("/change", handler.HandleChangeDNS)
 	dnsGroup.POST("/family", handler.HandleSetFamilyDNS)
 	dnsGroup.POST("/adblock", handler.HandleSetAdBlock)
+	dnsGroup.DELETE("/cache", handler.HandleFlushDNSCache)
 	dnsGroup.POST("/reset", handler.HandleResetDNS)
 
 	vpnGroup := e.Group("/api/vpn")

--- a/backend/pkg/routeros/dns.go
+++ b/backend/pkg/routeros/dns.go
@@ -115,6 +115,16 @@ func (c *Client) UpdateDNSConfig(config DNSUpdateConfig) error {
 	return nil
 }
 
+// FlushDNSCache clears the RouterOS DNS cache (/ip/dns/cache/flush).
+func (c *Client) FlushDNSCache() error {
+	_, err := c.Execute("/ip/dns/cache/flush")
+	if err != nil {
+		return fmt.Errorf("failed to flush DNS cache: %w", err)
+	}
+
+	return nil
+}
+
 // ListDNSForwarders retrieves every named DNS forwarder from /ip/dns/forwarders.
 func (c *Client) ListDNSForwarders() ([]DNSForwarder, error) {
 	results, err := c.GetAll("/ip/dns/forwarders")


### PR DESCRIPTION
* Closes #649
* Added an endpoint to flush DNS cache 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to flush the RouterOS DNS cache.
  * Reports clear success and error responses for completed requests, credential issues, and other failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->