### PR TITLE
feat(be): Add endpoint to export wireguard client config

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1230,6 +1230,37 @@ func HandleUpdateWireGuardPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusNotFound, "WireGuard peer not found", err)
 	}
 
+	var clientAddress *string
+	if req.ClientAddress != nil && *req.ClientAddress != "" {
+		if net.ParseIP(*req.ClientAddress) == nil {
+			return ErrorResponse(c, http.StatusBadRequest, "clientAddress must be a valid IP address", nil)
+		}
+		clientAddress = req.ClientAddress
+	} else {
+		unlockInterfacePeers := lockWireGuardInterfacePeers(peer.InterfaceName)
+		defer unlockInterfacePeers()
+
+		interfaceAddresses, err := client.GetIPAddressesByInterface(peer.InterfaceName)
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Failed to get WireGuard interface IP address", err)
+		}
+		if len(interfaceAddresses) == 0 {
+			return ErrorResponse(c, http.StatusBadRequest, "WireGuard interface has no IP address configured", nil)
+		}
+
+		existingPeers, err := client.GetWireGuardPeers(peer.InterfaceName)
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Failed to list WireGuard peers", err)
+		}
+
+		usedAddresses := wireGuardUsedClientAddresses(existingPeers)
+		resolved, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, usedAddresses)
+		if err != nil {
+			return ErrorResponse(c, http.StatusConflict, "Failed to determine client IP address", err)
+		}
+		clientAddress = &resolved
+	}
+
 	if err := client.UpdateWireGuardPeer(peer.ID, routeros.UpdateWireGuardPeerConfig{
 		Name:                 req.Name,
 		PublicKey:            req.PublicKey,
@@ -1240,7 +1271,7 @@ func HandleUpdateWireGuardPeer(c echo.Context) error {
 		PreSharedKey:         req.PreSharedKey,
 		PersistentKeepalive:  req.PersistentKeepalive,
 		ClientEndpoint:       req.ClientEndpoint,
-		ClientAddress:        req.IP,
+		ClientAddress:        clientAddress,
 		ClientKeepalive:      req.ClientKeepalive,
 		ClientAllowedAddress: req.ClientAllowedAddress,
 		ClientListenPort:     req.ClientListenPort,
@@ -1572,10 +1603,6 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		req.AllowedAddresses = "0.0.0.0/0"
 	}
 
-	if req.ClientEndpoint != nil && req.ClientEndpointIP != nil {
-		return ErrorResponse(c, http.StatusBadRequest, "Only one of clientEndpoint or clientEndpointIp may be supplied", nil)
-	}
-
 	if req.ClientEndpoint != nil && net.ParseIP(*req.ClientEndpoint) == nil {
 		return ErrorResponse(c, http.StatusBadRequest, "clientEndpoint must be a valid IP address", nil)
 	}
@@ -1583,19 +1610,11 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	interfaceName := req.InterfaceName
 
 	// Verify the WireGuard interface exists
-	wg, err := client.GetWireGuard(interfaceName)
-	if err != nil {
+	if _, err := client.GetWireGuard(interfaceName); err != nil {
 		return ErrorResponse(c, http.StatusNotFound, "WireGuard interface not found", err)
 	}
 
 	clientEndpoint := req.ClientEndpoint
-	if req.ClientEndpointIP != nil && *req.ClientEndpointIP != "" {
-		if net.ParseIP(*req.ClientEndpointIP) == nil {
-			return ErrorResponse(c, http.StatusBadRequest, "clientEndpointIp must be a valid IP address", nil)
-		}
-		derived := net.JoinHostPort(*req.ClientEndpointIP, strconv.Itoa(wg.ListenPort))
-		clientEndpoint = &derived
-	}
 
 	interfaceAddresses, err := client.GetIPAddressesByInterface(interfaceName)
 	if err != nil {
@@ -1605,11 +1624,16 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusBadRequest, "WireGuard interface has no IP address configured", nil)
 	}
 
-	interfaceIP, _, err := net.ParseCIDR(interfaceAddresses[0].Address)
-	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to parse WireGuard interface IP address", err)
+	var clientDNS string
+	if req.ClientDNS != nil && *req.ClientDNS != "" {
+		clientDNS = *req.ClientDNS
+	} else {
+		interfaceIP, _, err := net.ParseCIDR(interfaceAddresses[0].Address)
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Failed to parse WireGuard interface IP address", err)
+		}
+		clientDNS = interfaceIP.String()
 	}
-	clientDNS := interfaceIP.String()
 
 	// Serialize the read-allocate-create sequence below per interface, so
 	// concurrent requests for the same interface can't both allocate the
@@ -1617,20 +1641,30 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 	unlockInterfacePeers := lockWireGuardInterfacePeers(interfaceName)
 	defer unlockInterfacePeers()
 
-	existingPeers, err := client.GetWireGuardPeers(interfaceName)
-	if err != nil {
-		return ErrorResponse(c, http.StatusInternalServerError, "Failed to list WireGuard peers", err)
-	}
+	var clientAddress string
+	if req.ClientAddress != nil && *req.ClientAddress != "" {
+		if net.ParseIP(*req.ClientAddress) == nil {
+			return ErrorResponse(c, http.StatusBadRequest, "clientAddress must be a valid IP address", nil)
+		}
+		clientAddress = *req.ClientAddress
+	} else {
+		existingPeers, err := client.GetWireGuardPeers(interfaceName)
+		if err != nil {
+			return ErrorResponse(c, http.StatusInternalServerError, "Failed to list WireGuard peers", err)
+		}
 
-	usedAddresses := wireGuardUsedClientAddresses(existingPeers)
+		usedAddresses := wireGuardUsedClientAddresses(existingPeers)
 
-	clientAddress, err := nextWireGuardClientAddress(interfaceAddresses[0].Address, usedAddresses)
-	if err != nil {
-		return ErrorResponse(c, http.StatusConflict, "Failed to determine client IP address", err)
+		clientAddress, err = nextWireGuardClientAddress(interfaceAddresses[0].Address, usedAddresses)
+		if err != nil {
+			return ErrorResponse(c, http.StatusConflict, "Failed to determine client IP address", err)
+		}
 	}
 
 	clientKeepalive := 30
-	clientListenPort := wg.ListenPort
+	if req.ClientKeepalive != nil {
+		clientKeepalive = *req.ClientKeepalive
+	}
 	clientAllowedAddress := req.AllowedAddresses
 
 	// Determine peer name
@@ -1701,7 +1735,7 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		ClientAddress:        &clientAddress,
 		ClientKeepalive:      &clientKeepalive,
 		ClientAllowedAddress: &clientAllowedAddress,
-		ClientListenPort:     &clientListenPort,
+		ClientListenPort:     req.ClientListenPort,
 		ClientDNS:            &clientDNS,
 		Comment:              req.Comment,
 		Responder:            req.Responder,
@@ -1744,13 +1778,15 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		ClientDNS:            clientDNS,
 		ClientKeepalive:      clientKeepalive,
 		ClientAllowedAddress: clientAllowedAddress,
-		ClientListenPort:     clientListenPort,
 		ClientEndpoint:       clientEndpointResponse,
 		Disabled:             disabledResponse,
 	}
 
 	if req.PersistentKeepalive != nil {
 		response.PersistentKeepalive = *req.PersistentKeepalive
+	}
+	if req.ClientListenPort != nil {
+		response.ClientListenPort = *req.ClientListenPort
 	}
 
 	return SuccessResponse(c, http.StatusOK, "WireGuard server peer created successfully", response)

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1230,13 +1230,20 @@ func HandleUpdateWireGuardPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusNotFound, "WireGuard peer not found", err)
 	}
 
