### PR TITLE
feat(fe): Require at least 8 characters for OpenVPN passwords

### DIFF
--- a/frontend/src/routes/easy-config/steps/VpnServerStep.tsx
+++ b/frontend/src/routes/easy-config/steps/VpnServerStep.tsx
@@ -5,12 +5,14 @@ import {
   CardHeader,
   CardTitle,
   FieldRow,
+  FormError,
   Input,
   Label,
   PasswordInput,
   Stack,
   Switch,
 } from '@nasnet/ui';
+import { validateOvpnSecret } from '../../../utils/validators';
 import wizardStyles from '../../EasyConfigWizard.module.scss';
 import type { Action, State } from '../state';
 import { Collapsible } from './components/Collapsible';
@@ -25,6 +27,11 @@ interface Props {
 export function VpnServerStep({ state, dispatch, footer }: Props) {
   const set = (field: keyof State) => (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch({ type: 'setField', field, value: e.target.value });
+
+  const certPassphraseError = state.vpnServerCertPassphrase
+    ? validateOvpnSecret(state.vpnServerCertPassphrase, 'Certificate passphrase')
+    : null;
+  const firstUserKeyError = state.firstUserKey ? validateOvpnSecret(state.firstUserKey) : null;
 
   return (
     <Card>
@@ -52,7 +59,9 @@ export function VpnServerStep({ state, dispatch, footer }: Props) {
                     value={state.vpnServerCertPassphrase}
                     onChange={set('vpnServerCertPassphrase')}
                     aria-label="Certificate passphrase"
+                    aria-invalid={!!certPassphraseError}
                   />
+                  {certPassphraseError ? <FormError>{certPassphraseError}</FormError> : null}
                 </Label>
               </FieldRow>
               <FieldRow>
@@ -72,7 +81,9 @@ export function VpnServerStep({ state, dispatch, footer }: Props) {
                     value={state.firstUserKey}
                     onChange={set('firstUserKey')}
                     aria-label="Password"
+                    aria-invalid={!!firstUserKeyError}
                   />
+                  {firstUserKeyError ? <FormError>{firstUserKeyError}</FormError> : null}
                 </Label>
               </FieldRow>
             </Stack>

--- a/frontend/src/routes/easy-config/steps/VpnServerStep.tsx
+++ b/frontend/src/routes/easy-config/steps/VpnServerStep.tsx
@@ -28,10 +28,11 @@ export function VpnServerStep({ state, dispatch, footer }: Props) {
   const set = (field: keyof State) => (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch({ type: 'setField', field, value: e.target.value });
 
-  const certPassphraseError = state.vpnServerCertPassphrase
-    ? validateOvpnSecret(state.vpnServerCertPassphrase, 'Certificate passphrase')
-    : null;
-  const firstUserKeyError = state.firstUserKey ? validateOvpnSecret(state.firstUserKey) : null;
+  const certPassphraseError = validateOvpnSecret(
+    state.vpnServerCertPassphrase,
+    'Certificate passphrase',
+  );
+  const firstUserKeyError = validateOvpnSecret(state.firstUserKey);
 
   return (
     <Card>

--- a/frontend/src/routes/easy-config/steps/vpnsrv/FirstUserForm.tsx
+++ b/frontend/src/routes/easy-config/steps/vpnsrv/FirstUserForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FieldRow, Input, Label, PasswordInput } from '@nasnet/ui';
+import { FieldRow, FormError, Input, Label, PasswordInput } from '@nasnet/ui';
+import { validateOvpnSecret } from '../../../../utils/validators';
 import type { Action, State, VpnServerProtocol } from '../../state';
 
 interface Props {
@@ -14,6 +15,8 @@ function keyLabel(protocol: VpnServerProtocol): string {
 
 export function FirstUserForm({ state, dispatch }: Props) {
   const isPassword = state.vpnServerProtocol !== 'wireguard';
+  const passwordError =
+    isPassword && state.firstUserKey ? validateOvpnSecret(state.firstUserKey) : null;
   return (
     <FieldRow>
       <Label>
@@ -35,6 +38,7 @@ export function FirstUserForm({ state, dispatch }: Props) {
               dispatch({ type: 'setField', field: 'firstUserKey', value: e.target.value })
             }
             aria-label="First user password"
+            aria-invalid={!!passwordError}
           />
         ) : (
           <Input
@@ -45,6 +49,7 @@ export function FirstUserForm({ state, dispatch }: Props) {
             aria-label="First user public key"
           />
         )}
+        {passwordError ? <FormError>{passwordError}</FormError> : null}
       </Label>
     </FieldRow>
   );

--- a/frontend/src/routes/easy-config/steps/vpnsrv/FirstUserForm.tsx
+++ b/frontend/src/routes/easy-config/steps/vpnsrv/FirstUserForm.tsx
@@ -15,8 +15,7 @@ function keyLabel(protocol: VpnServerProtocol): string {
 
 export function FirstUserForm({ state, dispatch }: Props) {
   const isPassword = state.vpnServerProtocol !== 'wireguard';
-  const passwordError =
-    isPassword && state.firstUserKey ? validateOvpnSecret(state.firstUserKey) : null;
+  const passwordError = isPassword ? validateOvpnSecret(state.firstUserKey) : null;
   return (
     <FieldRow>
       <Label>

--- a/frontend/src/routes/easy-config/validation.ts
+++ b/frontend/src/routes/easy-config/validation.ts
@@ -1,4 +1,11 @@
-import { isIPv4, isPort, isRequired, isSsid, isWifiPassword } from '../../utils/validators';
+import {
+  isIPv4,
+  isPort,
+  isRequired,
+  isSsid,
+  isWifiPassword,
+  validateOvpnSecret,
+} from '../../utils/validators';
 import type { State } from './state';
 
 const FORBIDDEN_SSID_WORDS = ['star', 'starlink', 'vpn', 'iran'];
@@ -69,14 +76,16 @@ export function canAdvance(state: State): string | null {
       }
       return null;
     }
-    case 'vpnsrv':
+    case 'vpnsrv': {
       if (!state.vpnServerEnabled) return null;
-      if (!isRequired(state.vpnServerCertPassphrase)) {
-        return 'Certificate passphrase is required.';
-      }
+      const passphraseProblem = validateOvpnSecret(
+        state.vpnServerCertPassphrase,
+        'Certificate passphrase',
+      );
+      if (passphraseProblem) return passphraseProblem;
       if (!isRequired(state.firstUserName)) return 'Username is required.';
-      if (!isRequired(state.firstUserKey)) return 'Password is required.';
-      return null;
+      return validateOvpnSecret(state.firstUserKey);
+    }
     default:
       return null;
   }

--- a/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/AddVpnServerDialog.tsx
@@ -26,7 +26,7 @@ import {
   type SstpServerTaskStatus,
   type VPNCredentials,
 } from '../../../api';
-import { isCIDR, isPort, validateIdentifier } from '../../../utils/validators';
+import { isCIDR, isPort, validateIdentifier, validateOvpnSecret } from '../../../utils/validators';
 import { pollSstpServerTask } from '../sstpTask';
 
 export type AddVpnServerType = 'openvpn' | 'wireguard' | 'sstp';
@@ -144,7 +144,7 @@ function OvpnServerForm({ creds, onCancel, onCreated }: FormProps) {
 
   const errors = useMemo(
     () => ({
-      certPassphrase: certPassphrase ? null : 'Certificate passphrase is required.',
+      certPassphrase: validateOvpnSecret(certPassphrase, 'Certificate passphrase'),
     }),
     [certPassphrase],
   );

--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
@@ -23,6 +23,7 @@ import {
   type VPNProfileResponse,
   type VPNUserResponse,
 } from '../../../api';
+import { validateOvpnSecret } from '../../../utils/validators';
 import styles from './UserFormDialog.module.scss';
 
 const PREFERRED_PROFILE = 'VPN-VPN';
@@ -126,7 +127,7 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
   const errors = useMemo(
     () => ({
       name: draft.name.trim() === '' ? 'Name is required.' : null,
-      password: draft.password === '' ? 'Password is required.' : null,
+      password: validateOvpnSecret(draft.password),
       profile: draft.profile === '' ? 'Profile is required.' : null,
     }),
     [draft],

--- a/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
+++ b/frontend/src/routes/vpn/dialogs/UserFormDialog.tsx
@@ -58,12 +58,13 @@ interface Props {
 }
 
 export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
+  const isEdit = !!user;
   const [profiles, setProfiles] = useState<VPNProfileResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [draft, setDraft] = useState<Draft>({
     name: user?.name ?? '',
-    password: user?.password ?? '',
+    password: '',
     profile: user?.profile ?? '',
     disabled: user?.disabled ?? false,
   });
@@ -127,10 +128,10 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
   const errors = useMemo(
     () => ({
       name: draft.name.trim() === '' ? 'Name is required.' : null,
-      password: validateOvpnSecret(draft.password),
+      password: isEdit && draft.password === '' ? null : validateOvpnSecret(draft.password),
       profile: draft.profile === '' ? 'Profile is required.' : null,
     }),
-    [draft],
+    [draft, isEdit],
   );
 
   const hasErrors = Object.values(errors).some(Boolean);
@@ -148,7 +149,7 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
         const body: UpdateVPNUserRequest = {};
         const name = draft.name.trim();
         if (name !== user.name) body.name = name;
-        if (draft.password !== user.password) body.password = draft.password;
+        if (draft.password !== '') body.password = draft.password;
         if (draft.profile !== user.profile) body.profile = draft.profile;
         if (draft.disabled !== user.disabled) body.disabled = draft.disabled;
         if (Object.keys(body).length > 0) {
@@ -248,6 +249,7 @@ export function UserFormDialog({ creds, user, onCancel, onSaved }: Props) {
                 aria-label="Password"
                 aria-invalid={touched.password && !!errors.password}
                 autoComplete="new-password"
+                placeholder={isEdit ? 'Leave blank to keep the current password' : undefined}
               />
               {touched.password && errors.password ? (
                 <FormError>{errors.password}</FormError>

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -35,6 +35,16 @@ export const isWifiPassword = (value: string): boolean => value.length >= 8 && v
 export const isRequired = (value: string | undefined | null): boolean =>
   typeof value === 'string' && value.trim().length > 0;
 
+export const OVPN_PASSWORD_MIN_LENGTH = 8;
+
+export function validateOvpnSecret(value: string, label = 'Password'): string | null {
+  if (!isRequired(value)) return `${label} is required.`;
+  if (value.length < OVPN_PASSWORD_MIN_LENGTH) {
+    return `${label} must be at least ${OVPN_PASSWORD_MIN_LENGTH} characters.`;
+  }
+  return null;
+}
+
 const IDENTIFIER_RE = /^[A-Za-z0-9_-]+$/;
 const HOSTNAME_RE =
   /^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/;

--- a/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
+++ b/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
@@ -43,10 +43,22 @@ AllowedIPs = 0.0.0.0/0`);
     await page.getByRole('switch', { name: /enabled|disabled/i }).check();
     await page.getByLabel(/certificate passphrase/i).fill('super-secret');
     await page.getByLabel(/^username$/i).fill('alice');
-    await page.getByLabel(/^password$/i).fill('alice-pass');
+
+    const password = page.getByLabel(/^password$/i);
+    const apply = page.getByRole('button', { name: /^apply$/i });
+
+    // a password shorter than 8 characters blocks the step
+    await password.fill('short12');
+    await expect(page.getByText('Password must be at least 8 characters.')).toBeVisible();
+    await expect(password).toHaveAttribute('aria-invalid', 'true');
+    await expect(apply).toBeDisabled();
+
+    await password.fill('alice-pass');
+    await expect(page.getByText('Password must be at least 8 characters.')).toBeHidden();
 
     // Apply from the VPN Server step (last step)
-    await page.getByRole('button', { name: /^apply$/i }).click();
+    await expect(apply).toBeEnabled();
+    await apply.click();
     await expect(page.getByText(/configuration applied/i).first()).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
+++ b/frontend/tests/e2e/09-easy-config-vpn-server.spec.ts
@@ -41,11 +41,20 @@ AllowedIPs = 0.0.0.0/0`);
 
     // Step 5 — VPN Server
     await page.getByRole('switch', { name: /enabled|disabled/i }).check();
-    await page.getByLabel(/certificate passphrase/i).fill('super-secret');
-    await page.getByLabel(/^username$/i).fill('alice');
 
+    const passphrase = page.getByLabel(/certificate passphrase/i);
     const password = page.getByLabel(/^password$/i);
     const apply = page.getByRole('button', { name: /^apply$/i });
+
+    await expect(page.getByText('Certificate passphrase is required.')).toBeVisible();
+    await expect(passphrase).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByText('Password is required.')).toBeVisible();
+    await expect(password).toHaveAttribute('aria-invalid', 'true');
+    await expect(apply).toBeDisabled();
+
+    await passphrase.fill('super-secret');
+    await expect(page.getByText('Certificate passphrase is required.')).toBeHidden();
+    await page.getByLabel(/^username$/i).fill('alice');
 
     // a password shorter than 8 characters blocks the step
     await password.fill('short12');

--- a/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
+++ b/frontend/tests/e2e/10-vpn-server-peers-crud.spec.ts
@@ -344,7 +344,16 @@ test.describe('VPN servers tab', () => {
     await expect(dialog.getByText('Certificate passphrase is required.')).toBeVisible();
     expect(lastPostBody).toBeNull();
 
-    await dialog.getByLabel('Client certificate passphrase', { exact: true }).fill('certpass123');
+    const passphrase = dialog.getByLabel('Client certificate passphrase', { exact: true });
+    await passphrase.fill('short12');
+    await dialog.getByRole('button', { name: 'Create OpenVPN server' }).click();
+    await expect(
+      dialog.getByText('Certificate passphrase must be at least 8 characters.'),
+    ).toBeVisible();
+    await expect(passphrase).toHaveAttribute('aria-invalid', 'true');
+    expect(lastPostBody).toBeNull();
+
+    await passphrase.fill('certpass123');
     await dialog.getByRole('button', { name: 'Create OpenVPN server' }).click();
 
     await expect

--- a/frontend/tests/e2e/30-vpn-users-crud.spec.ts
+++ b/frontend/tests/e2e/30-vpn-users-crud.spec.ts
@@ -175,7 +175,7 @@ test.describe('VPN users section', () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: envelope({ ...baseUsers[1], disabled: false, password: 'bob456' }),
+          body: envelope({ ...baseUsers[1], disabled: false, password: 'bob45678' }),
         });
         return;
       }
@@ -199,11 +199,11 @@ test.describe('VPN users section', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByLabel('Name')).toHaveValue('bob');
 
-    await dialog.getByLabel('Password', { exact: true }).fill('bob456');
+    await dialog.getByLabel('Password', { exact: true }).fill('bob45678');
     await dialog.getByRole('switch', { name: /enabled/i }).click();
     await dialog.getByRole('button', { name: 'Save changes' }).click();
 
-    await expect.poll(() => lastPutBody).toEqual({ password: 'bob456', disabled: false });
+    await expect.poll(() => lastPutBody).toEqual({ password: 'bob45678', disabled: false });
     await expect(dialog).toBeHidden();
 
     await page.getByRole('button', { name: 'Delete alice' }).click();
@@ -211,5 +211,66 @@ test.describe('VPN users section', () => {
     await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
     await expect.poll(() => deletedUrl).toContain('/api/vpn/users/*1');
+  });
+
+  test('blocks a password shorter than 8 characters', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await setup(context, resetMocks, seedRouter);
+
+    let posted = false;
+    await context.route('**/api/vpn/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        posted = true;
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: envelope({
+            id: '*3',
+            name: 'dave',
+            service: 'any',
+            profile: 'VPN-VPN',
+            password: 'dave1234',
+            disabled: false,
+            limitBytesIn: 0,
+            limitBytesOut: 0,
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(baseUsers),
+      });
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+    await page.getByRole('button', { name: 'Add user' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const password = dialog.getByLabel('Password', { exact: true });
+    const submit = dialog.getByRole('button', { name: 'Create user' });
+    await dialog.getByLabel('Name').fill('dave');
+    await password.fill('short12');
+    await password.press('Tab');
+
+    await expect(dialog.getByText('Password must be at least 8 characters.')).toBeVisible();
+    await expect(password).toHaveAttribute('aria-invalid', 'true');
+    await expect(submit).toBeDisabled();
+    expect(posted).toBe(false);
+
+    await password.fill('dave1234');
+    await expect(dialog.getByText('Password must be at least 8 characters.')).toBeHidden();
+    await expect(submit).toBeEnabled();
+    await submit.click();
+
+    await expect.poll(() => posted).toBe(true);
+    await expect(dialog).toBeHidden();
   });
 });

--- a/frontend/tests/e2e/30-vpn-users-crud.spec.ts
+++ b/frontend/tests/e2e/30-vpn-users-crud.spec.ts
@@ -213,6 +213,71 @@ test.describe('VPN users section', () => {
     await expect.poll(() => deletedUrl).toContain('/api/vpn/users/*1');
   });
 
+  test('edits a user with a short stored password without resending it', async ({
+    page,
+    context,
+    resetMocks,
+    seedRouter,
+  }) => {
+    await setup(context, resetMocks, seedRouter);
+
+    await context.route('**/api/vpn/users', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: envelope(baseUsers),
+      });
+    });
+
+    let lastPutBody: {
+      name?: string;
+      password?: string;
+      profile?: string;
+      disabled?: boolean;
+    } | null = null;
+    await context.route('**/api/vpn/users/*', async (route) => {
+      if (route.request().method() === 'PUT') {
+        lastPutBody = route.request().postDataJSON() as typeof lastPutBody;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: envelope({ ...baseUsers[1], disabled: false }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`/router/${ROUTER_ID}/vpn`);
+
+    await page.getByRole('button', { name: 'Edit bob' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const password = dialog.getByLabel('Password', { exact: true });
+    const submit = dialog.getByRole('button', { name: 'Save changes' });
+    await expect(password).toHaveValue('');
+    await expect(password).toHaveAttribute('placeholder', /keep the current password/i);
+    await expect(submit).toBeEnabled();
+
+    await password.fill('short12');
+    await password.press('Tab');
+    await expect(dialog.getByText('Password must be at least 8 characters.')).toBeVisible();
+    await expect(submit).toBeDisabled();
+
+    await password.fill('');
+    await expect(dialog.getByText('Password must be at least 8 characters.')).toBeHidden();
+    await expect(submit).toBeEnabled();
+
+    await dialog.getByLabel('Name').fill('bobby');
+    await dialog.getByRole('switch', { name: /enabled/i }).click();
+    await submit.click();
+
+    await expect.poll(() => lastPutBody).toEqual({ name: 'bobby', disabled: false });
+    await expect(dialog).toBeHidden();
+  });
+
   test('blocks a password shorter than 8 characters', async ({
     page,
     context,


### PR DESCRIPTION
Closes #665

- OpenVPN user passwords and certificate passphrases must now be at least 8 characters
- applies to the easy-config VPN server step and the VPN page user and server dialogs
- shared client-side check so the rule and its message stay in one place
- inline error and aria-invalid on the offending field, submit stays blocked until it is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenVPN secret validation requiring at least eight characters for certificate passphrases and user passwords.
  * Invalid or empty required values now show clear errors, mark fields as invalid, and prevent submission.
  * When editing a VPN user, leaving the password blank preserves the existing password; newly entered passwords are validated before saving.

* **Tests**
  * Expanded end-to-end coverage for certificate passphrases, password validation, edit behavior, error states, and successful submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->