### PR TITLE
feat(fe): add ad-block toggle to the DNS page

### DIFF
--- a/frontend/src/api/dns.ts
+++ b/frontend/src/api/dns.ts
@@ -98,6 +98,19 @@ export async function changeDns(
   });
 }
 
+export async function setDnsAdBlock(
+  creds: DnsCredentials,
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiRequest('/api/dns/adblock', {
+    method: 'POST',
+    headers: authHeaders(creds),
+    body: JSON.stringify({ enabled }),
+    signal,
+  });
+}
+
 export async function resetDns(creds: DnsCredentials, signal?: AbortSignal): Promise<void> {
   await apiRequest('/api/dns/reset', {
     method: 'POST',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -76,6 +76,7 @@ export {
   validateDnsChange,
   changeDns,
   resetDns,
+  setDnsAdBlock,
   type DnsCredentials,
   type DnsForwarderType,
   type DnsForwarderListItem,

--- a/frontend/src/routes/DNSPage.module.scss
+++ b/frontend/src/routes/DNSPage.module.scss
@@ -88,3 +88,24 @@
   grid-template-columns: 180px 1fr;
   gap: var(--space-sm) var(--space-md);
 }
+
+.warning {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-alt);
+  font-size: var(--font-sm);
+
+  p {
+    margin: 0;
+  }
+}
+
+.warningIcon {
+  color: var(--color-warning);
+  flex-shrink: 0;
+  margin-top: 2px;
+}

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
+import {
+  Globe,
+  Pencil,
+  RefreshCw,
+  RotateCcw,
+  SearchX,
+  ShieldBan,
+  TriangleAlert,
+} from 'lucide-react';
 import {
   Badge,
   Button,
@@ -13,14 +21,17 @@ import {
   Inline,
   Skeleton,
   Stack,
+  Switch,
   useToast,
   type DataTableColumn,
 } from '@nasnet/ui';
 import styles from './DNSPage.module.scss';
 import { DNSChangeDialog } from './DNSChangeDialog';
 import {
+  ApiError,
   fetchDnsForwarders,
   resetDns,
+  setDnsAdBlock,
   type DnsCredentials,
   type DnsForwarderListItem,
 } from '../api';
@@ -32,6 +43,26 @@ const TYPE_TONES: Record<string, 'info' | 'primary' | 'success'> = {
   Foreign: 'primary',
   VPN: 'success',
 };
+
+const ADBLOCK_STORAGE_PREFIX = 'nasnet-panel.dns-adblock.';
+
+function readStoredAdBlock(routerId: string | undefined): boolean {
+  if (!routerId || typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(`${ADBLOCK_STORAGE_PREFIX}${routerId}`) === 'on';
+  } catch {
+    return false;
+  }
+}
+
+function storeAdBlock(routerId: string | undefined, enabled: boolean): void {
+  if (!routerId || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`${ADBLOCK_STORAGE_PREFIX}${routerId}`, enabled ? 'on' : 'off');
+  } catch {
+    /* ignore */
+  }
+}
 
 export function DNSPage() {
   const { id } = useParams<{ id: string }>();
@@ -45,6 +76,8 @@ export function DNSPage() {
   const [editing, setEditing] = useState<DnsForwarderListItem | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [adBlockEnabled, setAdBlockEnabled] = useState(false);
+  const [adBlockBusy, setAdBlockBusy] = useState(false);
 
   const creds = useMemo<DnsCredentials | null>(() => {
     if (!id) return null;
@@ -76,6 +109,38 @@ export function DNSPage() {
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  useEffect(() => {
+    setAdBlockEnabled(readStoredAdBlock(id));
+  }, [id]);
+
+  const toggleAdBlock = async (next: boolean) => {
+    if (!creds) return;
+    setAdBlockBusy(true);
+    try {
+      await setDnsAdBlock(creds, next);
+      setAdBlockEnabled(next);
+      storeAdBlock(id, next);
+      toast.notify({
+        title: next ? 'Ad-block enabled' : 'Ad-block disabled',
+        tone: 'success',
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setAdBlockEnabled(next);
+        storeAdBlock(id, next);
+        toast.notify({
+          title: next ? 'Ad-block was already on' : 'Ad-block was already off',
+          tone: 'info',
+        });
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Failed to update ad-block.';
+      toast.notify({ title: 'Failed to update ad-block', description: message, tone: 'danger' });
+    } finally {
+      setAdBlockBusy(false);
+    }
+  };
 
   const runReset = async () => {
     if (!creds) return;
@@ -186,6 +251,40 @@ export function DNSPage() {
             emptyMessage="No DNS servers configured"
           />
         )}
+      </Card>
+
+      <Card data-testid="dns-adblock">
+        <CardHeader className={styles.cardHeader}>
+          <div>
+            <CardTitle>
+              <Inline>
+                <ShieldBan size={16} aria-hidden /> Ad-block
+              </Inline>
+            </CardTitle>
+            <CardDescription>
+              Filters known advertising and tracking domains at the router, so ads are blocked on
+              every device on the network without installing anything on them.
+            </CardDescription>
+          </div>
+          <div className={styles.headerActions}>
+            <Switch
+              label="Enable ad-block"
+              checked={adBlockEnabled}
+              onChange={(e) => {
+                void toggleAdBlock(e.target.checked);
+              }}
+              disabled={!creds || adBlockBusy}
+              aria-describedby="dns-adblock-warning"
+            />
+          </div>
+        </CardHeader>
+        <div className={styles.warning} id="dns-adblock-warning" role="note">
+          <TriangleAlert size={16} aria-hidden className={styles.warningIcon} />
+          <p>
+            Some websites stop working while an ad-blocker is active and ask visitors to turn it off
+            before they show their content. Turn ad-block off again if a site you need breaks.
+          </p>
+        </div>
       </Card>
 
       {editing && creds ? (

--- a/frontend/src/routes/DNSPage.tsx
+++ b/frontend/src/routes/DNSPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Globe, Pencil, RefreshCw, RotateCcw, SearchX } from 'lucide-react';
 import {
@@ -96,6 +96,7 @@ export function DNSPage() {
   const [resetting, setResetting] = useState(false);
   const [adBlockEnabled, setAdBlockEnabled] = useState(false);
   const [adBlockBusy, setAdBlockBusy] = useState(false);
+  const activeRouterRef = useRef(id);
   const [flushing, setFlushing] = useState(false);
   const [confirmingFamily, setConfirmingFamily] = useState<'enable' | 'disable' | null>(null);
   const [applyingFamily, setApplyingFamily] = useState(false);
@@ -136,34 +137,42 @@ export function DNSPage() {
   }, [reload]);
 
   useEffect(() => {
+    activeRouterRef.current = id;
     setAdBlockEnabled(readStoredAdBlock(id));
+    setAdBlockBusy(false);
   }, [id]);
 
   const toggleAdBlock = async (next: boolean) => {
     if (!creds) return;
+    const requestId = id;
     setAdBlockBusy(true);
     try {
       await setDnsAdBlock(creds, next);
+      storeAdBlock(requestId, next);
+      if (activeRouterRef.current !== requestId) return;
       setAdBlockEnabled(next);
-      storeAdBlock(id, next);
       toast.notify({
         title: next ? 'Ad-block enabled' : 'Ad-block disabled',
         tone: 'success',
       });
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
+        storeAdBlock(requestId, next);
+        if (activeRouterRef.current !== requestId) return;
         setAdBlockEnabled(next);
-        storeAdBlock(id, next);
         toast.notify({
           title: next ? 'Ad-block was already on' : 'Ad-block was already off',
           tone: 'info',
         });
         return;
       }
+      if (activeRouterRef.current !== requestId) return;
       const message = err instanceof Error ? err.message : 'Failed to update ad-block.';
       toast.notify({ title: 'Failed to update ad-block', description: message, tone: 'danger' });
     } finally {
-      setAdBlockBusy(false);
+      if (activeRouterRef.current === requestId) {
+        setAdBlockBusy(false);
+      }
     }
   };
 

--- a/frontend/tests/e2e/41-dns-adblock.spec.ts
+++ b/frontend/tests/e2e/41-dns-adblock.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures';
 
-test.describe('DNS page — ad-block', () => {
+test.describe('DNS page ad-block', () => {
   test('explains what ad-block does and warns about broken sites', async ({
     page,
     resetMocks,

--- a/frontend/tests/e2e/41-dns-adblock.spec.ts
+++ b/frontend/tests/e2e/41-dns-adblock.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from './fixtures';
+
+test.describe('DNS page — ad-block', () => {
+  test('explains what ad-block does and warns about broken sites', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_ab1', name: 'AdBlock Router', host: '10.20.0.1' });
+    await mockOverviewBackend({ id: 'rtr_ab1' });
+    await mockDnsBackend({ id: 'rtr_ab1' });
+
+    await page.goto('/router/rtr_ab1/dns');
+
+    const card = page.getByTestId('dns-adblock');
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(/advertising and tracking domains/i);
+    await expect(card).toContainText(/some websites stop working/i);
+
+    const toggle = page.getByRole('switch', { name: 'Enable ad-block' });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+  });
+
+  test('turns ad-block on and keeps the toggle on after a reload', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_ab2', name: 'AdBlock Router', host: '10.20.0.2' });
+    await mockOverviewBackend({ id: 'rtr_ab2' });
+    await mockDnsBackend({ id: 'rtr_ab2' });
+
+    const requests: Array<boolean | undefined> = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/dns/adblock')) {
+        const body = req.postDataJSON() as { enabled?: boolean } | null;
+        requests.push(body?.enabled);
+      }
+    });
+
+    await page.goto('/router/rtr_ab2/dns');
+
+    const toggle = page.getByRole('switch', { name: 'Enable ad-block' });
+    await toggle.click();
+
+    await expect(page.getByText('Ad-block enabled')).toBeVisible();
+    await expect(toggle).toBeChecked();
+    expect(requests).toEqual([true]);
+
+    await page.reload();
+    await expect(page.getByRole('switch', { name: 'Enable ad-block' })).toBeChecked();
+  });
+
+  test('reconciles the toggle when the router is already in that state', async ({
+    page,
+    resetMocks,
+    seedRouter,
+    mockOverviewBackend,
+    mockDnsBackend,
+  }) => {
+    await resetMocks();
+    await seedRouter({ id: 'rtr_ab3', name: 'AdBlock Router', host: '10.20.0.3' });
+    await mockOverviewBackend({ id: 'rtr_ab3' });
+    await mockDnsBackend({ id: 'rtr_ab3', adBlockStatus: 409 });
+
+    await page.goto('/router/rtr_ab3/dns');
+
+    const toggle = page.getByRole('switch', { name: 'Enable ad-block' });
+    await toggle.click();
+
+    await expect(page.getByText('Ad-block was already on')).toBeVisible();
+    await expect(page.getByText('Failed to update ad-block')).toHaveCount(0);
+    await expect(toggle).toBeChecked();
+
+    await page.reload();
+    await expect(page.getByRole('switch', { name: 'Enable ad-block' })).toBeChecked();
+  });
+});

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -67,6 +67,11 @@ export interface DhcpBackendOptions {
   id?: string;
 }
 
+export interface DnsBackendOptions {
+  id?: string;
+  adBlockStatus?: number;
+}
+
 export interface DiagBackendOptions {
   id?: string;
   initialProgress?: number;
@@ -115,6 +120,7 @@ export interface TestFixtures {
   mockWifiBackend: (router?: WifiBackendRouter) => Promise<void>;
   mockLogsBackend: (options?: LogsBackendOptions) => Promise<void>;
   mockDhcpBackend: (options?: DhcpBackendOptions) => Promise<void>;
+  mockDnsBackend: (options?: DnsBackendOptions) => Promise<void>;
   mockDiagBackend: (options?: DiagBackendOptions) => Promise<void>;
   mockEasyConfigBackend: (options: EasyConfigBackendOptions) => Promise<void>;
 }
@@ -807,6 +813,74 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope({ macAddress: 'AA:BB:CC:DD:EE:02', id: '*2', address: '192.168.88.102' }),
+        });
+      });
+    });
+  },
+  mockDnsBackend: async ({ context }, use) => {
+    await use(async (options = {}) => {
+      if (options.id) {
+        await context.addInitScript((routerId) => {
+          try {
+            const key = 'nasnet-panel.session-credentials.v1';
+            const raw = window.sessionStorage.getItem(key);
+            const map = (raw ? JSON.parse(raw) : {}) as Record<
+              string,
+              { username: string; password: string }
+            >;
+            map[routerId] = { username: 'admin', password: 'test' };
+            window.sessionStorage.setItem(key, JSON.stringify(map));
+          } catch {
+            /* ignore */
+          }
+        }, options.id);
+      }
+
+      const envelope = <T>(data: T, status = 200) =>
+        JSON.stringify({ status, message: 'OK', data });
+
+      const forwarders = [
+        { name: 'Domestic', ip: '217.218.127.127', comment: '' },
+        { name: 'Foreign', ip: '1.1.1.1', comment: '' },
+        { name: 'VPN', ip: '1.0.0.1', comment: '' },
+      ];
+
+      await context.route('**/api/dns/list', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope(forwarders),
+        });
+      });
+
+      await context.route('**/api/dns/suggest', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ domestic: [], foreign: [] }),
+        });
+      });
+
+      const adBlockStatus = options.adBlockStatus ?? 200;
+      await context.route('**/api/dns/adblock', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        const body = route.request().postDataJSON() as { enabled?: boolean } | null;
+        const enabled = body?.enabled ?? false;
+        if (adBlockStatus !== 200) {
+          await route.fulfill({
+            status: adBlockStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: adBlockStatus,
+              message: `Ad-block is already ${enabled ? 'enabled' : 'disabled'}`,
+            }),
+          });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ enabled }),
         });
       });
     });

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -69,7 +69,9 @@ export interface DhcpBackendOptions {
 
 export interface DnsBackendOptions {
   id?: string;
+  familyStatus?: number;
   adBlockStatus?: number;
+  flushFails?: boolean;
 }
 
 export interface DiagBackendOptions {
@@ -840,9 +842,9 @@ export const test = base.extend<TestFixtures>({
         JSON.stringify({ status, message: 'OK', data });
 
       const forwarders = [
-        { name: 'Domestic', ip: '217.218.127.127', comment: '' },
-        { name: 'Foreign', ip: '1.1.1.1', comment: '' },
-        { name: 'VPN', ip: '1.0.0.1', comment: '' },
+        { name: 'Domestic', ip: '217.218.127.127', description: 'ICT DNS', comment: '' },
+        { name: 'Foreign', ip: '1.1.1.1', description: 'Cloudflare Primary', comment: '' },
+        { name: 'VPN', ip: '1.0.0.1', description: 'Cloudflare Secondary', comment: '' },
       ];
 
       await context.route('**/api/dns/list', async (route) => {
@@ -853,11 +855,48 @@ export const test = base.extend<TestFixtures>({
         });
       });
 
-      await context.route('**/api/dns/suggest', async (route) => {
+      await context.route('**/api/dns/suggest**', async (route) => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
           body: envelope({ domestic: [], foreign: [] }),
+        });
+      });
+
+      const familyStatus = options.familyStatus ?? 200;
+      await context.route('**/api/dns/family', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        if (familyStatus !== 200) {
+          await route.fulfill({
+            status: familyStatus,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: familyStatus,
+              message: 'VPN DNS forwarder not found',
+              error: 'VPN DNS forwarder not found',
+            }),
+          });
+          return;
+        }
+        forwarders[1] = {
+          name: 'Foreign',
+          ip: '1.1.1.3',
+          description: 'Cloudflare Family Primary',
+          comment: '',
+        };
+        forwarders[2] = {
+          name: 'VPN',
+          ip: '1.0.0.3',
+          description: 'Cloudflare Family Secondary',
+          comment: '',
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({
+            foreign: { oldIp: '1.1.1.1', newIp: '1.1.1.3', servers: ['1.1.1.3'] },
+            vpn: { oldIp: '1.0.0.1', newIp: '1.0.0.3', servers: ['1.0.0.3'] },
+          }),
         });
       });
 
