### PR TITLE
fix(be): Assign local IP to wireguard server peers

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"strings"
@@ -1413,10 +1414,13 @@ func nextWireGuardClientAddress(interfaceCIDR string, offset int) (string, error
 	networkAddr := binary.BigEndian.Uint32(ipNet.IP.To4())
 	broadcastAddr := networkAddr | (^uint32(0) >> uint(ones)) //nolint:gosec // G115: ones is 0-32, guaranteed by net.ParseCIDR
 
-	candidate := binary.BigEndian.Uint32(ip4) + uint32(offset) //nolint:gosec // G115: offset is validated non-negative above
-	if candidate >= broadcastAddr {
+	// Do the arithmetic in a wider type so a large offset can't silently wrap
+	// uint32 and land back inside the subnet's valid range.
+	candidate64 := uint64(binary.BigEndian.Uint32(ip4)) + uint64(offset)
+	if candidate64 > uint64(math.MaxUint32) || candidate64 >= uint64(broadcastAddr) {
 		return "", fmt.Errorf("no available client IP addresses left in the %s subnet", interfaceCIDR)
 	}
+	candidate := uint32(candidate64)
 
 	clientIP := make(net.IP, 4)
 	binary.BigEndian.PutUint32(clientIP, candidate)

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1390,6 +1390,28 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "WireGuard peers retrieved successfully", response)
 }
 
+// wireGuardUsedClientAddresses collects every client address already in use
+// across peers, as plain IPs (no CIDR suffix), so nextWireGuardClientAddress
+// can avoid reassigning one. A peer's ClientAddress may itself hold more than
+// one comma-separated value; each is split, trimmed, and reserved on its own,
+// with empty entries ignored.
+func wireGuardUsedClientAddresses(peers []routeros.WireGuardPeerInfo) map[string]struct{} {
+	used := make(map[string]struct{}, len(peers))
+	for i := range peers {
+		for _, addr := range strings.Split(peers[i].ClientAddress, ",") {
+			addr = strings.TrimSpace(addr)
+			if addr == "" {
+				continue
+			}
+			if parsedIP, _, err := net.ParseCIDR(addr); err == nil {
+				addr = parsedIP.String()
+			}
+			used[addr] = struct{}{}
+		}
+	}
+	return used
+}
+
 // wireGuardPeerCreationLocks holds one *sync.Mutex per WireGuard interface
 // name, lazily created. Locking on the interface name (rather than a single
 // global lock) serializes peer creation for that interface only, so
@@ -1542,17 +1564,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list WireGuard peers", err)
 	}
 
-	usedAddresses := make(map[string]struct{}, len(existingPeers))
-	for i := range existingPeers {
-		addr := strings.TrimSpace(existingPeers[i].ClientAddress)
-		if addr == "" {
-			continue
-		}
-		if parsedIP, _, err := net.ParseCIDR(addr); err == nil {
-			addr = parsedIP.String()
-		}
-		usedAddresses[addr] = struct{}{}
-	}
+	usedAddresses := wireGuardUsedClientAddresses(existingPeers)
 
 	clientAddress, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, usedAddresses)
 	if err != nil {
@@ -1568,7 +1580,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	if req.Name != nil && *req.Name != "" {
 		peerName = *req.Name
 	} else {
-		peerName = fmt.Sprintf("%s-peer%d", interfaceName, len(existingPeers)+1)
+		peerName = utils.GenerateName(2, " ", utils.PascalCase)
 	}
 
 	// Determine private key

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1390,6 +1390,26 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "WireGuard peers retrieved successfully", response)
 }
 
+// wireGuardPeerCreationLocks holds one *sync.Mutex per WireGuard interface
+// name, lazily created. Locking on the interface name (rather than a single
+// global lock) serializes peer creation for that interface only, so
+// concurrent requests for the same interface can't race to pick and create
+// the same clientAddress, while requests against different interfaces still
+// proceed independently.
+var wireGuardPeerCreationLocks sync.Map
+
+// lockWireGuardInterfacePeers acquires the per-interface lock for
+// interfaceName and returns a func that releases it.
+func lockWireGuardInterfacePeers(interfaceName string) func() {
+	lockAny, _ := wireGuardPeerCreationLocks.LoadOrStore(interfaceName, &sync.Mutex{})
+	lock, ok := lockAny.(*sync.Mutex)
+	if !ok {
+		lock = &sync.Mutex{}
+	}
+	lock.Lock()
+	return lock.Unlock
+}
+
 // nextWireGuardClientAddress returns the first unused IPv4 address after the
 // WireGuard interface's own address (given as a CIDR, e.g. "10.0.0.1/24"),
 // staying within that address's subnet. Used holds the addresses already
