### PR TITLE
feat(fe): Add option to delete OpenVPN certificate files on server delete

### DIFF
--- a/frontend/src/routes/vpn/sections/ServersSection.tsx
+++ b/frontend/src/routes/vpn/sections/ServersSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Card, ConfirmDialog, Stack, useToast } from '@nasnet/ui';
+import { Card, Checkbox, ConfirmDialog, Stack, useToast } from '@nasnet/ui';
 import {
   ApiError,
   createSstpServer,
@@ -50,6 +50,7 @@ export function ServersSection({ creds, servers, peerCounts, onChanged }: Props)
   const [editingWg, setEditingWg] = useState<VPNServer | null>(null);
   const [pendingDelete, setPendingDelete] = useState<VPNServer | null>(null);
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+  const [deleteCertFiles, setDeleteCertFiles] = useState(false);
   const [pendingDisable, setPendingDisable] = useState<VPNServer | null>(null);
   const [disableSubmitting, setDisableSubmitting] = useState(false);
   const [pendingToggle, setPendingToggle] = useState<VPNServer | null>(null);
@@ -73,7 +74,7 @@ export function ServersSection({ creds, servers, peerCounts, onChanged }: Props)
     setDeleteSubmitting(true);
     try {
       if (target.protocol === 'openvpn') {
-        await deleteOvpnServer(creds, target.name);
+        await deleteOvpnServer(creds, target.name, deleteCertFiles);
       } else if (target.protocol === 'wireguard') {
         await deleteWireguardInterface(creds, target.name);
       }
@@ -94,6 +95,7 @@ export function ServersSection({ creds, servers, peerCounts, onChanged }: Props)
     }
     setDeleteSubmitting(false);
     setPendingDelete(null);
+    setDeleteCertFiles(false);
     toast.notify({
       title: paired
         ? `Servers "${target.name}" and "${paired.name}" deleted`
@@ -232,22 +234,33 @@ export function ServersSection({ creds, servers, peerCounts, onChanged }: Props)
         title={deletePaired ? 'Delete OpenVPN server pair' : 'Delete VPN server'}
         description={
           pendingDelete
-            ? `Remove "${pendingDelete.name}" from this router? ${
+            ? `Remove "${pendingDelete.name}" from this router?${
                 pendingDelete.protocol === 'openvpn'
                   ? `${
-                      deletePaired
-                        ? `The paired server "${deletePaired.name}" is removed together with it, because both share the same certificates. `
-                        : ''
-                    }Associated users, IP pool, profile and certificates will also be removed.`
-                  : 'Associated peers and IP address will also be removed.'
+                      deletePaired ? ` The paired server "${deletePaired.name}" goes with it.` : ''
+                    } Users, IP pool, profile and certificates go too.`
+                  : ' Peers and IP address go too.'
               } This cannot be undone.`
             : undefined
         }
         confirmLabel={deleteSubmitting ? 'Deleting…' : 'Delete'}
         destructive
         onConfirm={onConfirmDelete}
-        onCancel={() => (deleteSubmitting ? undefined : setPendingDelete(null))}
-      />
+        onCancel={() => {
+          if (deleteSubmitting) return;
+          setPendingDelete(null);
+          setDeleteCertFiles(false);
+        }}
+      >
+        {pendingDelete?.protocol === 'openvpn' ? (
+          <Checkbox
+            label="Also delete certificate files from device storage"
+            checked={deleteCertFiles}
+            disabled={deleteSubmitting}
+            onChange={(e) => setDeleteCertFiles(e.target.checked)}
+          />
+        ) : null}
+      </ConfirmDialog>
       <ConfirmDialog
         open={!!pendingToggle}
         title={toggleEnable ? 'Enable OpenVPN server' : 'Disable OpenVPN server'}

--- a/frontend/src/ui/patterns/Dialog.tsx
+++ b/frontend/src/ui/patterns/Dialog.tsx
@@ -93,6 +93,7 @@ export interface ConfirmDialogProps {
   cancelLabel?: string;
   destructive?: boolean;
   confirmVariant?: React.ComponentProps<typeof Button>['variant'];
+  children?: React.ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -105,6 +106,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   cancelLabel = 'Cancel',
   destructive,
   confirmVariant,
+  children,
   onConfirm,
   onCancel,
 }) => (
@@ -127,5 +129,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </Button>
       </>
     }
-  />
+  >
+    {children}
+  </Dialog>
 );

--- a/frontend/tests/e2e/37-ovpn-delete-pair.spec.ts
+++ b/frontend/tests/e2e/37-ovpn-delete-pair.spec.ts
@@ -89,7 +89,7 @@ test.describe('OpenVPN paired server deletion', () => {
     const confirm = page.getByRole('dialog');
     await expect(confirm).toBeVisible();
     await expect(confirm.getByText('Delete OpenVPN server pair')).toBeVisible();
-    await expect(confirm).toContainText(`The paired server "${TCP_NAME}" is removed together`);
+    await expect(confirm).toContainText(`The paired server "${TCP_NAME}" goes with it.`);
     await expect(confirm).toContainText(UDP_NAME);
 
     await confirm.getByRole('button', { name: 'Delete', exact: true }).click();


### PR DESCRIPTION
Closes #678

- Delete dialog for an OpenVPN server now offers an opt-in checkbox to also remove certificate files from device storage, off by default
- Confirm dialog can render extra content so the checkbox sits above the buttons
- Delete description shortened

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option when deleting an OpenVPN server to also remove its certificate files from device storage.
  - The deletion confirmation now includes a checkbox for selecting this option.

- **Bug Fixes**
  - The certificate-removal selection is cleared after deleting or canceling, preventing it from carrying over to future actions.
  - Updated deletion confirmation wording to clarify when a paired server is also removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->