+	// req.ClientAddress == nil means the field was omitted entirely: leave
+	// clientAddress nil so UpdateWireGuardPeer doesn't touch the peer's
+	// existing client-address. An explicit empty string means the caller
+	// wants a new address allocated; a non-empty string is used as-is.
 	var clientAddress *string
-	if req.ClientAddress != nil && *req.ClientAddress != "" {
+	switch {
+	case req.ClientAddress == nil:
+		// leave clientAddress nil
+	case *req.ClientAddress != "":
 		if net.ParseIP(*req.ClientAddress) == nil {
 			return ErrorResponse(c, http.StatusBadRequest, "clientAddress must be a valid IP address", nil)
 		}
 		clientAddress = req.ClientAddress
-	} else {
+	default:
 		unlockInterfacePeers := lockWireGuardInterfacePeers(peer.InterfaceName)
 		defer unlockInterfacePeers()
 

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1390,6 +1390,72 @@ func HandleGetWireGuardPeers(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "WireGuard peers retrieved successfully", response)
 }
 
+// HandleExportWireGuardPeerConfig exports a WireGuard peer's client
+// configuration.
+// @Summary Export WireGuard Peer Client Configuration
+// @Description Generates and returns a peer's client configuration using RouterOS's
+// @Description /interface/wireguard/peers/show-client-config command
+// @Tags VPN
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param nameOrID query string true "WireGuard peer name or ID"
+// @Param publicAddress query string true "Public IP address to set as the peer's client-endpoint"
+// @Produce json
+// @Success 200 {object} Response
+// @Failure 400 {object} Response
+// @Failure 404 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/vpn/wireguard/peer/export [get].
+func HandleExportWireGuardPeerConfig(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	nameOrID := c.QueryParam("nameOrID")
+	if nameOrID == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "nameOrID parameter is required", nil)
+	}
+
+	publicAddress := c.QueryParam("publicAddress")
+	if publicAddress == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "publicAddress parameter is required", nil)
+	}
+	if net.ParseIP(publicAddress) == nil {
+		return ErrorResponse(c, http.StatusBadRequest, "publicAddress must be a valid IP address", nil)
+	}
+
+	peer, err := client.GetWireGuardPeerByNameOrID(nameOrID)
+	if err != nil {
+		return ErrorResponse(c, http.StatusNotFound, "WireGuard peer not found", err)
+	}
+
+	wg, err := client.GetWireGuard(peer.InterfaceName)
+	if err != nil {
+		return ErrorResponse(c, http.StatusNotFound, "WireGuard interface not found", err)
+	}
+
+	clientEndpoint := net.JoinHostPort(publicAddress, strconv.Itoa(wg.ListenPort))
+	if err := client.UpdateWireGuardPeer(peer.ID, routeros.UpdateWireGuardPeerConfig{
+		ClientEndpoint: &clientEndpoint,
+	}); err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update WireGuard peer client endpoint", err)
+	}
+
+	config, err := client.GetWireGuardPeerClientConfig(peer.ID)
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to export WireGuard peer client config", err)
+	}
+
+	serverName := strings.TrimSuffix(peer.InterfaceName, "-server")
+	filename := serverName + "-" + strings.ReplaceAll(strings.ToLower(peer.Name), " ", "-") + "-wg.conf"
+
+	return SuccessResponse(c, http.StatusOK, "WireGuard peer client config exported successfully", map[string]interface{}{
+		"filename": filename,
+		"config":   config,
+	})
+}
+
 // wireGuardUsedClientAddresses collects every client address already in use
 // across peers, as plain IPs (no CIDR suffix), so nextWireGuardClientAddress
 // can avoid reassigning one. A peer's ClientAddress may itself hold more than

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -1240,7 +1240,7 @@ func HandleUpdateWireGuardPeer(c echo.Context) error {
 		PreSharedKey:         req.PreSharedKey,
 		PersistentKeepalive:  req.PersistentKeepalive,
 		ClientEndpoint:       req.ClientEndpoint,
-		ClientAddress:        req.ClientAddress,
+		ClientAddress:        req.IP,
 		ClientKeepalive:      req.ClientKeepalive,
 		ClientAllowedAddress: req.ClientAllowedAddress,
 		ClientListenPort:     req.ClientListenPort,
@@ -1430,14 +1430,8 @@ func HandleExportWireGuardPeerConfig(c echo.Context) error {
 		return ErrorResponse(c, http.StatusNotFound, "WireGuard peer not found", err)
 	}
 
-	wg, err := client.GetWireGuard(peer.InterfaceName)
-	if err != nil {
-		return ErrorResponse(c, http.StatusNotFound, "WireGuard interface not found", err)
-	}
-
-	clientEndpoint := net.JoinHostPort(publicAddress, strconv.Itoa(wg.ListenPort))
 	if err := client.UpdateWireGuardPeer(peer.ID, routeros.UpdateWireGuardPeerConfig{
-		ClientEndpoint: &clientEndpoint,
+		ClientEndpoint: &publicAddress,
 	}); err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update WireGuard peer client endpoint", err)
 	}
