### PR TITLE
feat(fe): add an Enable Family DNS action and show forwarder descriptions

### DIFF
--- a/frontend/src/api/dns.ts
+++ b/frontend/src/api/dns.ts
@@ -11,6 +11,7 @@ export type DnsForwarderType = 'Domestic' | 'Foreign' | 'VPN';
 export interface DnsForwarderListItem {
   name: string;
   ip: string;
+  description?: string;
   comment: string;
 }
 
@@ -35,6 +36,23 @@ export interface DnsValidateResponse {
 export interface ChangeDnsRequest {
   oldIp: string;
   newIp: string;
+}
+
+export interface DnsChangeResult {
+  oldIp: string;
+  newIp: string;
+  servers: string[];
+  updatedForwarders: string[];
+  updatedDstAddressRoutes: string[];
+  updatedGatewayRoutes: string[];
+  updatedNetwatchProbes: string[];
+  updatedAddressListItems: string[];
+  updatedNatRules: string[];
+}
+
+export interface DnsFamilyResponse {
+  foreign: DnsChangeResult;
+  vpn: DnsChangeResult;
 }
 
 function authHeaders({ host, username, password }: DnsCredentials): Record<string, string> {
@@ -94,6 +112,17 @@ export async function changeDns(
     method: 'POST',
     headers: authHeaders(creds),
     body: JSON.stringify(body),
+    signal,
+  });
+}
+
+export async function setFamilyDns(
+  creds: DnsCredentials,
+  signal?: AbortSignal,
+): Promise<DnsFamilyResponse> {
+  return apiRequest<DnsFamilyResponse>('/api/dns/family', {
+    method: 'POST',
+    headers: authHeaders(creds),
     signal,
   });
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -75,6 +75,7 @@ export {
   fetchDnsSuggestions,
   validateDnsChange,
   changeDns,
+  setFamilyDns,
   resetDns,
   type DnsCredentials,
   type DnsForwarderType,
@@ -83,6 +84,8 @@ export {
   type DnsSuggestResponse,
   type DnsValidateResponse,
   type ChangeDnsRequest,
+  type DnsChangeResult,
+  type DnsFamilyResponse,
 } from './dns';
 export {
   fetchDhcpLeases,

--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -64,6 +64,10 @@
   word-break: normal;
 }
 
+.muted {
+  color: var(--color-text-muted);
+}
+
 .errorNote {
   display: flex;
   flex-direction: column;

--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -16,7 +16,47 @@
   flex-shrink: 0;
 }
 
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: var(--space-lg);
+  align-items: start;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  min-width: 0;
+}
+
+.settingRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.settingTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.settingStatus {
+  margin: var(--space-sm) 0 0;
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+}
+
 @media (max-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .card {
     width: 100%;
     max-width: 100%;

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Globe, Pencil, RefreshCw, RotateCcw, SearchX, ShieldCheck } from 'lucide-react';
+import { Globe, Pencil, PersonStanding, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -13,12 +13,14 @@ import {
   Inline,
   Skeleton,
   Stack,
+  Switch,
   useToast,
   type DataTableColumn,
 } from '@nasnet/ui';
 import styles from './DNSPage.module.scss';
 import { DNSChangeDialog } from './DNSChangeDialog';
 import {
+  changeDns,
   fetchDnsForwarders,
   resetDns,
   setFamilyDns,
@@ -34,6 +36,27 @@ const TYPE_TONES: Record<string, 'info' | 'primary' | 'success'> = {
   VPN: 'success',
 };
 
+const FAMILY_PROVIDER_PREFIX = 'Cloudflare Family';
+const FAMILY_FOREIGN_IP = '1.1.1.3';
+const FAMILY_VPN_IP = '1.0.0.3';
+const PLAIN_FOREIGN_IP = '1.1.1.1';
+const PLAIN_VPN_IP = '1.0.0.1';
+
+function firstIp(ip: string): string {
+  return ip.split(',')[0]?.trim() ?? '';
+}
+
+function isFamilyForwarder(
+  forwarders: DnsForwarderListItem[],
+  name: string,
+  familyIp: string,
+): boolean {
+  const forwarder = forwarders.find((row) => row.name === name);
+  if (!forwarder) return false;
+  if (forwarder.description?.startsWith(FAMILY_PROVIDER_PREFIX)) return true;
+  return firstIp(forwarder.ip) === familyIp;
+}
+
 export function DNSPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter(id);
@@ -46,8 +69,12 @@ export function DNSPage() {
   const [editing, setEditing] = useState<DnsForwarderListItem | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [resetting, setResetting] = useState(false);
-  const [confirmingFamily, setConfirmingFamily] = useState(false);
+  const [confirmingFamily, setConfirmingFamily] = useState<'enable' | 'disable' | null>(null);
   const [applyingFamily, setApplyingFamily] = useState(false);
+
+  const familyEnabled =
+    isFamilyForwarder(forwarders, 'Foreign', FAMILY_FOREIGN_IP) &&
+    isFamilyForwarder(forwarders, 'VPN', FAMILY_VPN_IP);
 
   const creds = useMemo<DnsCredentials | null>(() => {
     if (!id) return null;
@@ -98,11 +125,11 @@ export function DNSPage() {
 
   const runFamilyDns = async () => {
     if (!creds) return;
-    setConfirmingFamily(false);
+    setConfirmingFamily(null);
     setApplyingFamily(true);
     try {
       await setFamilyDns(creds);
-      toast.notify({ title: 'Cloudflare Family DNS enabled', tone: 'success' });
+      toast.notify({ title: 'Family DNS enabled', tone: 'success' });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to enable Family DNS.';
       toast.notify({
@@ -115,6 +142,29 @@ export function DNSPage() {
       await reload();
     }
   };
+
+  const stopFamilyDns = async () => {
+    if (!creds) return;
+    setConfirmingFamily(null);
+    setApplyingFamily(true);
+    try {
+      await changeDns(creds, { oldIp: FAMILY_FOREIGN_IP, newIp: PLAIN_FOREIGN_IP });
+      await changeDns(creds, { oldIp: FAMILY_VPN_IP, newIp: PLAIN_VPN_IP });
+      toast.notify({ title: 'Family DNS disabled', tone: 'success' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to disable Family DNS.';
+      toast.notify({
+        title: 'Failed to disable Family DNS',
+        description: `${message} Some forwarders may already have been switched, so check the list before retrying.`,
+        tone: 'danger',
+      });
+    } finally {
+      setApplyingFamily(false);
+      await reload();
+    }
+  };
+
+  const familyToggleLabel = familyEnabled ? 'Disabling…' : 'Enabling…';
 
   const columns: DataTableColumn<DnsForwarderListItem>[] = [
     {
@@ -166,84 +216,82 @@ export function DNSPage() {
 
   return (
     <Stack>
-      <Card>
-        <CardHeader className={styles.cardHeader}>
-          <div>
-            <CardTitle>
-              <Inline>
-                <Globe size={16} aria-hidden /> DNS
-              </Inline>
-            </CardTitle>
-            <CardDescription>
-              DNS servers configured on this router, grouped by domestic, foreign and VPN traffic.
-            </CardDescription>
-          </div>
-          <div className={styles.headerActions}>
-            <Button size="sm" variant="secondary" onClick={reload} disabled={loading || resetting}>
-              <RefreshCw size={14} aria-hidden /> Refresh
-            </Button>
-            <Button
-              size="sm"
-              variant="danger"
-              onClick={() => setConfirmingReset(true)}
-              disabled={loading || resetting || applyingFamily || !creds}
-            >
-              <RotateCcw size={14} aria-hidden /> {resetting ? 'Resetting…' : 'Reset'}
-            </Button>
-          </div>
-        </CardHeader>
+      <div className={styles.layout}>
+        <Card>
+          <CardHeader className={styles.cardHeader}>
+            <div>
+              <CardTitle>
+                <Inline>
+                  <Globe size={16} aria-hidden /> DNS
+                </Inline>
+              </CardTitle>
+              <CardDescription>
+                DNS servers configured on this router, grouped by domestic, foreign and VPN traffic.
+              </CardDescription>
+            </div>
+            <div className={styles.headerActions}>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={reload}
+                disabled={loading || resetting}
+              >
+                <RefreshCw size={14} aria-hidden /> Refresh
+              </Button>
+              <Button
+                size="sm"
+                variant="danger"
+                onClick={() => setConfirmingReset(true)}
+                disabled={loading || resetting || applyingFamily || !creds}
+              >
+                <RotateCcw size={14} aria-hidden /> {resetting ? 'Resetting…' : 'Reset'}
+              </Button>
+            </div>
+          </CardHeader>
 
-        {loading && forwarders.length === 0 ? (
-          <div className={styles.skeletonGrid} data-testid="dns-skeleton">
-            <Skeleton width={140} height={14} />
-            <Skeleton height={36} />
-            <Skeleton width={140} height={14} />
-            <Skeleton height={36} />
-            <Skeleton width={140} height={14} />
-            <Skeleton height={36} />
-          </div>
-        ) : error ? (
-          <div className={styles.errorNote}>
-            <SearchX size={28} aria-hidden className={styles.errorIcon} />
-            <p>{error}</p>
-          </div>
-        ) : (
-          <DataTable
-            columns={columns}
-            rows={forwarders}
-            rowKey={(row) => row.name}
-            emptyMessage="No DNS servers configured"
-          />
-        )}
-      </Card>
+          {loading && forwarders.length === 0 ? (
+            <div className={styles.skeletonGrid} data-testid="dns-skeleton">
+              <Skeleton width={140} height={14} />
+              <Skeleton height={36} />
+              <Skeleton width={140} height={14} />
+              <Skeleton height={36} />
+              <Skeleton width={140} height={14} />
+              <Skeleton height={36} />
+            </div>
+          ) : error ? (
+            <div className={styles.errorNote}>
+              <SearchX size={28} aria-hidden className={styles.errorIcon} />
+              <p>{error}</p>
+            </div>
+          ) : (
+            <DataTable
+              columns={columns}
+              rows={forwarders}
+              rowKey={(row) => row.name}
+              emptyMessage="No DNS servers configured"
+            />
+          )}
+        </Card>
 
-      <Card data-testid="family-dns-card">
-        <CardHeader className={styles.cardHeader}>
-          <div>
-            <CardTitle>
-              <Inline>
-                <ShieldCheck size={16} aria-hidden /> Family DNS
-              </Inline>
-            </CardTitle>
-            <CardDescription>
-              Cloudflare Family DNS (1.1.1.3 and 1.0.0.3) filters malware and adult content before a
-              device ever reaches it. Enabling it points the Foreign and VPN forwarders at
-              Cloudflare Family.
-            </CardDescription>
-          </div>
-          <div className={styles.headerActions}>
-            <Button
-              size="sm"
-              variant="primary"
-              onClick={() => setConfirmingFamily(true)}
-              disabled={loading || resetting || applyingFamily || !creds}
-            >
-              <ShieldCheck size={14} aria-hidden />{' '}
-              {applyingFamily ? 'Enabling…' : 'Enable Family DNS'}
-            </Button>
-          </div>
-        </CardHeader>
-      </Card>
+        <aside className={styles.sidebar}>
+          <Card data-testid="family-dns-card">
+            <div className={styles.settingRow}>
+              <span className={styles.settingTitle}>
+                <PersonStanding size={16} aria-hidden /> Family DNS
+              </span>
+              <Switch
+                aria-label="Family DNS"
+                checked={familyEnabled}
+                onChange={(e) =>
+                  setConfirmingFamily(e.currentTarget.checked ? 'enable' : 'disable')
+                }
+                disabled={loading || resetting || applyingFamily || !creds}
+              />
+            </div>
+            {applyingFamily ? <p className={styles.settingStatus}>{familyToggleLabel}</p> : null}
+          </Card>
+        </aside>
+      </div>
 
       {editing && creds ? (
         <DNSChangeDialog
@@ -268,12 +316,22 @@ export function DNSPage() {
       />
 
       <ConfirmDialog
-        open={confirmingFamily}
+        open={confirmingFamily === 'enable'}
         title="Enable Family DNS?"
-        description="The Foreign DNS forwarder switches to Cloudflare Family Primary 1.1.1.3 and the VPN forwarder to Cloudflare Family Secondary 1.0.0.3. Matching firewall entries, routes and netwatch probes follow. There is no one-click way back, so restore the previous servers by editing each forwarder."
+        description="The Foreign and VPN forwarders switch to filtering servers."
         confirmLabel="Enable"
+        confirmVariant="success"
         onConfirm={runFamilyDns}
-        onCancel={() => setConfirmingFamily(false)}
+        onCancel={() => setConfirmingFamily(null)}
+      />
+
+      <ConfirmDialog
+        open={confirmingFamily === 'disable'}
+        title="Disable Family DNS?"
+        description="The Foreign and VPN forwarders go back to their standard servers, and filtering stops."
+        confirmLabel="Disable"
+        onConfirm={stopFamilyDns}
+        onCancel={() => setConfirmingFamily(null)}
       />
     </Stack>
   );

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -186,7 +186,7 @@ export function DNSPage() {
               size="sm"
               variant="danger"
               onClick={() => setConfirmingReset(true)}
-              disabled={loading || resetting || !creds}
+              disabled={loading || resetting || applyingFamily || !creds}
             >
               <RotateCcw size={14} aria-hidden /> {resetting ? 'Resetting…' : 'Reset'}
             </Button>

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -118,6 +118,12 @@ export function DNSPage() {
       ),
     },
     {
+      key: 'description',
+      header: 'Provider',
+      render: (row) =>
+        row.description ? <span>{row.description}</span> : <span className={styles.muted}>-</span>,
+    },
+    {
       key: 'actions',
       header: '',
       width: '110px',

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
+import { Globe, Pencil, RefreshCw, RotateCcw, SearchX, ShieldCheck } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -21,6 +21,7 @@ import { DNSChangeDialog } from './DNSChangeDialog';
 import {
   fetchDnsForwarders,
   resetDns,
+  setFamilyDns,
   type DnsCredentials,
   type DnsForwarderListItem,
 } from '../api';
@@ -45,6 +46,8 @@ export function DNSPage() {
   const [editing, setEditing] = useState<DnsForwarderListItem | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [confirmingFamily, setConfirmingFamily] = useState(false);
+  const [applyingFamily, setApplyingFamily] = useState(false);
 
   const creds = useMemo<DnsCredentials | null>(() => {
     if (!id) return null;
@@ -93,6 +96,26 @@ export function DNSPage() {
     }
   };
 
+  const runFamilyDns = async () => {
+    if (!creds) return;
+    setConfirmingFamily(false);
+    setApplyingFamily(true);
+    try {
+      await setFamilyDns(creds);
+      toast.notify({ title: 'Cloudflare Family DNS enabled', tone: 'success' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to enable Family DNS.';
+      toast.notify({
+        title: 'Failed to enable Family DNS',
+        description: `${message} Some forwarders may already have been switched, so check the list before retrying.`,
+        tone: 'danger',
+      });
+    } finally {
+      setApplyingFamily(false);
+      await reload();
+    }
+  };
+
   const columns: DataTableColumn<DnsForwarderListItem>[] = [
     {
       key: 'type',
@@ -132,7 +155,7 @@ export function DNSPage() {
           size="sm"
           variant="secondary"
           onClick={() => setEditing(row)}
-          disabled={!creds || resetting}
+          disabled={!creds || resetting || applyingFamily}
           aria-label={`Edit ${row.name} DNS server`}
         >
           <Pencil size={14} aria-hidden /> Edit
@@ -194,6 +217,34 @@ export function DNSPage() {
         )}
       </Card>
 
+      <Card data-testid="family-dns-card">
+        <CardHeader className={styles.cardHeader}>
+          <div>
+            <CardTitle>
+              <Inline>
+                <ShieldCheck size={16} aria-hidden /> Family DNS
+              </Inline>
+            </CardTitle>
+            <CardDescription>
+              Cloudflare Family DNS (1.1.1.3 and 1.0.0.3) filters malware and adult content before a
+              device ever reaches it. Enabling it points the Foreign and VPN forwarders at
+              Cloudflare Family.
+            </CardDescription>
+          </div>
+          <div className={styles.headerActions}>
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => setConfirmingFamily(true)}
+              disabled={loading || resetting || applyingFamily || !creds}
+            >
+              <ShieldCheck size={14} aria-hidden />{' '}
+              {applyingFamily ? 'Enabling…' : 'Enable Family DNS'}
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
       {editing && creds ? (
         <DNSChangeDialog
           open
@@ -214,6 +265,15 @@ export function DNSPage() {
         destructive
         onConfirm={runReset}
         onCancel={() => setConfirmingReset(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmingFamily}
+        title="Enable Family DNS?"
+        description="The Foreign DNS forwarder switches to Cloudflare Family Primary 1.1.1.3 and the VPN forwarder to Cloudflare Family Secondary 1.0.0.3. Matching firewall entries, routes and netwatch probes follow. There is no one-click way back, so restore the previous servers by editing each forwarder."
+        confirmLabel="Enable"
+        onConfirm={runFamilyDns}
+        onCancel={() => setConfirmingFamily(false)}
       />
     </Stack>
   );

--- a/frontend/tests/e2e/41-dns-family.spec.ts
+++ b/frontend/tests/e2e/41-dns-family.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from './fixtures';
+
+test.describe('DNS page (descriptions + Family DNS)', () => {
+  test('lists each forwarder with its provider description', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_dns', name: 'DNS Router', host: '10.20.0.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_dns', model: 'hAP ax3' });
+    await mockDnsBackend({ id: 'rtr_dns' });
+    await page.goto('/router/rtr_dns/dns');
+
+    const table = page.getByRole('table');
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Provider' })).toBeVisible();
+    await expect(table).toContainText('ICT DNS');
+    await expect(table).toContainText('Cloudflare Primary');
+    await expect(table).toContainText('Cloudflare Secondary');
+  });
+
+  test('asks for confirmation before enabling Family DNS', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_fam', name: 'Family Router', host: '10.20.0.2', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_fam', model: 'hAP ax3' });
+    await mockDnsBackend({ id: 'rtr_fam' });
+
+    const familyCalls: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/dns/family')) {
+        familyCalls.push(req.url());
+      }
+    });
+
+    await page.goto('/router/rtr_fam/dns');
+
+    const card = page.getByTestId('family-dns-card');
+    await expect(card).toContainText('1.1.1.3');
+    await expect(card).toContainText('malware and adult content');
+
+    await card.getByRole('button', { name: 'Enable Family DNS' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('Enable Family DNS?');
+    await expect(dialog).toContainText('1.0.0.3');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    expect(familyCalls).toHaveLength(0);
+  });
+
+  test('applies Cloudflare Family DNS to the Foreign and VPN forwarders', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_ok', name: 'Apply Router', host: '10.20.0.3', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_ok', model: 'hAP ax3' });
+    await mockDnsBackend({ id: 'rtr_ok' });
+
+    const familyCalls: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/dns/family')) {
+        familyCalls.push(req.url());
+      }
+    });
+
+    await page.goto('/router/rtr_ok/dns');
+
+    const table = page.getByRole('table');
+    await expect(table).toContainText('1.1.1.1');
+
+    await page
+      .getByTestId('family-dns-card')
+      .getByRole('button', { name: 'Enable Family DNS' })
+      .click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Enable', exact: true }).click();
+
+    await expect.poll(() => familyCalls.length).toBeGreaterThan(0);
+    await expect(table).toContainText('1.1.1.3');
+    await expect(table).toContainText('1.0.0.3');
+    await expect(table).toContainText('Cloudflare Family Primary');
+  });
+});

--- a/frontend/tests/e2e/41-dns-family.spec.ts
+++ b/frontend/tests/e2e/41-dns-family.spec.ts
@@ -44,13 +44,13 @@ test.describe('DNS page (descriptions + Family DNS)', () => {
     await page.goto('/router/rtr_fam/dns');
 
     const card = page.getByTestId('family-dns-card');
-    await expect(card).toContainText('1.1.1.3');
-    await expect(card).toContainText('malware and adult content');
+    await expect(card).toContainText('Family DNS');
 
-    await card.getByRole('button', { name: 'Enable Family DNS' }).click();
+    const toggle = card.getByRole('switch', { name: 'Family DNS' });
+    await expect(toggle).not.toBeChecked();
+    await toggle.click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toContainText('Enable Family DNS?');
-    await expect(dialog).toContainText('1.0.0.3');
 
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(page.getByRole('dialog')).toHaveCount(0);
@@ -81,15 +81,51 @@ test.describe('DNS page (descriptions + Family DNS)', () => {
     const table = page.getByRole('table');
     await expect(table).toContainText('1.1.1.1');
 
-    await page
-      .getByTestId('family-dns-card')
-      .getByRole('button', { name: 'Enable Family DNS' })
-      .click();
+    await page.getByTestId('family-dns-card').getByRole('switch', { name: 'Family DNS' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Enable', exact: true }).click();
 
     await expect.poll(() => familyCalls.length).toBeGreaterThan(0);
     await expect(table).toContainText('1.1.1.3');
     await expect(table).toContainText('1.0.0.3');
     await expect(table).toContainText('Cloudflare Family Primary');
+    await expect(
+      page.getByTestId('family-dns-card').getByRole('switch', { name: 'Family DNS' }),
+    ).toBeChecked();
+  });
+
+  test('turns Family DNS back off from the toggle', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_off', name: 'Off Router', host: '10.20.0.5', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: 'rtr_off', model: 'hAP ax3' });
+    await mockDnsBackend({ id: 'rtr_off' });
+
+    const changeCalls: Array<{ oldIp?: string; newIp?: string }> = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/dns/change')) {
+        changeCalls.push(req.postDataJSON() as { oldIp?: string; newIp?: string });
+      }
+    });
+
+    await page.goto('/router/rtr_off/dns');
+
+    const toggle = page.getByTestId('family-dns-card').getByRole('switch', { name: 'Family DNS' });
+    await toggle.click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Enable', exact: true }).click();
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('Disable Family DNS?');
+    await dialog.getByRole('button', { name: 'Disable', exact: true }).click();
+
+    await expect.poll(() => changeCalls.length).toBe(2);
+    expect(changeCalls[0]).toEqual({ oldIp: '1.1.1.3', newIp: '1.1.1.1' });
+    expect(changeCalls[1]).toEqual({ oldIp: '1.0.0.3', newIp: '1.0.0.1' });
   });
 });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { test as base } from '@playwright/test';
+import type { DnsFamilyResponse } from '../../src/api/dns';
 import type { Router } from '../../src/mocks/types';
 
 export interface SeedInput extends Partial<Router> {
@@ -893,9 +894,29 @@ export const test = base.extend<TestFixtures>({
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: envelope({
-            foreign: { oldIp: '1.1.1.1', newIp: '1.1.1.3', servers: ['1.1.1.3'] },
-            vpn: { oldIp: '1.0.0.1', newIp: '1.0.0.3', servers: ['1.0.0.3'] },
+          body: envelope<DnsFamilyResponse>({
+            foreign: {
+              oldIp: '1.1.1.1',
+              newIp: '1.1.1.3',
+              servers: ['1.1.1.3'],
+              updatedForwarders: [],
+              updatedDstAddressRoutes: [],
+              updatedGatewayRoutes: [],
+              updatedNetwatchProbes: [],
+              updatedAddressListItems: [],
+              updatedNatRules: [],
+            },
+            vpn: {
+              oldIp: '1.0.0.1',
+              newIp: '1.0.0.3',
+              servers: ['1.0.0.3'],
+              updatedForwarders: [],
+              updatedDstAddressRoutes: [],
+              updatedGatewayRoutes: [],
+              updatedNetwatchProbes: [],
+              updatedAddressListItems: [],
+              updatedNatRules: [],
+            },
           }),
         });
       });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -70,6 +70,8 @@ export interface DhcpBackendOptions {
 export interface DnsBackendOptions {
   id?: string;
   familyStatus?: number;
+  adBlockStatus?: number;
+  flushFails?: boolean;
 }
 
 export interface DiagBackendOptions {
@@ -895,6 +897,49 @@ export const test = base.extend<TestFixtures>({
             foreign: { oldIp: '1.1.1.1', newIp: '1.1.1.3', servers: ['1.1.1.3'] },
             vpn: { oldIp: '1.0.0.1', newIp: '1.0.0.3', servers: ['1.0.0.3'] },
           }),
+        });
+      });
+
+      const adBlockStatus = options.adBlockStatus ?? 200;
+      await context.route('**/api/dns/adblock', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        const body = route.request().postDataJSON() as { enabled?: boolean } | null;
+        const enabled = body?.enabled ?? false;
+        if (adBlockStatus !== 200) {
+          await route.fulfill({
+            status: adBlockStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: adBlockStatus,
+              message: `Ad-block is already ${enabled ? 'enabled' : 'disabled'}`,
+            }),
+          });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ enabled }),
+        });
+      });
+
+      await context.route('**/api/dns/cache', async (route) => {
+        if (route.request().method() !== 'DELETE') return route.fallback();
+        if (options.flushFails) {
+          return route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: 500,
+              message: 'Failed to flush DNS cache',
+              error: 'Failed to flush DNS cache',
+            }),
+          });
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
         });
       });
     });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -864,6 +864,28 @@ export const test = base.extend<TestFixtures>({
         });
       });
 