@@ -1510,6 +1530,12 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to parse WireGuard interface IP address", err)
 	}
 	clientDNS := interfaceIP.String()
+
+	// Serialize the read-allocate-create sequence below per interface, so
+	// concurrent requests for the same interface can't both allocate the
+	// same clientAddress before either has created its peer.
+	unlockInterfacePeers := lockWireGuardInterfacePeers(interfaceName)
+	defer unlockInterfacePeers()
 
 	existingPeers, err := client.GetWireGuardPeers(interfaceName)
 	if err != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1390,18 +1390,17 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "WireGuard peers retrieved successfully", response)
 }
 
-// nextWireGuardClientAddress returns the IPv4 address offset addresses after
-// the WireGuard interface's own address (given as a CIDR, e.g. "10.0.0.1/24"),
-// staying within that address's subnet. Offset is typically the 1-based
-// position of the client being created (peer count + 1), so the first client
-// lands right after the interface's own address. Returns an error once the
+// nextWireGuardClientAddress returns the first unused IPv4 address after the
+// WireGuard interface's own address (given as a CIDR, e.g. "10.0.0.1/24"),
+// staying within that address's subnet. Used holds the addresses already
+// assigned to existing peers (as plain IPs, no CIDR suffix); walking the
+// range and skipping those already in use, rather than deriving an address
+// solely from the peer count, keeps addresses correct even after peers in
+// the middle of the range have been deleted. If used is empty, the result is
+// simply the interface's own address + 1. Returns an error once the
 // subnet's usable range (up to, but excluding, its broadcast address) is
 // exhausted.
-func nextWireGuardClientAddress(interfaceCIDR string, offset int) (string, error) {
-	if offset < 0 {
-		return "", fmt.Errorf("offset must be non-negative")
-	}
-
+func nextWireGuardClientAddress(interfaceCIDR string, used map[string]struct{}) (string, error) {
 	ip, ipNet, err := net.ParseCIDR(interfaceCIDR)
 	if err != nil {
 		return "", fmt.Errorf("invalid interface address %q: %w", interfaceCIDR, err)
@@ -1414,18 +1413,23 @@ func nextWireGuardClientAddress(interfaceCIDR string, offset int) (string, error
 	ones, _ := ipNet.Mask.Size() // guaranteed 0-32 by net.ParseCIDR
 	networkAddr := binary.BigEndian.Uint32(ipNet.IP.To4())
 	broadcastAddr := networkAddr | (^uint32(0) >> uint(ones)) //nolint:gosec // G115: ones is 0-32, guaranteed by net.ParseCIDR
+	base := uint64(binary.BigEndian.Uint32(ip4))
 
-	// Do the arithmetic in a wider type so a large offset can't silently wrap
-	// uint32 and land back inside the subnet's valid range.
-	candidate64 := uint64(binary.BigEndian.Uint32(ip4)) + uint64(offset)
-	if candidate64 > uint64(math.MaxUint32) || candidate64 >= uint64(broadcastAddr) {
-		return "", fmt.Errorf("no available client IP addresses left in the %s subnet", interfaceCIDR)
+	// Arithmetic is done in a wider type so a large offset can't silently
+	// wrap uint32 and land back inside the subnet's valid range.
+	for offset := uint64(1); ; offset++ {
+		candidate64 := base + offset
+		if candidate64 > uint64(math.MaxUint32) || candidate64 >= uint64(broadcastAddr) {
+			return "", fmt.Errorf("no available client IP addresses left in the %s subnet", interfaceCIDR)
+		}
+
+		clientIP := make(net.IP, 4)
+		binary.BigEndian.PutUint32(clientIP, uint32(candidate64))
+		candidateAddr := clientIP.String()
+		if _, taken := used[candidateAddr]; !taken {
+			return candidateAddr, nil
+		}
 	}
-	candidate := uint32(candidate64)
-
-	clientIP := make(net.IP, 4)
-	binary.BigEndian.PutUint32(clientIP, candidate)
-	return clientIP.String(), nil
 }
 
 // HandleCreateWireGuardServerPeer creates a new peer on a WireGuard server interface.
@@ -1507,12 +1511,24 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	}
 	clientDNS := interfaceIP.String()
 
-	peerCount, err := client.CountWireGuardPeers(interfaceName)
+	existingPeers, err := client.GetWireGuardPeers(interfaceName)
 	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list WireGuard peers", err)
 	}
 
-	clientAddress, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, peerCount+1)
+	usedAddresses := make(map[string]struct{}, len(existingPeers))
+	for i := range existingPeers {
+		addr := strings.TrimSpace(existingPeers[i].ClientAddress)
+		if addr == "" {
+			continue
+		}
+		if parsedIP, _, err := net.ParseCIDR(addr); err == nil {
+			addr = parsedIP.String()
+		}
+		usedAddresses[addr] = struct{}{}
+	}
+
+	clientAddress, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, usedAddresses)
 	if err != nil {
 		return ErrorResponse(c, http.StatusConflict, "Failed to determine client IP address", err)
 	}

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"net/http"
@@ -1387,9 +1388,49 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "WireGuard peers retrieved successfully", response)
 }
 