@@ -1582,10 +1576,8 @@ func HandleCreateWireGuardServerPeer(c echo.Context) error {
 		return ErrorResponse(c, http.StatusBadRequest, "Only one of clientEndpoint or clientEndpointIp may be supplied", nil)
 	}
 
-	if req.ClientEndpoint != nil {
-		if err := utils.ValidateIPPort(*req.ClientEndpoint); err != nil {
-			return ErrorResponse(c, http.StatusBadRequest, "clientEndpoint must be in ip:port format", err)
-		}
+	if req.ClientEndpoint != nil && net.ParseIP(*req.ClientEndpoint) == nil {
+		return ErrorResponse(c, http.StatusBadRequest, "clientEndpoint must be a valid IP address", nil)
 	}
 
 	interfaceName := req.InterfaceName

--- a/backend/internal/handler/vpn_dto.go
+++ b/backend/internal/handler/vpn_dto.go
@@ -331,7 +331,7 @@ type UpdateWireGuardPeerRequest struct {
 	PersistentKeepalive  *int    `json:"persistentKeepalive" example:"25"`
 	Disabled             *bool   `json:"disabled" example:"false"`
 	ClientEndpoint       *string `json:"clientEndpoint" example:"10.0.0.1"`
-	IP                   *string `json:"ip" example:"10.0.0.2"`
+	ClientAddress        *string `json:"clientAddress" example:"10.0.0.2"`
 	ClientKeepalive      *int    `json:"clientKeepalive" example:"10"`
 	ClientAllowedAddress *string `json:"clientAllowedAddress" example:"10.0.0.0/24"`
 	ClientListenPort     *int    `json:"clientListenPort" example:"51820"`
@@ -488,7 +488,10 @@ type CreateWireGuardServerPeerRequest struct {
 	SavePrivateKey      *bool   `json:"savePrivateKey" example:"false"`
 	Disabled            *bool   `json:"disabled" example:"false"`
 	ClientEndpoint      *string `json:"clientEndpoint" example:"10.0.0.1"`
-	ClientEndpointIP    *string `json:"clientEndpointIp" example:"10.0.0.1"`
+	ClientAddress       *string `json:"clientAddress" example:"10.0.0.2"`
+	ClientDNS           *string `json:"clientDNS" example:"8.8.8.8,8.8.4.4"`
+	ClientKeepalive     *int    `json:"clientKeepalive" example:"30"`
+	ClientListenPort    *int    `json:"clientListenPort" example:"51820"`
 	Comment             *string `json:"comment" example:"Office VPN Peer"`
 	Responder           *bool   `json:"responder" example:"false"`
 }
@@ -508,7 +511,7 @@ type WireGuardServerPeerCreateResponse struct {
 	ClientDNS            string `json:"clientDNS"`
 	ClientKeepalive      int    `json:"clientKeepalive"`
 	ClientAllowedAddress string `json:"clientAllowedAddress"`
-	ClientListenPort     int    `json:"clientListenPort"`
+	ClientListenPort     int    `json:"clientListenPort,omitempty"`
 	ClientEndpoint       string `json:"clientEndpoint,omitempty"`
 	Disabled             bool   `json:"disabled"`
 }

--- a/backend/internal/handler/vpn_dto.go
+++ b/backend/internal/handler/vpn_dto.go
@@ -330,8 +330,8 @@ type UpdateWireGuardPeerRequest struct {
 	PreSharedKey         *string `json:"preSharedKey" example:"qWbXwZgTbDGt66iCUtRHAtGju6w/Oyw3FLk/OPa+U1Y="`
 	PersistentKeepalive  *int    `json:"persistentKeepalive" example:"25"`
 	Disabled             *bool   `json:"disabled" example:"false"`
-	ClientEndpoint       *string `json:"clientEndpoint" example:"10.0.0.1:51820"`
-	ClientAddress        *string `json:"clientAddress" example:"10.0.0.2/32"`
+	ClientEndpoint       *string `json:"clientEndpoint" example:"10.0.0.1"`
+	IP                   *string `json:"ip" example:"10.0.0.2"`
 	ClientKeepalive      *int    `json:"clientKeepalive" example:"10"`
 	ClientAllowedAddress *string `json:"clientAllowedAddress" example:"10.0.0.0/24"`
 	ClientListenPort     *int    `json:"clientListenPort" example:"51820"`
@@ -487,7 +487,7 @@ type CreateWireGuardServerPeerRequest struct {
 	PersistentKeepalive *int    `json:"persistentKeepalive" example:"25"`
 	SavePrivateKey      *bool   `json:"savePrivateKey" example:"false"`
 	Disabled            *bool   `json:"disabled" example:"false"`
-	ClientEndpoint      *string `json:"clientEndpoint" example:"10.0.0.1:51820"`
+	ClientEndpoint      *string `json:"clientEndpoint" example:"10.0.0.1"`
 	ClientEndpointIP    *string `json:"clientEndpointIp" example:"10.0.0.1"`
 	Comment             *string `json:"comment" example:"Office VPN Peer"`
 	Responder           *bool   `json:"responder" example:"false"`

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -144,6 +144,7 @@ func RegisterRoutes(e *echo.Echo) {
 	vpnGroup.GET("/wireguard/detailed/:name", handler.HandleGetWireGuardDetailed)
 	vpnGroup.GET("/wireguard/interface/:nameOrID", handler.HandleGetWireGuardInterface)
 	vpnGroup.GET("/wireguard/peers/:name", handler.HandleGetWireGuardPeers)
+	vpnGroup.GET("/wireguard/peer/export", handler.HandleExportWireGuardPeerConfig)
 	vpnGroup.GET("/profiles", handler.HandleListVPNProfiles)
 	vpnGroup.GET("/users", handler.HandleListVPNUsers)
 	vpnGroup.POST("/users", handler.HandleCreateVPNUser)

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -1700,6 +1700,32 @@ func (c *Client) GetWireGuardPeerByNameOrID(nameOrID string) (*WireGuardPeerInfo
 	return nil, fmt.Errorf("WireGuard peer not found: %s", nameOrID)
 }
 
+// GetWireGuardPeerClientConfig runs
+// /interface/wireguard/peers/show-client-config for the peer identified by
+// its RouterOS .id, returning the generated client configuration text.
+func (c *Client) GetWireGuardPeerClientConfig(peerID string) (string, error) {
+	if peerID == "" {
+		return "", fmt.Errorf("peer ID is required")
+	}
+
+	reply, err := c.Execute("/interface/wireguard/peers/show-client-config",
+		"=.id="+peerID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get WireGuard peer client config: %w", err)
+	}
+	if reply == nil || len(reply.Re) == 0 {
+		return "", fmt.Errorf("show-client-config returned no response")
+	}
+
+	config, ok := reply.Re[0].Map["conf"]
+	if !ok || config == "" {
+		return "", fmt.Errorf("show-client-config returned no configuration")
+	}
+
+	return strings.Trim(config, "\n"), nil
+}
+
 // DeleteWireGuardPeer deletes a WireGuard peer by name or ID.
 func (c *Client) DeleteWireGuardPeer(nameOrID string) error {
 	if nameOrID == "" {

--- a/backend/pkg/utils/ip.go
+++ b/backend/pkg/utils/ip.go
@@ -2,10 +2,8 @@ package utils
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net"
 	"sort"
-	"strconv"
 )
 
 type IPSortable struct {
@@ -23,22 +21,6 @@ func ParseIPToNumeric(ipStr string) uint32 {
 		return 0
 	}
 	return binary.BigEndian.Uint32(ip)
-}
-
-// ValidateIPPort reports an error unless value is a valid "ip:port" pair.
-func ValidateIPPort(value string) error {
-	host, portStr, err := net.SplitHostPort(value)
-	if err != nil {
-		return fmt.Errorf("invalid ip:port %q: %w", value, err)
-	}
-	if net.ParseIP(host) == nil {
-		return fmt.Errorf("invalid IP address: %s", host)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil || port < 1 || port > 65535 {
-		return fmt.Errorf("invalid port: %s", portStr)
-	}
-	return nil
 }
 
 func SortIPsByNumeric(ips []string) []string {


### PR DESCRIPTION
* Closes #563

## Summary
- Add `GET /api/vpn/wireguard/peer/export?nameOrID=<peer name or id>&publicAddress=<ip>`.
- Resolves the peer by name or RouterOS `.id`, validates `publicAddress` as a well-formed IP, looks up the peer's WireGuard interface to read its listen port, and updates the peer's `client-endpoint` to `<publicAddress>:<listenPort>`.
- Generates the client config via RouterOS's `/interface/wireguard/peers/show-client-config` (`=.id=<peer id>`), trimming leading/trailing newlines from the result.
- Returns JSON: `{ "filename": "<server>-<peer-name>-wg.conf", "config": "<config text>" }`, where the filename is the interface name (with a trailing `-server` suffix stripped) plus the lowercased, dash-separated peer name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated endpoint for downloading WireGuard peer client configurations as `.conf` files.
  - Added support for configuring client DNS, keepalive intervals, listen ports, and addresses when creating server peers.

- **Updates**
  - Client addresses are now supplied separately from client endpoints.
  - Updating a peer preserves its existing client address when no address is provided.
  - Explicitly empty addresses receive a new available address, while specified addresses are validated.
  - Peer identifiers and exported configuration data are validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->