### PR TITLE
feat(fe): Only set gateway when enabling a VPN tunnel

### DIFF
--- a/frontend/src/routes/InternetPage.tsx
+++ b/frontend/src/routes/InternetPage.tsx
@@ -81,12 +81,6 @@ export function InternetPage() {
         await updateVPNClient(creds, vpnName, { disabled: !isActive });
         if (isActive) {
           await updateForeignGateway(creds, vpnName);
-          const others = topology.nodes.filter((n) => n.kind === 'vpn' && n.id !== target.id);
-          await Promise.all(
-            others.map((n) =>
-              updateVPNClient(creds, n.id.replace(/^vpn_/, ''), { disabled: true }),
-            ),
-          );
         }
         await reload();
         toast.notify({ title: 'VPN tunnel updated', tone: 'success' });

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -345,7 +345,7 @@ test.describe('Internet routing page', () => {
     );
   });
 
-  test('activating a tunnel from the hop dialog points routes at it and disables others', async ({
+  test('activating a tunnel from the hop dialog points routes at it and leaves others alone', async ({
     page,
     context,
     resetMocks,
@@ -375,7 +375,9 @@ test.describe('Internet routing page', () => {
 
     let otherPutBody: { disabled?: boolean } | null = null;
     await context.route('**/api/vpn/clients/wg-client-alt', async (route) => {
-      otherPutBody = route.request().postDataJSON() as typeof otherPutBody;
+      if (route.request().method() === 'PUT') {
+        otherPutBody = route.request().postDataJSON() as typeof otherPutBody;
+      }
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -409,7 +411,8 @@ test.describe('Internet routing page', () => {
 
     await expect.poll(() => targetPutBody?.disabled).toBe(false);
     await expect.poll(() => gatewayPutBody?.gateway).toBe('wg-client-mask');
-    await expect.poll(() => otherPutBody?.disabled).toBe(true);
+    await expect(page.getByText('VPN tunnel updated')).toBeVisible();
+    expect(otherPutBody).toBeNull();
   });
 
   test('marks no VPN path as active when no gateway route exists', async ({

--- a/frontend/tests/e2e/22-internet-routing.spec.ts
+++ b/frontend/tests/e2e/22-internet-routing.spec.ts
@@ -373,10 +373,10 @@ test.describe('Internet routing page', () => {
       });
     });
 
-    let otherPutBody: { disabled?: boolean } | null = null;
+    let otherPutSeen = false;
     await context.route('**/api/vpn/clients/wg-client-alt', async (route) => {
       if (route.request().method() === 'PUT') {
-        otherPutBody = route.request().postDataJSON() as typeof otherPutBody;
+        otherPutSeen = true;
       }
       await route.fulfill({
         status: 200,
@@ -412,7 +412,7 @@ test.describe('Internet routing page', () => {
     await expect.poll(() => targetPutBody?.disabled).toBe(false);
     await expect.poll(() => gatewayPutBody?.gateway).toBe('wg-client-mask');
     await expect(page.getByText('VPN tunnel updated')).toBeVisible();
-    expect(otherPutBody).toBeNull();
+    expect(otherPutSeen).toBe(false);
   });
 
   test('marks no VPN path as active when no gateway route exists', async ({


### PR DESCRIPTION
Closes #670

- Enabling a VPN tunnel from the internet page now only toggles that tunnel and sets it as the gateway
- Drops the fan-out that disabled every other tunnel, so their state is left alone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabling a VPN tunnel now updates the foreign gateway without disabling other configured VPN clients.
  * Existing VPN connections remain active when another tunnel is enabled, helping preserve uninterrupted access through previously configured tunnels.
  * Tunnel activation behavior is now more consistent when multiple VPN clients are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->