### PR TITLE
fix(installer): show step failure message once

### DIFF
--- a/graphical-installer/frontend/dist/app.js
+++ b/graphical-installer/frontend/dist/app.js
@@ -326,8 +326,10 @@
   }
 
   function onRunError(message) {
-    $('run-error').textContent = message;
-    show('run-error');
+    if (!document.querySelector('#steps li.failed')) {
+      $('run-error').textContent = message;
+      show('run-error');
+    }
     hide('btn-cancel');
     show('btn-back');
     hideModals();


### PR DESCRIPTION
Closes #733

- Failed steps no longer repeat their error in the box below the step list
- The box still shows errors raised before any step runs