### PR TITLE
fix(be): Removed DoH server

### DIFF
--- a/backend/internal/handler/dns.go
+++ b/backend/internal/handler/dns.go
@@ -800,9 +800,8 @@ func changeDNSIPOrNoop(client *routeros.Client, oldIP, newIP string) (*DNSChange
 
 // HandleResetDNS godoc
 // @Summary Reset all DNS-related settings to their default configuration
-// @Description Replaces /ip/dns's servers with 1.0.0.1, 217.218.127.127 and 1.1.1.1, sets its
-// @Description DoH server to https://cloudflare-dns.com/dns-query with certificate verification
-// @Description disabled, and finds the existing Domestic, Foreign, General and VPN /ip/dns/forwarders
+// @Description Replaces /ip/dns's servers with 1.0.0.1, 217.218.127.127 and 1.1.1.1, and finds
+// @Description the existing Domestic, Foreign, General and VPN /ip/dns/forwarders
 // @Description entries by name, updating each one's dns-servers to its default: Domestic
 // @Description (217.218.127.127), Foreign (1.1.1.1), General (1.0.0.1, 217.218.127.127, 1.1.1.1) and
 // @Description VPN (1.0.0.1). A forwarder that doesn't already exist is left uncreated and skipped,
@@ -845,11 +844,8 @@ func HandleResetDNS(c echo.Context) error {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to check for domestic WAN interface", err)
 	}
 
-	verifyDOHCert := false
 	if err := client.UpdateDNSConfig(routeros.DNSUpdateConfig{
-		Servers:       &dnsResetServers,
-		DOHServer:     &dnsResetDOHServer,
-		VerifyDOHCert: &verifyDOHCert,
+		Servers: &dnsResetServers,
 	}); err != nil {
 		if IsCredentialError(err) {
 			return ErrorResponse(c, http.StatusUnauthorized, "Invalid RouterOS credentials", err)
@@ -1005,7 +1001,6 @@ func HandleResetDNS(c echo.Context) error {
 
 	return SuccessResponse(c, http.StatusOK, "DNS settings reset successfully", DNSResetResponse{
 		Servers:                  strings.Split(dnsResetServers, ","),
-		DOHServer:                dnsResetDOHServer,
 		Forwarders:               updatedForwarders,
 		UpdatedCheckIPRoutes:     updatedCheckIPRoutes,
 		UpdatedRouteDstAddresses: updatedRouteDstAddresses,

--- a/backend/internal/handler/dns_dto.go
+++ b/backend/internal/handler/dns_dto.go
@@ -71,11 +71,10 @@ type dnsResetNetwatchProbe struct {
 	Domestic bool
 }
 
-// dnsResetServers, dnsResetDOHServer and dnsResetForwarders define the fixed
-// state GET /api/dns/reset restores /ip/dns and /ip/dns/forwarders to.
+// dnsResetServers and dnsResetForwarders define the fixed state GET
+// /api/dns/reset restores /ip/dns and /ip/dns/forwarders to.
 var (
-	dnsResetServers   = strings.Join([]string{dnsDefaultVPNIP, dnsDefaultDomesticIP, dnsDefaultForeignIP}, ",")
-	dnsResetDOHServer = "https://cloudflare-dns.com/dns-query"
+	dnsResetServers = strings.Join([]string{dnsDefaultVPNIP, dnsDefaultDomesticIP, dnsDefaultForeignIP}, ",")
 
 	dnsResetForwarders = []dnsResetForwarder{
 		{Name: dnsForwarderTypeDomestic, DNSServers: dnsDefaultDomesticIP, Domestic: true},
@@ -156,7 +155,6 @@ type DNSForwarderResult struct {
 // DNSResetResponse is the response for POST /api/dns/reset.
 type DNSResetResponse struct {
 	Servers                  []string             `json:"servers"`
-	DOHServer                string               `json:"dohServer"`
 	Forwarders               []DNSForwarderResult `json:"forwarders"`
 	UpdatedCheckIPRoutes     []string             `json:"updatedCheckIpRoutes"`
 	UpdatedRouteDstAddresses []string             `json:"updatedRouteDstAddresses"`

--- a/backend/internal/template/wizard.tmpl
+++ b/backend/internal/template/wizard.tmpl
@@ -290,7 +290,6 @@ add add-default-route=no comment="Domestic Link to Domestic" interface="MacVLAN-
 /ip dns
 set allow-remote-requests=yes  max-concurrent-queries=500 max-concurrent-tcp-sessions=50 cache-size=20480KiB cache-max-ttl=7d
 set servers=1.0.0.1,{{ if .DomesticEnabled}}217.218.127.127,{{ end }}1.1.1.1
-set use-doh-server="https://cloudflare-dns.com/dns-query" verify-doh-cert=no doh-max-concurrent-queries=500 doh-max-server-connections=50
 
 /ip dns forwarders
 add name=VPN dns-servers=1.0.0.1 verify-doh-cert=no


### PR DESCRIPTION
* Fixes #676
* Removed DoH server from wizard and Reset DNS endpoints, DoH support in routeros package and other endpoints remains untouched 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * DNS reset now updates DNS server addresses without configuring a DNS-over-HTTPS server.
  * DNS-over-HTTPS certificate verification is no longer changed during DNS reset.
  * DNS reset responses no longer include a DNS-over-HTTPS server value.
  * The RouterOS setup wizard no longer configures a global Cloudflare DNS-over-HTTPS endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->