### PR TITLE
feat(fe): add a flush DNS cache button to the DNS page

### DIFF
--- a/frontend/src/api/dns.ts
+++ b/frontend/src/api/dns.ts
@@ -98,6 +98,14 @@ export async function changeDns(
   });
 }
 
+export async function flushDnsCache(creds: DnsCredentials, signal?: AbortSignal): Promise<void> {
+  await apiRequest('/api/dns/cache', {
+    method: 'DELETE',
+    headers: authHeaders(creds),
+    signal,
+  });
+}
+
 export async function resetDns(creds: DnsCredentials, signal?: AbortSignal): Promise<void> {
   await apiRequest('/api/dns/reset', {
     method: 'POST',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -75,6 +75,7 @@ export {
   fetchDnsSuggestions,
   validateDnsChange,
   changeDns,
+  flushDnsCache,
   resetDns,
   type DnsCredentials,
   type DnsForwarderType,

--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -132,3 +132,20 @@
   grid-template-columns: 180px 1fr;
   gap: var(--space-sm) var(--space-md);
 }
+
+.settingDivider {
+  margin: var(--space-md) 0;
+}
+
+.purgeButton.purgeButton {
+  transition:
+    background var(--transition-fast),
+    border var(--transition-fast),
+    color var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: var(--color-danger);
+    border-color: var(--color-danger);
+    color: #fff;
+  }
+}

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
+import { Eraser, Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -20,6 +20,7 @@ import styles from './DNSPage.module.scss';
 import { DNSChangeDialog } from './DNSChangeDialog';
 import {
   fetchDnsForwarders,
+  flushDnsCache,
   resetDns,
   type DnsCredentials,
   type DnsForwarderListItem,
@@ -45,6 +46,7 @@ export function DNSPage() {
   const [editing, setEditing] = useState<DnsForwarderListItem | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [flushing, setFlushing] = useState(false);
 
   const creds = useMemo<DnsCredentials | null>(() => {
     if (!id) return null;
@@ -93,6 +95,20 @@ export function DNSPage() {
     }
   };
 
+  const runFlushCache = async () => {
+    if (!creds) return;
+    setFlushing(true);
+    try {
+      await flushDnsCache(creds);
+      toast.notify({ title: 'DNS cache cleared', tone: 'success' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to clear the DNS cache.';
+      toast.notify({ title: 'Failed to clear DNS cache', description: message, tone: 'danger' });
+    } finally {
+      setFlushing(false);
+    }
+  };
+
   const columns: DataTableColumn<DnsForwarderListItem>[] = [
     {
       key: 'type',
@@ -126,7 +142,7 @@ export function DNSPage() {
           size="sm"
           variant="secondary"
           onClick={() => setEditing(row)}
-          disabled={!creds || resetting}
+          disabled={!creds || resetting || flushing}
           aria-label={`Edit ${row.name} DNS server`}
         >
           <Pencil size={14} aria-hidden /> Edit
@@ -150,14 +166,29 @@ export function DNSPage() {
             </CardDescription>
           </div>
           <div className={styles.headerActions}>
-            <Button size="sm" variant="secondary" onClick={reload} disabled={loading || resetting}>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={reload}
+              disabled={loading || resetting || flushing}
+            >
               <RefreshCw size={14} aria-hidden /> Refresh
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={runFlushCache}
+              disabled={loading || resetting || flushing || !creds}
+              aria-label="Flush DNS cache"
+              data-testid="dns-flush-cache"
+            >
+              <Eraser size={14} aria-hidden /> {flushing ? 'Flushing…' : 'Flush cache'}
             </Button>
             <Button
               size="sm"
               variant="danger"
               onClick={() => setConfirmingReset(true)}
-              disabled={loading || resetting || !creds}
+              disabled={loading || resetting || flushing || !creds}
             >
               <RotateCcw size={14} aria-hidden /> {resetting ? 'Resetting…' : 'Reset'}
             </Button>

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Eraser, Globe, Pencil, PersonStanding, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
+import { Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -10,6 +10,7 @@ import {
   CardTitle,
   ConfirmDialog,
   DataTable,
+  Divider,
   Inline,
   Skeleton,
   Stack,
@@ -42,6 +43,7 @@ const FAMILY_FOREIGN_IP = '1.1.1.3';
 const FAMILY_VPN_IP = '1.0.0.3';
 const PLAIN_FOREIGN_IP = '1.1.1.1';
 const PLAIN_VPN_IP = '1.0.0.1';
+const FLUSH_MIN_DURATION_MS = 1000;
 
 function firstIp(ip: string): string {
   return ip.split(',')[0]?.trim() ?? '';
@@ -128,15 +130,21 @@ export function DNSPage() {
   const runFlushCache = async () => {
     if (!creds) return;
     setFlushing(true);
+    const startedAt = Date.now();
+    let result: Parameters<typeof toast.notify>[0];
     try {
       await flushDnsCache(creds);
-      toast.notify({ title: 'DNS cache cleared', tone: 'success' });
+      result = { title: 'DNS cache cleared', tone: 'success' };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to clear the DNS cache.';
-      toast.notify({ title: 'Failed to clear DNS cache', description: message, tone: 'danger' });
-    } finally {
-      setFlushing(false);
+      result = { title: 'Failed to clear DNS cache', description: message, tone: 'danger' };
     }
+    const elapsed = Date.now() - startedAt;
+    if (elapsed < FLUSH_MIN_DURATION_MS) {
+      await new Promise((resolve) => setTimeout(resolve, FLUSH_MIN_DURATION_MS - elapsed));
+    }
+    setFlushing(false);
+    toast.notify(result);
   };
 
   const runFamilyDns = async () => {
@@ -256,16 +264,6 @@ export function DNSPage() {
               </Button>
               <Button
                 size="sm"
-                variant="secondary"
-                onClick={runFlushCache}
-                disabled={loading || resetting || flushing || applyingFamily || !creds}
-                aria-label="Flush DNS cache"
-                data-testid="dns-flush-cache"
-              >
-                <Eraser size={14} aria-hidden /> {flushing ? 'Flushing…' : 'Flush cache'}
-              </Button>
-              <Button
-                size="sm"
                 variant="danger"
                 onClick={() => setConfirmingReset(true)}
                 disabled={loading || resetting || flushing || applyingFamily || !creds}
@@ -302,9 +300,25 @@ export function DNSPage() {
         <aside className={styles.sidebar}>
           <Card data-testid="family-dns-card">
             <div className={styles.settingRow}>
-              <span className={styles.settingTitle}>
-                <PersonStanding size={16} aria-hidden /> Family DNS
-              </span>
+              <span className={styles.settingTitle}>DNS cache</span>
+              <Button
+                size="sm"
+                variant="secondary"
+                className={styles.purgeButton}
+                onClick={runFlushCache}
+                loading={flushing}
+                disabled={loading || resetting || applyingFamily || !creds}
+                aria-label="Purge DNS cache"
+                data-testid="dns-flush-cache"
+              >
+                {flushing ? 'Purging…' : 'Purge cache'}
+              </Button>
+            </div>
+
+            <Divider className={styles.settingDivider} />
+
+            <div className={styles.settingRow}>
+              <span className={styles.settingTitle}>Family DNS</span>
               <Switch
                 aria-label="Family DNS"
                 checked={familyEnabled}

--- a/frontend/tests/e2e/41-dns-flush-cache.spec.ts
+++ b/frontend/tests/e2e/41-dns-flush-cache.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from './fixtures';
+
+const ROUTER_ID = 'rtr_dns';
+
+test.describe('DNS page flush cache', () => {
+  test('shows the flush cache action next to the existing header actions', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'DNS Router', host: '10.20.30.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: ROUTER_ID, model: 'hAP ax3' });
+    await mockDnsBackend({ id: ROUTER_ID });
+    await page.goto(`/router/${ROUTER_ID}/dns`);
+
+    await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Flush DNS cache' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
+  });
+
+  test('clearing the cache reports success', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'DNS Router', host: '10.20.30.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: ROUTER_ID, model: 'hAP ax3' });
+    await mockDnsBackend({ id: ROUTER_ID });
+    await page.goto(`/router/${ROUTER_ID}/dns`);
+
+    await page.getByRole('button', { name: 'Flush DNS cache' }).click();
+
+    const notifications = page.getByRole('region', { name: 'Notifications' });
+    await expect(notifications).toContainText('DNS cache cleared');
+  });
+
+  test('a failed flush reports the backend error', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'DNS Router', host: '10.20.30.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: ROUTER_ID, model: 'hAP ax3' });
+    await mockDnsBackend({ id: ROUTER_ID, flushFails: true });
+    await page.goto(`/router/${ROUTER_ID}/dns`);
+
+    await page.getByRole('button', { name: 'Flush DNS cache' }).click();
+
+    const notifications = page.getByRole('region', { name: 'Notifications' });
+    await expect(notifications).toContainText('Failed to clear DNS cache');
+    await expect(page.getByRole('button', { name: 'Flush DNS cache' })).toBeEnabled();
+  });
+});

--- a/frontend/tests/e2e/41-dns-flush-cache.spec.ts
+++ b/frontend/tests/e2e/41-dns-flush-cache.spec.ts
@@ -57,6 +57,7 @@ test.describe('DNS page flush cache', () => {
 
     const notifications = page.getByRole('region', { name: 'Notifications' });
     await expect(notifications).toContainText('Failed to clear DNS cache');
+    await expect(notifications).toContainText('Failed to flush DNS cache');
     await expect(page.getByRole('button', { name: 'Flush DNS cache' })).toBeEnabled();
   });
 });

--- a/frontend/tests/e2e/41-dns-flush-cache.spec.ts
+++ b/frontend/tests/e2e/41-dns-flush-cache.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 const ROUTER_ID = 'rtr_dns';
 
 test.describe('DNS page flush cache', () => {
-  test('shows the flush cache action next to the existing header actions', async ({
+  test('shows the purge cache action in the sidebar', async ({
     page,
     resetMocks,
     seedRouter,
@@ -17,7 +17,7 @@ test.describe('DNS page flush cache', () => {
     await page.goto(`/router/${ROUTER_ID}/dns`);
 
     await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Flush DNS cache' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Purge DNS cache' })).toBeEnabled();
     await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
   });
 
@@ -34,7 +34,7 @@ test.describe('DNS page flush cache', () => {
     await mockDnsBackend({ id: ROUTER_ID });
     await page.goto(`/router/${ROUTER_ID}/dns`);
 
-    await page.getByRole('button', { name: 'Flush DNS cache' }).click();
+    await page.getByRole('button', { name: 'Purge DNS cache' }).click();
 
     const notifications = page.getByRole('region', { name: 'Notifications' });
     await expect(notifications).toContainText('DNS cache cleared');
@@ -53,11 +53,80 @@ test.describe('DNS page flush cache', () => {
     await mockDnsBackend({ id: ROUTER_ID, flushFails: true });
     await page.goto(`/router/${ROUTER_ID}/dns`);
 
-    await page.getByRole('button', { name: 'Flush DNS cache' }).click();
+    await page.getByRole('button', { name: 'Purge DNS cache' }).click();
 
     const notifications = page.getByRole('region', { name: 'Notifications' });
     await expect(notifications).toContainText('Failed to clear DNS cache');
     await expect(notifications).toContainText('Failed to flush DNS cache');
-    await expect(page.getByRole('button', { name: 'Flush DNS cache' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Purge DNS cache' })).toBeEnabled();
+  });
+
+  test('disables the button until the response arrives', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'DNS Router', host: '10.20.30.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: ROUTER_ID, model: 'hAP ax3' });
+    await mockDnsBackend({ id: ROUTER_ID });
+
+    let release: () => void = () => {};
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route('**/api/dns/cache', async (route) => {
+      if (route.request().method() !== 'DELETE') return route.fallback();
+      await pending;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/dns`);
+
+    const button = page.getByRole('button', { name: 'Purge DNS cache' });
+    await expect(button).toBeEnabled();
+    await button.click();
+
+    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute('aria-busy', 'true');
+    await expect(button).toHaveText('Purging…');
+
+    release();
+
+    await expect(button).toBeEnabled();
+    await expect(button).toHaveText('Purge cache');
+  });
+
+  test('keeps the spinner up briefly when the response is instant', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: ROUTER_ID, name: 'DNS Router', host: '10.20.30.1', model: 'hAP ax3' });
+    await mockOverviewBackend({ id: ROUTER_ID, model: 'hAP ax3' });
+    await mockDnsBackend({ id: ROUTER_ID });
+    await page.goto(`/router/${ROUTER_ID}/dns`);
+
+    const button = page.getByRole('button', { name: 'Purge DNS cache' });
+    await expect(button).toBeEnabled();
+
+    const startedAt = Date.now();
+    await button.click();
+    await expect(button).toBeDisabled();
+    await expect(button).toBeEnabled({ timeout: 5000 });
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900);
+    await expect(page.getByRole('region', { name: 'Notifications' })).toContainText(
+      'DNS cache cleared',
+    );
   });
 });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -72,6 +72,11 @@ export interface DiagBackendOptions {
   initialProgress?: number;
 }
 
+export interface DnsBackendOptions {
+  id?: string;
+  flushFails?: boolean;
+}
+
 export interface EasyConfigBackendInterface {
   id?: string;
   name: string;
@@ -116,6 +121,7 @@ export interface TestFixtures {
   mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
   mockDhcpBackend: (options?: DhcpBackendOptions) => Promise<void>;
   mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
+  mockDnsBackend: (options?: DnsBackendOptions) => Promise<void>;
   mockEasyConfigBackend: (options: EasyConfigBackendOptions) => Promise<void>;
 }
 
@@ -870,6 +876,62 @@ export const test = base.extend<TestFixtures>({
             'Content-Disposition': 'attachment; filename="nasnet-diagnostic-report.txt"',
           },
           body: 'NasNet Panel Diagnostic Report',
+        });
+      });
+    });
+  },
+  mockDnsBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      const forwarders = [
+        { name: 'Domestic', ip: '78.157.42.100,78.157.42.101', comment: 'domestic' },
+        { name: 'Foreign', ip: '1.1.1.1,8.8.8.8', comment: 'foreign' },
+      ];
+
+      await context.route('**/api/dns/list', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(forwarders),
+        });
+      });
+
+      await context.route('**/api/dns/cache', async (route) => {
+        if (route.request().method() !== 'DELETE') return route.fallback();
+        if (options.flushFails) {
+          return route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: 500,
+              message: 'Failed to flush DNS cache',
+              error: 'Failed to flush DNS cache',
+            }),
+          });
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
         });
       });
     });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -67,14 +67,16 @@ export interface DhcpBackendOptions {
   id?: string;
 }
 
+export interface DnsBackendOptions {
+  id?: string;
+  familyStatus?: number;
+  adBlockStatus?: number;
+  flushFails?: boolean;
+}
+
 export interface DiagBackendOptions {
   id?: string;
   initialProgress?: number;
-}
-
-export interface DnsBackendOptions {
-  id?: string;
-  flushFails?: boolean;
 }
 
 export interface EasyConfigBackendInterface {
@@ -120,8 +122,8 @@ export interface TestFixtures {
   mockWifiBackend: (router?: WifiBackendRouter) => Promise<void>;
   mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
   mockDhcpBackend: (options?: DhcpBackendOptions) => Promise<void>;
-  mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
   mockDnsBackend: (options?: DnsBackendOptions) => Promise<void>;
+  mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
   mockEasyConfigBackend: (options: EasyConfigBackendOptions) => Promise<void>;
 }
 
@@ -817,6 +819,131 @@ export const test = base.extend<TestFixtures>({
       });
     });
   },
+  mockDnsBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      const forwarders = [
+        { name: 'Domestic', ip: '217.218.127.127', description: 'ICT DNS', comment: '' },
+        { name: 'Foreign', ip: '1.1.1.1', description: 'Cloudflare Primary', comment: '' },
+        { name: 'VPN', ip: '1.0.0.1', description: 'Cloudflare Secondary', comment: '' },
+      ];
+
+      await context.route('**/api/dns/list', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(forwarders),
+        });
+      });
+
+      await context.route('**/api/dns/suggest**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ domestic: [], foreign: [] }),
+        });
+      });
+
+      const familyStatus = options.familyStatus ?? 200;
+      await context.route('**/api/dns/family', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        if (familyStatus !== 200) {
+          await route.fulfill({
+            status: familyStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: familyStatus,
+              message: 'VPN DNS forwarder not found',
+              error: 'VPN DNS forwarder not found',
+            }),
+          });
+          return;
+        }
+        forwarders[1] = {
+          name: 'Foreign',
+          ip: '1.1.1.3',
+          description: 'Cloudflare Family Primary',
+          comment: '',
+        };
+        forwarders[2] = {
+          name: 'VPN',
+          ip: '1.0.0.3',
+          description: 'Cloudflare Family Secondary',
+          comment: '',
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({
+            foreign: { oldIp: '1.1.1.1', newIp: '1.1.1.3', servers: ['1.1.1.3'] },
+            vpn: { oldIp: '1.0.0.1', newIp: '1.0.0.3', servers: ['1.0.0.3'] },
+          }),
+        });
+      });
+
+      const adBlockStatus = options.adBlockStatus ?? 200;
+      await context.route('**/api/dns/adblock', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        const body = route.request().postDataJSON() as { enabled?: boolean } | null;
+        const enabled = body?.enabled ?? false;
+        if (adBlockStatus !== 200) {
+          await route.fulfill({
+            status: adBlockStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: adBlockStatus,
+              message: `Ad-block is already ${enabled ? 'enabled' : 'disabled'}`,
+            }),
+          });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ enabled }),
+        });
+      });
+
+      await context.route('**/api/dns/cache', async (route) => {
+        if (route.request().method() !== 'DELETE') return route.fallback();
+        if (options.flushFails) {
+          return route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: 500,
+              message: 'Failed to flush DNS cache',
+              error: 'Failed to flush DNS cache',
+            }),
+          });
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
+        });
+      });
+    });
+  },
   mockDiagBackend: async ({ context }, use) => {
     await use(async (options = {}) => {
       if (options.id) {
@@ -876,62 +1003,6 @@ export const test = base.extend<TestFixtures>({
             'Content-Disposition': 'attachment; filename="nasnet-diagnostic-report.txt"',
           },
           body: 'NasNet Panel Diagnostic Report',
-        });
-      });
-    });
-  },
-  mockDnsBackend: async ({ context }, use) => {
-    await use(async (options = {}) => {
-      if (options.id) {
-        await context.addInitScript((routerId) => {
-          try {
-            const key = 'nasnet-panel.session-credentials.v1';
-            const raw = window.sessionStorage.getItem(key);
-            const map = (raw ? JSON.parse(raw) : {}) as Record<
-              string,
-              { username: string; password: string }
-            >;
-            map[routerId] = { username: 'admin', password: 'test' };
-            window.sessionStorage.setItem(key, JSON.stringify(map));
-          } catch {
-            /* ignore */
-          }
-        }, options.id);
-      }
-
-      const envelope = <T>(data: T, status = 200) =>
-        JSON.stringify({ status, message: 'OK', data });
-
-      const forwarders = [
-        { name: 'Domestic', ip: '78.157.42.100,78.157.42.101', comment: 'domestic' },
-        { name: 'Foreign', ip: '1.1.1.1,8.8.8.8', comment: 'foreign' },
-      ];
-
-      await context.route('**/api/dns/list', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: envelope(forwarders),
-        });
-      });
-
-      await context.route('**/api/dns/cache', async (route) => {
-        if (route.request().method() !== 'DELETE') return route.fallback();
-        if (options.flushFails) {
-          return route.fulfill({
-            status: 500,
-            contentType: 'application/json',
-            body: JSON.stringify({
-              status: 500,
-              message: 'Failed to flush DNS cache',
-              error: 'Failed to flush DNS cache',
-            }),
-          });
-        }
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
         });
       });
     });


### PR DESCRIPTION
Closes #664

- adds a Flush cache action to the DNS page header next to Refresh and Reset
- disables the header and row actions while the flush is in flight
- reports success or the backend error through a toast


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Family DNS management, including detection and enable/disable controls.
  * Added DNS provider information to the DNS table.
  * Moved cache purging to a dedicated settings sidebar.
* **Bug Fixes**
  * Improved error messages and handling for unsuccessful DNS operations.
  * Prevented conflicting DNS actions while another operation is in progress.
* **Style**
  * Added clearer loading feedback and enhanced purge-button hover transitions.
* **Tests**
  * Expanded coverage for cache purging, loading states, errors, and control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->