### PR TITLE
fix(be): Changed plugin install status route

### DIFF
--- a/backend/internal/handler/plugin.go
+++ b/backend/internal/handler/plugin.go
@@ -111,7 +111,7 @@ const (
 var pluginHTTPClient = &http.Client{Timeout: pluginFetchTimeout}
 
 // pluginInstallPhase enumerates the stages of an async plugin installation,
-// tracked in-process so GET /api/plugin/status/{pluginId} has something to
+// tracked in-process so GET /api/plugin/install/status/{pluginId} has something to
 // report while the background goroutine runs independently of the request
 // that started it.
 type pluginInstallPhase string
@@ -647,7 +647,7 @@ func HandleViewPlugin(c echo.Context) error {
 // @Description Starts an async install of a plugin from the community registry:
 // @Description creates the veth interface its manifest specifies (if not already
 // @Description present), creates its mounts, and adds its container, then waits for
-// @Description the image to finish pulling. Poll GET /api/plugin/status/{pluginId} for
+// @Description the image to finish pulling. Poll GET /api/plugin/install/status/{pluginId} for
 // @Description progress. At most one install per plugin id may run at a time;
 // @Description different plugins may install concurrently.
 // @Tags Plugin
@@ -955,7 +955,7 @@ func startPluginContainer(ctx context.Context, client *routeros.Client, task *pl
 // @Produce json
 // @Success 200 {object} Response{data=PluginInstallStatusResponse}
 // @Failure 404 {object} Response
-// @Router /api/plugin/status/{pluginId} [get].
+// @Router /api/plugin/install/status/{pluginId} [get].
 func HandleGetPluginInstallStatus(c echo.Context) error {
 	pluginID := c.Param("pluginId")
 

--- a/backend/internal/handler/plugin_dto.go
+++ b/backend/internal/handler/plugin_dto.go
@@ -173,7 +173,7 @@ type InstallPluginRequest struct {
 }
 
 // InstallPluginResponse is the response for POST /api/plugin/install.
-// Installation runs asynchronously; poll GET /api/plugin/status/{pluginId} for
+// Installation runs asynchronously; poll GET /api/plugin/install/status/{pluginId} for
 // progress and the resulting container details.
 type InstallPluginResponse struct {
 	ID       string `json:"id"`
@@ -191,7 +191,7 @@ type UninstallPluginResponse struct {
 	Warnings   []string `json:"warnings,omitempty"`
 }
 
-// PluginInstallStatusResponse is the response for GET /api/plugin/status/{pluginId}.
+// PluginInstallStatusResponse is the response for GET /api/plugin/install/status/{pluginId}.
 type PluginInstallStatusResponse struct {
 	PluginID    string `json:"pluginId"`
 	Phase       string `json:"phase"` // preparing, creating_interface, creating_mounts, running_pre_install_script, creating_container, pulling, starting_container, running_post_install_script, done, error

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -33,7 +33,7 @@ func RegisterRoutes(e *echo.Echo) {
 	pluginGroup.GET("/installed", handler.HandleListInstalledPlugins)
 	pluginGroup.POST("/install", handler.HandleInstallPlugin)
 	pluginGroup.DELETE("/plugin/:name", handler.HandleUninstallPlugin)
-	pluginGroup.GET("/status/:pluginId", handler.HandleGetPluginInstallStatus)
+	pluginGroup.GET("/install/status/:pluginId", handler.HandleGetPluginInstallStatus)
 	pluginGroup.POST("/update/:pluginId", handler.HandleUpdatePlugin)
 	pluginGroup.GET("/update/status/:pluginId", handler.HandleGetPluginUpdateStatus)
 	pluginGroup.GET("/envs/:pluginId", handler.HandleListPluginEnvVars)


### PR DESCRIPTION
* Closes #713

* Route: internal/routes/routes.go — GET /api/plugin/status/:pluginId → GET /api/plugin/install/status/:pluginId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Moved the plugin installation status endpoint to `GET /api/plugin/install/status/{pluginId}`.
  - Existing plugin installation status checks continue to use the same response behavior at the updated path.

- **Documentation**
  - Updated API documentation and polling guidance to reference the new installation status endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->