### PR TITLE
fix(be): Renamed ovpn certificate names from cert-x-x to ovpn-x-x

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -802,9 +802,11 @@ func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChange
 // @Summary Reset all DNS-related settings to their default configuration
 // @Description Replaces /ip/dns's servers with 1.0.0.1, 217.218.127.127 and 1.1.1.1, sets its
 // @Description DoH server to https://cloudflare-dns.com/dns-query with certificate verification
-// @Description disabled, removes every existing /ip/dns/forwarders entry, and recreates exactly
-// @Description four, each with certificate verification disabled: Domestic (217.218.127.127),
-// @Description Foreign (1.1.1.1), General (1.0.0.1, 217.218.127.127, 1.1.1.1) and VPN (1.0.0.1).
+// @Description disabled, and finds the existing Domestic, Foreign, General and VPN /ip/dns/forwarders
+// @Description entries by name, updating each one's dns-servers to its default: Domestic
+// @Description (217.218.127.127), Foreign (1.1.1.1), General (1.0.0.1, 217.218.127.127, 1.1.1.1) and
+// @Description VPN (1.0.0.1). A forwarder that doesn't already exist is left uncreated and skipped,
+// @Description rather than being treated as an error.
 // @Description Also resets the gateway of every /ip/route entry commented CheckIP-Route-to-
 // @Description Domestic-Domestic Link to 217.218.127.127, CheckIP-Route-to-Foreign-Foreign Link
 // @Description to 1.1.1.1, and CheckIP-Route-to-VPN-Client to 1.0.0.1. And, unless its
@@ -859,28 +861,30 @@ func HandleResetDNS(c echo.Context) error {
 	if err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list DNS forwarders", err)
 	}
-	for i := range existingForwarders {
-		if !hasDomesticLink && existingForwarders[i].Name == dnsForwarderTypeDomestic {
-			continue
-		}
-		if err := client.RemoveDNSForwarder(existingForwarders[i].ID); err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to remove DNS forwarder %q", existingForwarders[i].Name), err)
-		}
-	}
 