@@ -881,6 +920,26 @@ export const test = base.extend<TestFixtures>({
           status: 200,
           contentType: 'application/json',
           body: envelope({ enabled }),
+        });
+      });
+
+      await context.route('**/api/dns/cache', async (route) => {
+        if (route.request().method() !== 'DELETE') return route.fallback();
+        if (options.flushFails) {
+          return route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              status: 500,
+              message: 'Failed to flush DNS cache',
+              error: 'Failed to flush DNS cache',
+            }),
+          });
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 200, message: 'DNS cache cleared successfully' }),
         });
       });
     });


### PR DESCRIPTION
Closes #661

- adds an ad-block switch to the DNS page with a plain description of what it filters
- warns that some sites stop working while an ad-blocker is active
- remembers the toggle position per router in local storage, since the router state cannot be read back
- treats an already-in-that-state response as informational and reconciles the toggle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a DNS ad-block setting with an on/off switch.
  - The selected ad-block state persists after page reloads.
  - Added confirmation and warning notifications, with guidance available through an accessible tooltip.
  - The control is temporarily disabled while changes are being applied.
  - Added handling for settings that are already enabled, keeping the displayed state accurate.

- **Tests**
  - Added end-to-end coverage for the default state, enabling ad-block, persistence, informational content, and backend state reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->