### PR TITLE
ci: split the Playwright E2E run into three parallel shards

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -190,11 +190,15 @@ jobs:
         run: GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags desktop,production -ldflags "-H windowsgui" -o /dev/null .
 
   e2e:
-    name: E2E (Playwright)
+    name: E2E (Playwright) shard ${{ matrix.shard }}/3
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [up-to-date, changes]
     if: needs.changes.outputs.frontend == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v5
 
@@ -218,13 +222,13 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Run Playwright tests
-        run: npm run e2e
+        run: npm run e2e -- --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 7
 


### PR DESCRIPTION
Closes #687

- E2E job runs as a three-way shard matrix instead of one serial run, cutting the slowest PR gate to about a third of its wall time
- shards do not fail fast, and the status gate still passes only when all three succeed
- each shard uploads its own Playwright report so a failure stays traceable to a spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end tests now run across three parallel Playwright shards.
  * All shards complete independently, allowing the full test suite to finish even if one shard fails.
  * Test reports are uploaded separately for each shard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->