### PR TITLE
fix(installer): escape the tar cleanup pattern and log rejected router commands

### DIFF
--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -290,7 +290,6 @@ func (e *Engine) ensure(label, path, selector, addArgs string) error {
 	}
 	cmd := fmt.Sprintf("%s/add %s", path, addArgs)
 	if out, err := e.cl.Run(cmd); err != nil {
-		e.log("command failed: %s", cmd)
 		return fmt.Errorf("failed to add %s: %w (%s)", label, err, strings.TrimSpace(out))
 	}
 	e.log("added %s", label)
@@ -317,7 +316,7 @@ func (e *Engine) removeContainerFiles(includeImageDir bool) {
 		return
 	}
 	e.log("removing leftover %s-*.tar files from the router", assetPrefix)
-	_, _ = e.cl.RunRaw(fmt.Sprintf(`/file/remove [find where name~"(^|/)%s-[^/]*\.tar$"]`, assetPrefix), 30*time.Second)
+	_, _ = e.cl.RunRaw(fmt.Sprintf(`/file/remove [find where name~"(^|/)%s-[^/]*\\.tar\$"]`, assetPrefix), 30*time.Second)
 	if !includeImageDir {
 		return
 	}

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -26,6 +26,9 @@ func (e *Engine) stepConnect() error {
 		return fmt.Errorf("SSH login failed, check user/password or SSH service policies: %w", err)
 	}
 	e.cl = cl
+	e.cl.OnFailure = func(cmd, out string) {
+		e.log("command failed: %s (%s)", cmd, strings.TrimSpace(out))
+	}
 	if _, err := e.cl.Run(":put ok"); err != nil {
 		return fmt.Errorf("SSH command test failed: %w", err)
 	}

--- a/graphical-installer/internal/install/uninstall.go
+++ b/graphical-installer/internal/install/uninstall.go
@@ -73,7 +73,7 @@ func (e *Engine) stepRemoveFiles() error {
 	if e.opts.DryRun {
 		return nil
 	}
-	_, _ = e.cl.RunRaw(fmt.Sprintf(`/file/remove [find where name~"(^|/)%s-[^/]*\.tar$"]`, assetPrefix), 30*time.Second)
+	_, _ = e.cl.RunRaw(fmt.Sprintf(`/file/remove [find where name~"(^|/)%s-[^/]*\\.tar\$"]`, assetPrefix), 30*time.Second)
 	_, _ = e.cl.RunRaw(fmt.Sprintf("/file/remove [find name=%q]", lanBaselineRsc), 15*time.Second)
 	e.note = "uploaded files removed"
 	return nil

--- a/graphical-installer/internal/ros/client.go
+++ b/graphical-installer/internal/ros/client.go
@@ -36,6 +36,8 @@ type Client struct {
 
 	mu   sync.Mutex
 	conn *ssh.Client
+
+	OnFailure func(cmd, out string)
 }
 
 func Dial(host string, port int, user, pass string) (*Client, error) {
@@ -120,7 +122,11 @@ func (c *Client) RunRaw(cmd string, timeout time.Duration) (string, error) {
 	}()
 	select {
 	case r := <-done:
-		return strings.ReplaceAll(string(r.out), "\r", ""), r.err
+		out := strings.ReplaceAll(string(r.out), "\r", "")
+		if c.OnFailure != nil && hasErrorMarker(out) {
+			c.OnFailure(cmd, out)
+		}
+		return out, r.err
 	case <-time.After(timeout):
 		return "", fmt.Errorf("command timed out after %s", timeout)
 	}
@@ -138,13 +144,20 @@ func (c *Client) RunChecked(cmd string, timeout time.Duration) (string, error) {
 		}
 		return out, err
 	}
+	if hasErrorMarker(out) {
+		return out, errors.New(strings.TrimSpace(out))
+	}
+	return out, nil
+}
+
+func hasErrorMarker(out string) bool {
 	low := strings.ToLower(out)
 	for _, marker := range errorMarkers {
 		if strings.Contains(low, marker) {
-			return out, errors.New(strings.TrimSpace(out))
+			return true
 		}
 	}
-	return out, nil
+	return false
 }
 
 func (c *Client) Upload(localPath, remotePath string, progress func(done, total int64)) error {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1203,7 +1203,7 @@ uninstall_path() {
 
   log "  remove: ${ASSET_PREFIX}-*.tar from router storage"
   if (( ! DRY_RUN )); then
-    ros_cmd "/file/remove [find where (name~\"(^|/)${ASSET_PREFIX}-\") and (name~\"\\.tar\$\")]" \
+    ros_cmd "/file/remove [find where (name~\"(^|/)${ASSET_PREFIX}-\") and (name~\"\\\\.tar\\\$\")]" \
       >/dev/null 2>&1 || true
     remove_remote_file "$LAN_BASELINE_RSC"
   fi


### PR DESCRIPTION
Closes #734

- Old tar cleanup sent an invalid `\.` escape that RouterOS rejected at line 1 column 55
- Fixed the same pattern in both installers
- Graphical installer now logs the command and router output whenever the router reports an error
- Skip container lookups before the container package is installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation diagnostics by logging failed commands and their output when connection or execution errors occur.
  * Corrected file matching during cleanup so downloaded `.tar` assets are identified and removed reliably.
  * Improved consistency between graphical and command-line uninstall flows when clearing installation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