+// nextWireGuardClientAddress returns the IPv4 address offset addresses after
+// the WireGuard interface's own address (given as a CIDR, e.g. "10.0.0.1/24"),
+// staying within that address's subnet. Offset is typically the 1-based
+// position of the client being created (peer count + 1), so the first client
+// lands right after the interface's own address. Returns an error once the
+// subnet's usable range (up to, but excluding, its broadcast address) is
+// exhausted.
+func nextWireGuardClientAddress(interfaceCIDR string, offset int) (string, error) {
+	if offset < 0 {
+		return "", fmt.Errorf("offset must be non-negative")
+	}
+
+	ip, ipNet, err := net.ParseCIDR(interfaceCIDR)
+	if err != nil {
+		return "", fmt.Errorf("invalid interface address %q: %w", interfaceCIDR, err)
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", fmt.Errorf("interface address %q is not an IPv4 address", interfaceCIDR)
+	}
+
+	ones, _ := ipNet.Mask.Size() // guaranteed 0-32 by net.ParseCIDR
+	networkAddr := binary.BigEndian.Uint32(ipNet.IP.To4())
+	broadcastAddr := networkAddr | (^uint32(0) >> uint(ones)) //nolint:gosec // G115: ones is 0-32, guaranteed by net.ParseCIDR
+
+	candidate := binary.BigEndian.Uint32(ip4) + uint32(offset) //nolint:gosec // G115: offset is validated non-negative above
+	if candidate >= broadcastAddr {
+		return "", fmt.Errorf("no available client IP addresses left in the %s subnet", interfaceCIDR)
+	}
+
+	clientIP := make(net.IP, 4)
+	binary.BigEndian.PutUint32(clientIP, candidate)
+	return clientIP.String(), nil
+}
+
 // HandleCreateWireGuardServerPeer creates a new peer on a WireGuard server interface.
 // @Summary Create WireGuard Server Peer
-// @Description Add a new peer to an existing WireGuard server interface with auto-generated keys
+// @Description Add a new peer to an existing WireGuard server interface with auto-generated keys.
+// @Description The client's address, DNS, keepalive, allowed-address and listen-port are all
+// @Description derived automatically: address is the next free IP after the interface's own
+// @Description address within its subnet, DNS is the interface's own address, keepalive is 30,
+// @Description allowed-address matches the peer's own allowedAddresses, and listen-port matches
+// @Description the interface's listen port. Only the client endpoint may be supplied by the caller.
 // @Tags VPN
 // @Security BasicAuth
 // @Param X-RouterOS-Host header string true "RouterOS host address"
@@ -1398,6 +1439,7 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 // @Success 200 {object} Response{data=WireGuardServerPeerCreateResponse}
 // @Failure 400 {object} Response
 // @Failure 404 {object} Response
+// @Failure 409 {object} Response
 // @Failure 500 {object} Response
 // @Router /api/vpn/wireguard/peer [post].
 func HandleCreateWireGuardServerPeer(c echo.Context) error {
@@ -1415,13 +1457,61 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusBadRequest, "WireGuard interface name is required", nil)
 	}
 
