### PR TITLE
fix(installer): Set fallback DNS servers when the router has none

### DIFF
--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -38,6 +38,9 @@ const (
 	lanDstNet      = "192.168.0.0/16"
 	lanBaselineRsc = "nasnet-lan-baseline.rsc"
 
+	fallbackDNSServers = "1.1.1.1,1.0.0.1"
+	dnsSettleDelay     = 3 * time.Second
+
 	commentTag        = "nasnet-panel-installer"
 	minFreeMB         = 30
 	minROSMajor       = 7

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -726,12 +726,16 @@ func (e *Engine) checkVethMenu() error {
 }
 
 func (e *Engine) ensureDNS() error {
-	out, err := e.cl.RunRaw(":put [/ip/dns/get servers]", 15*time.Second)
+	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])`, 15*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to read DNS servers: %w", err)
 	}
-	if strings.TrimSpace(out) != "" {
-		e.log("DNS servers %s (exists)", strings.TrimSpace(out))
+	count := strings.TrimSpace(out)
+	if count == "" {
+		return fmt.Errorf("could not read DNS servers from the router")
+	}
+	if count[0] >= '1' && count[0] <= '9' {
+		e.log("router already has DNS servers configured")
 		return nil
 	}
 	if e.opts.DryRun {

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -726,7 +726,7 @@ func (e *Engine) checkVethMenu() error {
 }
 
 func (e *Engine) ensureDNS() error {
-	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :local h ""; :do { :set h [/ip/dns/get use-doh-server] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d] + [:len $h])`, 15*time.Second)
+	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])`, 15*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to read DNS servers: %w", err)
 	}

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -730,11 +730,11 @@ func (e *Engine) ensureDNS() error {
 	if err != nil {
 		return fmt.Errorf("failed to read DNS servers: %w", err)
 	}
-	count := strings.TrimSpace(out)
-	if count == "" {
-		return fmt.Errorf("could not read DNS servers from the router")
+	count, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("could not read DNS servers from the router: %q", strings.TrimSpace(out))
 	}
-	if count[0] >= '1' && count[0] <= '9' {
+	if count > 0 {
 		e.log("router already has DNS servers configured")
 		return nil
 	}

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -726,7 +726,7 @@ func (e *Engine) checkVethMenu() error {
 }
 
 func (e *Engine) ensureDNS() error {
-	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])`, 15*time.Second)
+	out, err := e.cl.RunChecked(":put ([:len [/ip/dns/get servers]] + [:len [/ip/dns/get dynamic-servers]])", 15*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to read DNS servers: %w", err)
 	}

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -725,8 +725,31 @@ func (e *Engine) checkVethMenu() error {
 	return fmt.Errorf("the router has no /interface/veth menu, so the container package is not active (device-mode container is %s). Check the container package under System > Packages, restart the router, then run the installer again", state)
 }
 