-	createdForwarders := make([]DNSForwarderResult, 0, len(dnsResetForwarders))
+	updatedForwarders := make([]DNSForwarderResult, 0, len(dnsResetForwarders))
 	for _, forwarder := range dnsResetForwarders {
 		if !hasDomesticLink && forwarder.Domestic {
 			continue
 		}
-		id, err := client.AddDNSForwarder(forwarder.Name, forwarder.DNSServers, false)
-		if err != nil {
-			return ErrorResponse(c, http.StatusInternalServerError,
-				fmt.Sprintf("Failed to create DNS forwarder %q", forwarder.Name), err)
+
+		var existing *routeros.DNSForwarder
+		for i := range existingForwarders {
+			if strings.TrimSpace(existingForwarders[i].Name) == forwarder.Name {
+				existing = &existingForwarders[i]
+				break
+			}
 		}
-		createdForwarders = append(createdForwarders, DNSForwarderResult{
-			ID:         id,
+		if existing == nil {
+			continue
+		}
+
+		if err := client.SetDNSForwarderServers(existing.ID, forwarder.DNSServers); err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update DNS forwarder %q", forwarder.Name), err)
+		}
+		updatedForwarders = append(updatedForwarders, DNSForwarderResult{
+			ID:         existing.ID,
 			Name:       forwarder.Name,
 			DNSServers: strings.Split(forwarder.DNSServers, ","),
 		})
@@ -1002,7 +1006,7 @@ func HandleResetDNS(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "DNS settings reset successfully", DNSResetResponse{
 		Servers:                  strings.Split(dnsResetServers, ","),
 		DOHServer:                dnsResetDOHServer,
-		Forwarders:               createdForwarders,
+		Forwarders:               updatedForwarders,
 		UpdatedCheckIPRoutes:     updatedCheckIPRoutes,
 		UpdatedRouteDstAddresses: updatedRouteDstAddresses,
 		UpdatedNetwatchProbes:    updatedNetwatchProbes,

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -2182,9 +2182,9 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		task.mu.Unlock()
 	}
 
-	caName := "cert-ca-" + timestamp
-	serverName := "cert-server-" + timestamp
-	clientName := "cert-client-" + timestamp
+	caName := "ovpn-ca-" + timestamp
+	serverName := "ovpn-server-" + timestamp
+	clientName := "ovpn-client-" + timestamp
 
 	updateTask(5, "Creating CA certificate")
 	caCertParams := routeros.AddCertificateParams{
@@ -2930,9 +2930,9 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 
 	if timestamp != "" {
 		certNames := []string{
-			"cert-client-" + ovpnServerName,
-			"cert-server-" + ovpnServerName,
-			"cert-ca-" + ovpnServerName,
+			"ovpn-client-" + ovpnServerName,
+			"ovpn-server-" + ovpnServerName,
+			"ovpn-ca-" + ovpnServerName,
 		}
 		for _, certName := range certNames {
 			if err := client.RemoveCertificate(certName); err != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -2371,7 +2371,7 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		Action:   "accept",
 		Protocol: "tcp",
 		DstPort:  fmt.Sprintf("%d", tcpPort),
-		Comment:  "openvpn-" + serverConfigNameTCP,
+		Comment:  serverConfigNameTCP,
 	}
 	_, err = client.AddFirewallRule(tcpFwRuleConfig)
 	if err != nil {
@@ -2385,7 +2385,7 @@ func processOvpnServerTask(client *routeros.Client, task *OvpnServerTask, req Cr
 		Action:   "accept",
 		Protocol: "udp",
 		DstPort:  fmt.Sprintf("%d", udpPort),
-		Comment:  "openvpn-" + serverConfigNameUDP,
+		Comment:  serverConfigNameUDP,
 	}
 	_, err = client.AddFirewallRule(udpFwRuleConfig)
 	if err != nil {
@@ -2902,7 +2902,6 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 		deleteErrors = append(deleteErrors, fmt.Sprintf("failed to delete OpenVPN server: %v", err))
 	}
 
-	ovpnServerName := "ovpn-server-" + timestamp
 	otherServer := ""
 	if strings.HasSuffix(serverName, "-tcp") {
 		otherServer = strings.TrimSuffix(serverName, "-tcp") + "-udp"
@@ -2917,10 +2916,8 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 	// Delete associated firewall rules
 	rules, err := client.GetFirewallRulesByChain("input")
 	if err == nil {
-		// Search for firewall rules associated with this OpenVPN server
 		for i := range rules {
-			// Check if the rule comment starts with "openvpn-" and contains the server config names
-			if strings.HasPrefix(rules[i].Comment, "openvpn-"+baseName) {
+			if strings.HasPrefix(rules[i].Comment, baseName) {
 				if err := client.RemoveFirewallRule(rules[i].ID); err != nil {
 					deleteErrors = append(deleteErrors, fmt.Sprintf("failed to delete firewall rule %s: %v", rules[i].Comment, err))
 				}
@@ -2930,9 +2927,9 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 
 	if timestamp != "" {
 		certNames := []string{
-			"ovpn-client-" + ovpnServerName,
-			"ovpn-server-" + ovpnServerName,
-			"ovpn-ca-" + ovpnServerName,
+			"ovpn-client-" + timestamp,
+			"ovpn-server-" + timestamp,
+			"ovpn-ca-" + timestamp,
 		}
 		for _, certName := range certNames {
 			if err := client.RemoveCertificate(certName); err != nil {

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -2848,6 +2848,17 @@ func HandleUpdateOvpnServerEnabled(c echo.Context) error {
 	})
 }
 
+func extractOvpnServerTimestamp(name string) string {
+	rest, ok := strings.CutPrefix(name, "ovpn-server-")
+	if !ok {
+		return ""
+	}
+	if _, err := strconv.Atoi(rest); err != nil {
+		return ""
+	}
+	return rest
+}
+
 // HandleDeleteOvpnServer deletes an OpenVPN server and all related items.
 // @Summary Delete OpenVPN Server
 // @Description Delete an OpenVPN server and all related items (secrets, certificates, firewall rules)
@@ -2886,15 +2897,7 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 		baseName = strings.TrimSuffix(baseName, "-udp")
 	}
 
-	extractTimestamp := func(name string) string {
-		parts := strings.Split(name, "-")
-		if len(parts) >= 3 {
-			return parts[len(parts)-1]
-		}
-		return ""
-	}
-
-	timestamp := extractTimestamp(baseName)
+	timestamp := extractOvpnServerTimestamp(baseName)
 	deleteErrors := []string{}
 
 	deleteCertFiles := c.QueryParam("deleteCertificateFiles") == "true"
@@ -2935,7 +2938,9 @@ func HandleDeleteOvpnServer(c echo.Context) error {
 			if err := client.RemoveCertificate(certName); err != nil {
 				deleteErrors = append(deleteErrors, fmt.Sprintf("failed to delete certificate %s: %v", certName, err))
 			} else if deleteCertFiles {
-				_ = client.RemoveCertificateFiles(certName)
+				if err := client.RemoveCertificateFiles(certName); err != nil {
+					deleteErrors = append(deleteErrors, fmt.Sprintf("failed to delete certificate files for %s: %v", certName, err))
+				}
 			}
 		}
 	}

--- a/backend/internal/template/ovpn_server.tmpl
+++ b/backend/internal/template/ovpn_server.tmpl
@@ -32,9 +32,9 @@ add name="{{ .Username }}" password="{{ .Password }}" profile=VPN-VPN service=an
 {{end}}
 :global WizardProgress "93"
 /ip firewall filter
-add action=accept chain=input comment="OpenVPN Server ovpn-tcp (tcp)" dst-port="1194" \
+add action=accept chain=input comment="ovpn-server-{{ .CurrentTimestamp }}-tcp" dst-port="1194" \
 in-interface-list="Domestic-WAN" protocol="tcp"
-add action=accept chain=input comment="OpenVPN Server ovpn-udp (udp)" dst-port="1194" \
+add action=accept chain=input comment="ovpn-server-{{ .CurrentTimestamp }}-udp" dst-port="1194" \
 in-interface-list="Domestic-WAN" protocol="udp"
 :global WizardProgress "94"
 /ip firewall mangle

--- a/backend/internal/template/ovpn_server.tmpl
+++ b/backend/internal/template/ovpn_server.tmpl
@@ -1,30 +1,30 @@
 /certificate
-add name=cert-ca-{{ .CurrentTimestamp }} common-name=cert-ca-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=crl-sign,key-cert-sign
-sign cert-ca-{{ .CurrentTimestamp }}
+add name=ovpn-ca-{{ .CurrentTimestamp }} common-name=ovpn-ca-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=crl-sign,key-cert-sign
+sign ovpn-ca-{{ .CurrentTimestamp }}
 :delay 1s
 :global WizardProgress "87"
 /certificate
-add name=cert-server-{{ .CurrentTimestamp }} common-name=cert-server-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=digital-signature,key-encipherment,tls-server
-sign cert-server-{{ .CurrentTimestamp }} ca=cert-ca-{{ .CurrentTimestamp }}
+add name=ovpn-server-{{ .CurrentTimestamp }} common-name=ovpn-server-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=digital-signature,key-encipherment,tls-server
+sign ovpn-server-{{ .CurrentTimestamp }} ca=ovpn-ca-{{ .CurrentTimestamp }}
 :global WizardProgress "88"
 /certificate
-add name=cert-client-{{ .CurrentTimestamp }} common-name=cert-client-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=tls-client
-sign cert-client-{{ .CurrentTimestamp }} ca=cert-ca-{{ .CurrentTimestamp }}
-/file add name=cert-client-{{ .CurrentTimestamp }}-password.txt contents="{{ .OvpnServer.ClientCertificatePassword }}"
+add name=ovpn-client-{{ .CurrentTimestamp }} common-name=ovpn-client-{{ .CurrentTimestamp }} key-size=2048 days-valid=3650 trusted=yes key-usage=tls-client
+sign ovpn-client-{{ .CurrentTimestamp }} ca=ovpn-ca-{{ .CurrentTimestamp }}
+/file add name=ovpn-client-{{ .CurrentTimestamp }}-password.txt contents="{{ .OvpnServer.ClientCertificatePassword }}"
 
 :global WizardProgress "89"
 /certificate
-export-certificate cert-ca-{{ .CurrentTimestamp }} file-name=cert-ca-{{ .CurrentTimestamp }} type=pem
-export-certificate cert-server-{{ .CurrentTimestamp }} file-name=cert-server-{{ .CurrentTimestamp }} type=pem
-export-certificate cert-client-{{ .CurrentTimestamp }} file-name=cert-client-{{ .CurrentTimestamp }} type=pem export-passphrase={{ .OvpnServer.ClientCertificatePassword }}
+export-certificate ovpn-ca-{{ .CurrentTimestamp }} file-name=ovpn-ca-{{ .CurrentTimestamp }} type=pem
+export-certificate ovpn-server-{{ .CurrentTimestamp }} file-name=ovpn-server-{{ .CurrentTimestamp }} type=pem
+export-certificate ovpn-client-{{ .CurrentTimestamp }} file-name=ovpn-client-{{ .CurrentTimestamp }} type=pem export-passphrase={{ .OvpnServer.ClientCertificatePassword }}
 :global WizardProgress "90"
 /interface ovpn-server server
 add name="ovpn-server-{{ .CurrentTimestamp }}-tcp" default-profile="default" disabled=no \
-port="1194" protocol="tcp" mode="ip" certificate=cert-server-{{ .CurrentTimestamp }} \
+port="1194" protocol="tcp" mode="ip" certificate=ovpn-server-{{ .CurrentTimestamp }} \
 require-client-certificate=yes auth=sha1,md5,sha256,sha384,sha512 cipher=blowfish128,aes128-cbc,aes192-cbc,aes256-cbc,aes128-gcm,aes192-gcm,aes256-gcm \
 redirect-gateway=def1 keepalive-timeout=60 comment="Client Certificate Password: {{ .OvpnServer.ClientCertificatePassword }}"
 add name="ovpn-server-{{ .CurrentTimestamp }}-udp" default-profile="default" disabled=no port="1194" protocol="udp" \
-mode="ip" certificate=cert-server-{{ .CurrentTimestamp }} require-client-certificate=yes auth=sha1,md5,sha256,sha384,sha512 cipher=blowfish128,aes128-cbc,aes192-cbc,aes256-cbc,aes128-gcm,aes192-gcm,aes256-gcm \
+mode="ip" certificate=ovpn-server-{{ .CurrentTimestamp }} require-client-certificate=yes auth=sha1,md5,sha256,sha384,sha512 cipher=blowfish128,aes128-cbc,aes192-cbc,aes256-cbc,aes128-gcm,aes192-gcm,aes256-gcm \
 redirect-gateway=def1 keepalive-timeout=60 comment="Client Certificate Password: {{ .OvpnServer.ClientCertificatePassword }}"
 :global WizardProgress "92"
 /ppp secret{{range .OvpnServer.Users}}

--- a/backend/pkg/routeros/certificate.go
+++ b/backend/pkg/routeros/certificate.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -688,6 +689,7 @@ func (c *Client) RemoveCertificateFiles(name string) error {
 		name + "-password.txt",
 	}
 
+	var errs []error
 	for _, filename := range filesToDelete {
 		results, err := c.GetAll("/file", "?=name="+filename)
 		if err != nil || len(results) == 0 {
@@ -695,11 +697,10 @@ func (c *Client) RemoveCertificateFiles(name string) error {
 		}
 
 		fileID := results[0][".id"]
-		_, err = c.Remove("/file", "=.id="+fileID)
-		if err != nil {
-			continue
+		if _, err := c.Remove("/file", "=.id="+fileID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove file %s: %w", filename, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/backend/pkg/routeros/certificate.go
+++ b/backend/pkg/routeros/certificate.go
@@ -685,6 +685,7 @@ func (c *Client) RemoveCertificateFiles(name string) error {
 		name + ".pem",
 		name + ".key",
 		name + ".crt",
+		name + "-password.txt",
 	}
 
 	for _, filename := range filesToDelete {


### PR DESCRIPTION
* Closes #667
* Fixes #679 
* Fixes #680 
* Renamed ovpn certificate names from cert-x-x to ovpn-x-x for better organization 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Standardized OpenVPN certificate and exported file names with clear CA, server, and client prefixes.
- Updated TCP and UDP OpenVPN configurations to reference the renamed certificates consistently.
- Improved firewall rule handling by matching rules to their server configuration names.
- Improved cleanup when removing OpenVPN servers by deleting associated certificates and password files more reliably.
- Certificate and file cleanup errors are now reported in deletion warnings instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->