+	if req.AllowedAddresses == "" {
+		req.AllowedAddresses = "0.0.0.0/0"
+	}
+
+	if req.ClientEndpoint != nil && req.ClientEndpointIP != nil {
+		return ErrorResponse(c, http.StatusBadRequest, "Only one of clientEndpoint or clientEndpointIp may be supplied", nil)
+	}
+
+	if req.ClientEndpoint != nil {
+		if err := utils.ValidateIPPort(*req.ClientEndpoint); err != nil {
+			return ErrorResponse(c, http.StatusBadRequest, "clientEndpoint must be in ip:port format", err)
+		}
+	}
+
 	interfaceName := req.InterfaceName
 
 	// Verify the WireGuard interface exists
-	_, err = client.GetWireGuard(interfaceName)
+	wg, err := client.GetWireGuard(interfaceName)
 	if err != nil {
 		return ErrorResponse(c, http.StatusNotFound, "WireGuard interface not found", err)
 	}
+
+	clientEndpoint := req.ClientEndpoint
+	if req.ClientEndpointIP != nil && *req.ClientEndpointIP != "" {
+		derived := fmt.Sprintf("%s:%d", *req.ClientEndpointIP, wg.ListenPort)
+		clientEndpoint = &derived
+	}
+
+	interfaceAddresses, err := client.GetIPAddressesByInterface(interfaceName)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to get WireGuard interface IP address", err)
+	}
+	if len(interfaceAddresses) == 0 {
+		return ErrorResponse(c, http.StatusBadRequest, "WireGuard interface has no IP address configured", nil)
+	}
+
+	interfaceIP, _, err := net.ParseCIDR(interfaceAddresses[0].Address)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to parse WireGuard interface IP address", err)
+	}
+	clientDNS := interfaceIP.String()
+
+	peerCount, err := client.CountWireGuardPeers(interfaceName)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+	}
+
+	clientAddress, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, peerCount+1)
+	if err != nil {
+		return ErrorResponse(c, http.StatusConflict, "Failed to determine client IP address", err)
+	}
+
+	clientKeepalive := 30
+	clientListenPort := wg.ListenPort
+	clientAllowedAddress := req.AllowedAddresses
 
 	// Determine peer name
 	var peerName string
@@ -1487,12 +1577,12 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		PersistentKeepalive:  req.PersistentKeepalive,
 		SavePrivateKey:       req.SavePrivateKey != nil && *req.SavePrivateKey,
 		Disabled:             req.Disabled,
-		ClientEndpoint:       req.ClientEndpoint,
-		ClientAddress:        req.ClientAddress,
-		ClientKeepalive:      req.ClientKeepalive,
-		ClientAllowedAddress: req.ClientAllowedAddress,
-		ClientListenPort:     req.ClientListenPort,
-		ClientDNS:            req.ClientDNS,
+		ClientEndpoint:       clientEndpoint,
+		ClientAddress:        &clientAddress,
+		ClientKeepalive:      &clientKeepalive,
+		ClientAllowedAddress: &clientAllowedAddress,
+		ClientListenPort:     &clientListenPort,
+		ClientDNS:            &clientDNS,
 		Comment:              req.Comment,
 		Responder:            req.Responder,
 	}
@@ -1508,16 +1598,27 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		preSharedKeyResponse = *preSharedKey
 	}
 
+	var clientEndpointResponse string
+	if clientEndpoint != nil {
+		clientEndpointResponse = *clientEndpoint
+	}
+
 	response := WireGuardServerPeerCreateResponse{
-		Name:             peerName,
-		InterfaceName:    interfaceName,
-		PublicKey:        publicKey,
-		PrivateKey:       privateKey,
-		PreSharedKey:     preSharedKeyResponse,
-		EndpointAddress:  req.EndpointAddress,
-		EndpointPort:     req.EndpointPort,
-		AllowedAddresses: req.AllowedAddresses,
-		Disabled:         false,
+		Name:                 peerName,
+		InterfaceName:        interfaceName,
+		PublicKey:            publicKey,
+		PrivateKey:           privateKey,
+		PreSharedKey:         preSharedKeyResponse,
+		EndpointAddress:      req.EndpointAddress,
+		EndpointPort:         req.EndpointPort,
+		AllowedAddresses:     req.AllowedAddresses,
+		ClientAddress:        clientAddress,
+		ClientDNS:            clientDNS,
+		ClientKeepalive:      clientKeepalive,
+		ClientAllowedAddress: clientAllowedAddress,
+		ClientListenPort:     clientListenPort,
+		ClientEndpoint:       clientEndpointResponse,
+		Disabled:             false,
 	}
 
 	if req.PersistentKeepalive != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1627,6 +1627,14 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		clientEndpointResponse = *clientEndpoint
 	}
 
