### PR TITLE
fix(be): Removed one problematic mangle rule

### DIFF
--- a/backend/internal/template/wizard.tmpl
+++ b/backend/internal/template/wizard.tmpl
@@ -378,7 +378,6 @@ add action=mark-routing chain=output comment="VPN Endpoint" \
 dst-address-list="VPNE" new-routing-mark="to-Foreign" passthrough=no
 add action=mark-routing chain=output comment="S4I Route" content="s4i.co" new-routing-mark="to-Foreign" passthrough=no
 add action=mark-routing chain=output comment="S4I Route" src-address=192.168.39.12 new-routing-mark="to-Foreign" passthrough=no
-add action=mark-routing chain=output comment="Router Foreign" new-routing-mark=to-Foreign passthrough=no
 {{ if .DomesticEnabled}}
 add action=mark-routing chain=output dst-address-list="MikroTik-Cloud-Services" \
 new-routing-mark="to-Domestic" passthrough=no \


### PR DESCRIPTION
* Fixes #691
* Removed "Router Foreign" mangle rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unconditional routing rule for router-originated traffic, allowing traffic to follow applicable destination-, content-, and source-specific routing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->