### PR TITLE
feat(be): Friendly name for wireguard peers

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -874,6 +874,11 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		interfaceName += "-wg-client"
 	}
 
+	peerCount, err := client.CountWireGuardPeers(interfaceName)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+	}
+
 	config := routeros.WireGuardClientConfig{
 		Name:       interfaceName,
 		PrivateKey: req.InterfacePrivateKey,
@@ -898,10 +903,6 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to add IP address to interface", err)
 	}
 
-	peerCount, err := client.CountWireGuardPeers(wireguard.Name)
-	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
-	}
 	peerName := fmt.Sprintf("%s-peer%d", wireguard.Name, peerCount+1)
 
 	var publicKey *string

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -898,7 +898,11 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to add IP address to interface", err)
 	}
 
-	peerName := wireguard.Name + "-peer"
+	peerCount, err := client.CountWireGuardPeers(wireguard.Name)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+	}
+	peerName := fmt.Sprintf("%s-peer%d", wireguard.Name, peerCount+1)
 
 	var publicKey *string
 	if req.PeerPublicKey == nil {
@@ -1423,7 +1427,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	if req.Name != nil && *req.Name != "" {
 		peerName = *req.Name
 	} else {
-		peerName = utils.RandString(8)
+		peerName = utils.GenerateName(2, " ", utils.PascalCase)
 	}
 
 	// Determine private key
@@ -1755,7 +1759,7 @@ func HandleImportWireGuardConfig(c echo.Context) error {
 		}
 
 		persistentKeepalive := int(peer.PersistentKeepalive)
-		peerName := publicKey[:8]
+		peerName := fmt.Sprintf("%s-peer%d", wg.Name, i+1)
 
 		config := routeros.WireGuardPeerConfig{
 			InterfaceName:       wg.Name,


### PR DESCRIPTION
* Closes #651
* Wireguard server peers now have two word friendly name instead of random generated string
* Wireguard client peers now have [server-name]-peer[no] names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WireGuard client peer names now include an incrementing peer count.
  * WireGuard server peer names now use generated PascalCase names.
  * Imported WireGuard peers now use indexed names based on the interface.

* **Bug Fixes**
  * WireGuard peer-counting failures now return an HTTP 500 response without creating network resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->