+	// req.Disabled reflects what was actually sent to RouterOS; when it's
+	// nil the disabled property was omitted from the add call, so the
+	// created peer's disabled state is RouterOS's own default (enabled).
+	disabledResponse := false
+	if req.Disabled != nil {
+		disabledResponse = *req.Disabled
+	}
+
 	response := WireGuardServerPeerCreateResponse{
 		Name:                 peerName,
 		InterfaceName:        interfaceName,
@@ -1642,7 +1650,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		ClientAllowedAddress: clientAllowedAddress,
 		ClientListenPort:     clientListenPort,
 		ClientEndpoint:       clientEndpointResponse,
-		Disabled:             false,
+		Disabled:             disabledResponse,
 	}
 
 	if req.PersistentKeepalive != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1542,7 +1542,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	if req.Name != nil && *req.Name != "" {
 		peerName = *req.Name
 	} else {
-		peerName = utils.GenerateName(2, " ", utils.PascalCase)
+		peerName = fmt.Sprintf("%s-peer%d", interfaceName, len(existingPeers)+1)
 	}
 
 	// Determine private key

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1485,7 +1486,10 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 
 	clientEndpoint := req.ClientEndpoint
 	if req.ClientEndpointIP != nil && *req.ClientEndpointIP != "" {
-		derived := fmt.Sprintf("%s:%d", *req.ClientEndpointIP, wg.ListenPort)
+		if net.ParseIP(*req.ClientEndpointIP) == nil {
+			return ErrorResponse(c, http.StatusBadRequest, "clientEndpointIp must be a valid IP address", nil)
+		}
+		derived := net.JoinHostPort(*req.ClientEndpointIP, strconv.Itoa(wg.ListenPort))
 		clientEndpoint = &derived
 	}
 

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -874,6 +874,11 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		interfaceName += "-wg-client"
 	}
 
+	peerCount, err := client.CountWireGuardPeers(interfaceName)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+	}
+
 	config := routeros.WireGuardClientConfig{
 		Name:       interfaceName,
 		PrivateKey: req.InterfacePrivateKey,
@@ -898,10 +903,6 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to add IP address to interface", err)
 	}
 
-	peerCount, err := client.CountWireGuardPeers(wireguard.Name)
-	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
-	}
 	peerName := fmt.Sprintf("%s-peer%d", wireguard.Name, peerCount+1)
 
 	var publicKey *string

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -898,7 +898,11 @@ func HandleCreateWireGuardClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to add IP address to interface", err)
 	}
 