+func (e *Engine) ensureDNS() error {
+	out, err := e.cl.RunRaw(":put [/ip/dns/get servers]", 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to read DNS servers: %w", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		e.log("DNS servers %s (exists)", strings.TrimSpace(out))
+		return nil
+	}
+	if e.opts.DryRun {
+		e.log("[dry-run] would set DNS servers to %s", fallbackDNSServers)
+		return nil
+	}
+	if out, err := e.cl.RunChecked(fmt.Sprintf("/ip/dns/set servers=%s", fallbackDNSServers), 15*time.Second); err != nil {
+		return fmt.Errorf("failed to set DNS servers: %w (%s)", err, strings.TrimSpace(out))
+	}
+	e.log("set DNS servers to %s", fallbackDNSServers)
+	return e.sleep(dnsSettleDelay)
+}
+
 func (e *Engine) stepNetwork() error {
 	if err := e.checkVethMenu(); err != nil {
+		return err
+	}
+	if err := e.ensureDNS(); err != nil {
 		return err
 	}
 	if err := e.ensure(fmt.Sprintf("veth %s (%s)", vethName, vethAddrCIDR),

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -726,7 +726,7 @@ func (e *Engine) checkVethMenu() error {
 }
 
 func (e *Engine) ensureDNS() error {
-	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])`, 15*time.Second)
+	out, err := e.cl.RunChecked(`:local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :local h ""; :do { :set h [/ip/dns/get use-doh-server] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d] + [:len $h])`, 15*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to read DNS servers: %w", err)
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -923,7 +923,7 @@ check_veth_menu() {
 
 ensure_dns() {
   local count
-  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])' 2>/dev/null || true)")"
+  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :local h ""; :do { :set h [/ip/dns/get use-doh-server] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d] + [:len $h])' 2>/dev/null || true)")"
   if [[ "$count" =~ ^[1-9] ]]; then
     printf '  \033[32m✓\033[0m DNS servers already configured\n'
     return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -922,11 +922,14 @@ check_veth_menu() {
 }
 
 ensure_dns() {
-  local servers
-  servers="$(trim "$(ros_cmd ':put [/ip/dns/get servers]' 2>/dev/null || true)")"
-  if [[ -n "$servers" ]]; then
-    printf '  \033[32m✓\033[0m DNS servers %s (exists)\n' "$servers"
+  local count
+  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])' 2>/dev/null || true)")"
+  if [[ "$count" =~ ^[1-9] ]]; then
+    printf '  \033[32m✓\033[0m DNS servers already configured\n'
     return 0
+  fi
+  if [[ ! "$count" =~ ^0 ]]; then
+    err "could not read DNS servers from the router"; return 1
   fi
   if (( DRY_RUN )); then
     printf '  + DNS servers %s (would set)\n' "$FALLBACK_DNS_SERVERS"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -923,7 +923,7 @@ check_veth_menu() {
 
 ensure_dns() {
   local count
-  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :local h ""; :do { :set h [/ip/dns/get use-doh-server] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d] + [:len $h])' 2>/dev/null || true)")"
+  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])' 2>/dev/null || true)")"
   if [[ "$count" =~ ^[1-9] ]]; then
     printf '  \033[32m✓\033[0m DNS servers already configured\n'
     return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -923,7 +923,7 @@ check_veth_menu() {
 
 ensure_dns() {
   local count
-  count="$(trim "$(ros_cmd ':local d ""; :do { :set d [/ip/dns/get dynamic-servers] } on-error={}; :put ([:len [/ip/dns/get servers]] + [:len $d])' 2>/dev/null || true)")"
+  count="$(trim "$(ros_cmd ':put ([:len [/ip/dns/get servers]] + [:len [/ip/dns/get dynamic-servers]])' 2>/dev/null || true)")"
   if [[ "$count" =~ ^[1-9] ]]; then
     printf '  \033[32m✓\033[0m DNS servers already configured\n'
     return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,9 @@ LAN_BRIDGE="LANBridgeSplit"
 LAN_BRIDGE_IP="192.168.10.1"
 LAN_BASELINE_RSC="nasnet-lan-baseline.rsc"
 
+FALLBACK_DNS_SERVERS="1.1.1.1,1.0.0.1"
+DNS_SETTLE_DELAY=3
+
 COMMENT_TAG="nasnet-panel-installer"
 MIN_FREE_MB=30
 DEVICE_MODE_TIMEOUT=120
@@ -918,11 +921,30 @@ check_veth_menu() {
   return 1
 }
 
+ensure_dns() {
+  local servers
+  servers="$(trim "$(ros_cmd ':put [/ip/dns/get servers]' 2>/dev/null || true)")"
+  if [[ -n "$servers" ]]; then
+    printf '  \033[32m✓\033[0m DNS servers %s (exists)\n' "$servers"
+    return 0
+  fi
+  if (( DRY_RUN )); then
+    printf '  + DNS servers %s (would set)\n' "$FALLBACK_DNS_SERVERS"
+    return 0
+  fi
+  if ! spin "DNS servers ${FALLBACK_DNS_SERVERS}" ros_cmd "/ip/dns/set servers=${FALLBACK_DNS_SERVERS}"; then
+    err "failed to set DNS servers"; return 1
+  fi
+  sleep "$DNS_SETTLE_DELAY"
+}
+
 configure_network() {
   log ""
   log "Configuring network ..."
 
   check_veth_menu || exit 1
+
+  ensure_dns || exit 1
 
   ros_ensure "veth ${VETH_NAME} (${VETH_ADDR_CIDR})" \
     /interface/veth "name=${VETH_NAME}" \


### PR DESCRIPTION
## Summary

- installer sets 1.1.1.1,1.0.0.1 as DNS when the router has neither static nor dynamic servers
- without a resolver the container never comes up and the start/health-check step spins until timeout
- same fallback the LAN baseline already applies, moved early enough to prevent the hang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer network setup by correctly handling static, dynamic, and DoH-only DNS configurations.
  * Preserves existing DNS settings and applies fallback DNS servers when bootstrap DNS is unavailable.
  * Fails safely when DNS checks cannot be completed.
  * Waits briefly for DNS changes to take effect.
  * Dry-run mode now reports DNS configuration actions.
  * Configures DNS before creating networking resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->