### PR TITLE
feat(fe): point knowledge base link to the user guide

### DIFF
--- a/frontend/src/routes/help/links.ts
+++ b/frontend/src/routes/help/links.ts
@@ -2,4 +2,4 @@ export const GITHUB_ISSUES_URL = 'https://github.com/nasnet-community/nasnet-pan
 
 export const TELEGRAM_SUPPORT_URL = 'https://t.me/joinNASNETGroup';
 
-export const KNOWLEDGE_BASE_URL = 'https://docs.s4i.co/hc/nasnet/fa';
+export const KNOWLEDGE_BASE_URL = 'https://www.joinnasnet.com/en/guides/nasnet-panel/';

--- a/frontend/tests/e2e/25-help-page.spec.ts
+++ b/frontend/tests/e2e/25-help-page.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 const ROUTER = { id: 'rtr_help', name: 'Help Router', host: '10.0.0.5' };
 
 const GITHUB_ISSUES_URL = 'https://github.com/nasnet-community/nasnet-panel/issues/new';
-const KNOWLEDGE_BASE_URL = 'https://docs.s4i.co/hc/nasnet/fa';
+const KNOWLEDGE_BASE_URL = 'https://www.joinnasnet.com/en/guides/nasnet-panel/';
 
 test.describe('Help page', () => {
   test('Help tab is enabled and navigates to the help page', async ({

--- a/graphical-installer/frontend/dist/app.js
+++ b/graphical-installer/frontend/dist/app.js
@@ -169,7 +169,7 @@
       this.setAttribute('aria-label', wasHidden ? 'Hide password' : 'Show password');
     });
     $('btn-help').addEventListener('click', function () {
-      App.OpenURL('https://docs.s4i.co/hc/nasnet/fa');
+      App.OpenURL('https://www.joinnasnet.com/en/guides/nasnet-panel/');
     });
     $('btn-telegram').addEventListener('click', function () {
       App.OpenURL('https://t.me/joinNASNETGroup');


### PR DESCRIPTION
Closes #740

- Help page knowledge base link now opens the Nasnet Panel user guide
- Installer help button uses the same link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Help page’s knowledge base link to the latest NASNET Panel guides.
  - Updated link validation to reflect the new documentation destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->