-	peerName := wireguard.Name + "-peer"
+	peerCount, err := client.CountWireGuardPeers(wireguard.Name)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to count WireGuard peers", err)
+	}
+	peerName := fmt.Sprintf("%s-peer%d", wireguard.Name, peerCount+1)
 
 	var publicKey *string
 	if req.PeerPublicKey == nil {
@@ -1423,7 +1427,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	if req.Name != nil && *req.Name != "" {
 		peerName = *req.Name
 	} else {
-		peerName = utils.RandString(8)
+		peerName = utils.GenerateName(2, " ", utils.PascalCase)
 	}
 
 	// Determine private key
@@ -1755,7 +1759,7 @@ func HandleImportWireGuardConfig(c echo.Context) error {
 		}
 
 		persistentKeepalive := int(peer.PersistentKeepalive)
-		peerName := publicKey[:8]
+		peerName := fmt.Sprintf("%s-peer%d", wg.Name, i+1)
 
 		config := routeros.WireGuardPeerConfig{
 			InterfaceName:       wg.Name,

--- a/backend/internal/handler/vpn_dto.go
+++ b/backend/internal/handler/vpn_dto.go
@@ -476,39 +476,41 @@ func ToWireGuardDetailedResponse(wg *routeros.WireGuardInfo, peers []routeros.Wi
 
 // CreateWireGuardServerPeerRequest represents a request to add a peer to a WireGuard server.
 type CreateWireGuardServerPeerRequest struct {
-	InterfaceName        string  `json:"interfaceName" binding:"required" example:"wg-server"`
-	Name                 *string `json:"name" example:"office-peer-1"`
-	EndpointAddress      string  `json:"endpointAddress" example:"203.0.113.50" binding:"required"`
-	EndpointPort         int     `json:"endpointPort" example:"51820" binding:"required"`
-	AllowedAddresses     string  `json:"allowedAddresses" example:"192.168.1.0/24" binding:"required"`
-	PrivateKey           *string `json:"privateKey" example:"KIEp5mJ2Llk..."`
-	PublicKey            *string `json:"publicKey" example:"wV8gHkfwQ3z3YTSQ1byU2uygaLdu8twzugKFoHVofXs="`
-	PreSharedKey         *string `json:"preSharedKey" example:"qWbXwZgTbDGt66iCUtRHAtGju6w/Oyw3FLk/OPa+U1Y="`
-	PersistentKeepalive  *int    `json:"persistentKeepalive" example:"25"`
-	SavePrivateKey       *bool   `json:"savePrivateKey" example:"false"`
-	Disabled             *bool   `json:"disabled" example:"false"`
-	ClientEndpoint       *string `json:"clientEndpoint" example:"10.0.0.1:51820"`
-	ClientAddress        *string `json:"clientAddress" example:"10.0.0.2/32"`
-	ClientKeepalive      *int    `json:"clientKeepalive" example:"10"`
-	ClientAllowedAddress *string `json:"clientAllowedAddress" example:"10.0.0.0/24"`
-	ClientListenPort     *int    `json:"clientListenPort" example:"51820"`
-	ClientDNS            *string `json:"clientDNS" example:"8.8.8.8,8.8.4.4"`
-	Comment              *string `json:"comment" example:"Office VPN Peer"`
-	Responder            *bool   `json:"responder" example:"false"`
+	InterfaceName       string  `json:"interfaceName" binding:"required" example:"wg-server"`
+	Name                *string `json:"name" example:"office-peer-1"`
+	EndpointAddress     string  `json:"endpointAddress" example:"203.0.113.50" binding:"required"`
+	EndpointPort        int     `json:"endpointPort" example:"51820" binding:"required"`
+	AllowedAddresses    string  `json:"allowedAddresses" example:"192.168.1.0/24"`
+	PrivateKey          *string `json:"privateKey" example:"KIEp5mJ2Llk..."`
+	PublicKey           *string `json:"publicKey" example:"wV8gHkfwQ3z3YTSQ1byU2uygaLdu8twzugKFoHVofXs="`
+	PreSharedKey        *string `json:"preSharedKey" example:"qWbXwZgTbDGt66iCUtRHAtGju6w/Oyw3FLk/OPa+U1Y="`
+	PersistentKeepalive *int    `json:"persistentKeepalive" example:"25"`
+	SavePrivateKey      *bool   `json:"savePrivateKey" example:"false"`
+	Disabled            *bool   `json:"disabled" example:"false"`
+	ClientEndpoint      *string `json:"clientEndpoint" example:"10.0.0.1:51820"`
+	ClientEndpointIP    *string `json:"clientEndpointIp" example:"10.0.0.1"`
+	Comment             *string `json:"comment" example:"Office VPN Peer"`
+	Responder           *bool   `json:"responder" example:"false"`
 }
 
 // WireGuardServerPeerCreateResponse represents the response after creating a peer on a WireGuard server.
 type WireGuardServerPeerCreateResponse struct {
-	Name                string `json:"name"`
-	InterfaceName       string `json:"interfaceName"`
-	PublicKey           string `json:"publicKey"`
-	PrivateKey          string `json:"privateKey"`
-	PreSharedKey        string `json:"preSharedKey"`
-	EndpointAddress     string `json:"endpointAddress"`
-	EndpointPort        int    `json:"endpointPort"`
-	AllowedAddresses    string `json:"allowedAddresses"`
-	PersistentKeepalive int    `json:"persistentKeepalive"`
-	Disabled            bool   `json:"disabled"`
+	Name                 string `json:"name"`
+	InterfaceName        string `json:"interfaceName"`
+	PublicKey            string `json:"publicKey"`
+	PrivateKey           string `json:"privateKey"`
+	PreSharedKey         string `json:"preSharedKey"`
+	EndpointAddress      string `json:"endpointAddress"`
+	EndpointPort         int    `json:"endpointPort"`
+	AllowedAddresses     string `json:"allowedAddresses"`
+	PersistentKeepalive  int    `json:"persistentKeepalive"`
+	ClientAddress        string `json:"clientAddress"`
+	ClientDNS            string `json:"clientDNS"`
+	ClientKeepalive      int    `json:"clientKeepalive"`
+	ClientAllowedAddress string `json:"clientAllowedAddress"`
+	ClientListenPort     int    `json:"clientListenPort"`
+	ClientEndpoint       string `json:"clientEndpoint,omitempty"`
+	Disabled             bool   `json:"disabled"`
 }
 
 // ImportWireGuardConfigRequest represents a request to import a WireGuard configuration.

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -1550,6 +1550,14 @@ func (c *Client) AddWireGuardPeer(config WireGuardPeerConfig) (string, error) {
 		args = append(args, "=private-key="+*config.PrivateKey)
 	}
 
+	if config.Disabled != nil {
+		if *config.Disabled {
+			args = append(args, "=disabled=yes")
+		} else {
+			args = append(args, "=disabled=no")
+		}
+	}
+
 	if config.ClientEndpoint != nil && *config.ClientEndpoint != "" {
 		args = append(args, "=client-endpoint="+*config.ClientEndpoint)
 	}

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -333,6 +333,7 @@ type WireGuardPeerInfo struct {
 	PreSharedKey           string
 	PersistentKeepalive    string
 	ClientEndpoint         string
+	ClientAddress          string
 	ClientAllowedAddress   string
 	LastHandshake          string
 	RxBytes                int64
@@ -1619,6 +1620,7 @@ func (c *Client) GetWireGuardPeers(interfaceName string) ([]WireGuardPeerInfo, e
 			PreSharedKey:           result["preshared-key"],
 			PersistentKeepalive:    result["persistent-keepalive"],
 			ClientEndpoint:         result["client-endpoint"],
+			ClientAddress:          result["client-address"],
 			ClientAllowedAddress:   result["client-allowed-address"],
 			LastHandshake:          result["last-handshake"],
 			RxBytes:                rxBytes,

--- a/backend/pkg/utils/ip.go
+++ b/backend/pkg/utils/ip.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 	"sort"
+	"strconv"
 )
 
 type IPSortable struct {
@@ -21,6 +23,22 @@ func ParseIPToNumeric(ipStr string) uint32 {
 		return 0
 	}
 	return binary.BigEndian.Uint32(ip)
+}
+
+// ValidateIPPort reports an error unless value is a valid "ip:port" pair.
+func ValidateIPPort(value string) error {
+	host, portStr, err := net.SplitHostPort(value)
+	if err != nil {
+		return fmt.Errorf("invalid ip:port %q: %w", value, err)
+	}
+	if net.ParseIP(host) == nil {
+		return fmt.Errorf("invalid IP address: %s", host)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("invalid port: %s", portStr)
+	}
+	return nil
 }
 
 func SortIPsByNumeric(ips []string) []string {


### PR DESCRIPTION
* Closes #666
## Add client-config auto-derivation to WireGuard server peer creation

### Summary
- `allowedAddresses` is now optional on `POST /api/vpn/wireguard/peer`; when empty or omitted it defaults to `0.0.0.0/0`.
- Added `clientEndpointIp` as an alternative to `clientEndpoint`: supplying it derives the client endpoint automatically as `<clientEndpointIp>:<interface listen port>`. Supplying both `clientEndpoint` and `clientEndpointIp` in the same request is rejected with `400`.
- Client-side WireGuard config fields (`clientAddress`, `clientDNS`, `clientKeepalive`, `clientAllowedAddress`, `clientListenPort`) are now derived automatically instead of being accepted as request input:
  - `clientAddress`: next free IP after the interface's own address, within the interface's actual subnet, based on the current peer count (`409 Conflict` once the subnet's usable range is exhausted).
  - `clientDNS`: the interface's own IP.
  - `clientKeepalive`: fixed at `30`.
  - `clientListenPort`: the interface's own listen port.
  - `clientAllowedAddress`: mirrors the peer's own `allowedAddresses`.
- These derived values are returned in the response (`WireGuardServerPeerCreateResponse`) since they're no longer visible as request input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WireGuard peer creation assigns sequential names and automatically derives client network settings.
  * Peer creation responses include generated client configuration details.
  * Allowed addresses can be omitted and assigned automatically.
  * Imported peers receive sequential interface-based names.
  * Endpoint addresses support IP and port validation.

* **Bug Fixes**
  * Clear conflict responses are returned when subnet addresses are exhausted.
  * Invalid endpoint inputs produce descriptive validation errors.
  * IPv4 address allocation avoids calculation errors for larger address ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->