### PR TITLE
fix(installer): Enable right click menu

### DIFF
--- a/graphical-installer/main.go
+++ b/graphical-installer/main.go
@@ -27,6 +27,7 @@ func main() {
 		Bind: []any{
 			app,
 		},
+		EnableDefaultContextMenu: true,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Closes #721

- Wails hides the default context menu in production builds
- Turn it on so users can paste passwords and IPs with the mouse
- Menu shows on inputs and selected text only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the default context menu in the graphical installer, allowing standard browser-style actions such as copy, paste, and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->