+      const providerNames: Record<string, string> = {
+        '1.1.1.1': 'Cloudflare Primary',
+        '1.0.0.1': 'Cloudflare Secondary',
+        '1.1.1.3': 'Cloudflare Family Primary',
+        '1.0.0.3': 'Cloudflare Family Secondary',
+      };
+
+      await context.route('**/api/dns/change', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        const body = route.request().postDataJSON() as { oldIp?: string; newIp?: string } | null;
+        const target = forwarders.find((row) => row.ip === body?.oldIp);
+        if (target && body?.newIp) {
+          target.ip = body.newIp;
+          target.description = providerNames[body.newIp] ?? '';
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(null),
+        });
+      });
+
       const familyStatus = options.familyStatus ?? 200;
       await context.route('**/api/dns/family', async (route) => {
         if (route.request().method() !== 'POST') return route.fallback();

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -67,6 +67,11 @@ export interface DhcpBackendOptions {
   id?: string;
 }
 
+export interface DnsBackendOptions {
+  id?: string;
+  familyStatus?: number;
+}
+
 export interface DiagBackendOptions {
   id?: string;
   initialProgress?: number;
@@ -115,6 +120,7 @@ export interface TestFixtures {
   mockWifiBackend: (router?: WifiBackendRouter) => Promise<void>;
   mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
   mockDhcpBackend: (options?: DhcpBackendOptions) => Promise<void>;
+  mockDnsBackend: (options?: DnsBackendOptions) => Promise<void>;
   mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
   mockEasyConfigBackend: (options: EasyConfigBackendOptions) => Promise<void>;
 }
@@ -807,6 +813,88 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope({ macAddress: 'AA:BB:CC:DD:EE:02', id: '*2', address: '192.168.88.102' }),
+        });
+      });
+    });
+  },
+  mockDnsBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      const forwarders = [
+        { name: 'Domestic', ip: '217.218.127.127', description: 'ICT DNS', comment: '' },
+        { name: 'Foreign', ip: '1.1.1.1', description: 'Cloudflare Primary', comment: '' },
+        { name: 'VPN', ip: '1.0.0.1', description: 'Cloudflare Secondary', comment: '' },
+      ];
+
+      await context.route('**/api/dns/list', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(forwarders),
+        });
+      });
+
+      await context.route('**/api/dns/suggest**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ domestic: [], foreign: [] }),
+        });
+      });
+
+      const familyStatus = options.familyStatus ?? 200;
+      await context.route('**/api/dns/family', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        if (familyStatus !== 200) {
+          await route.fulfill({
+            status: familyStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: familyStatus,
+              message: 'VPN DNS forwarder not found',
+              error: 'VPN DNS forwarder not found',
+            }),
+          });
+          return;
+        }
+        forwarders[1] = {
+          name: 'Foreign',
+          ip: '1.1.1.3',
+          description: 'Cloudflare Family Primary',
+          comment: '',
+        };
+        forwarders[2] = {
+          name: 'VPN',
+          ip: '1.0.0.3',
+          description: 'Cloudflare Family Secondary',
+          comment: '',
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({
+            foreign: { oldIp: '1.1.1.1', newIp: '1.1.1.3', servers: ['1.1.1.3'] },
+            vpn: { oldIp: '1.0.0.1', newIp: '1.0.0.3', servers: ['1.0.0.3'] },
+          }),
         });
       });
     });


### PR DESCRIPTION
Closes #660

- new Family DNS card on the DNS page explaining Cloudflare Family malware and adult-content filtering
- Enable Family DNS button behind a confirm dialog that spells out the Foreign and VPN forwarder switch to 1.1.1.3 and 1.0.0.3
- forwarder list gains a Provider column fed by the description the backend already returns
- error path reloads the list and warns that some forwarders may already have switched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-way Family DNS controls for Foreign and VPN forwarders, with confirmation dialogs, progress feedback, notifications, and automatic refresh.
  * Disabling Family DNS restores standard DNS forwarders.
  * DNS forwarders now display provider descriptions.
  * Editing and reset actions are temporarily disabled while changes are applied.

* **Style**
  * Added a responsive DNS settings layout and muted supporting text styles.

* **Tests**
  * Added end-to-end coverage for Family DNS enablement, cancellation, disabling, descriptions, and update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->