### PR TITLE
feat(installer): retry image download on failure

### DIFF
--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -51,6 +51,8 @@ const (
 	baselineTimeout   = 30 * time.Second
 	rebootSettle      = 15 * time.Second
 	rebootTimeout     = 5 * time.Minute
+	downloadAttempts  = 3
+	downloadRetryWait = 3 * time.Second
 )
 
 type Options struct {

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -231,8 +231,10 @@ func (e *Engine) installContainerPackage() error {
 		return err
 	}
 	local := filepath.Join(outDir, name)
-	e.log("downloading %s", url)
-	if _, err := e.download(url, local, "device-mode"); err != nil {
+	if err := e.withRetries("downloading "+url, func() error {
+		_, err := e.download(url, local, "device-mode")
+		return err
+	}); err != nil {
 		return fmt.Errorf("could not download the container package for RouterOS %s (%s): %w. Install it via WebFig/Winbox (System > Packages) instead", e.sys.Version, e.sys.Arch, err)
 	}
 
@@ -575,23 +577,45 @@ func (e *Engine) stepDownload() error {
 	}
 	outPath := filepath.Join(outDir, asset)
 
-	e.log("downloading %s", url)
-	actual, err := e.download(url, outPath, "download")
-	if err != nil {
-		return err
-	}
 	expected, err := e.fetchChecksum(url + ".sha256")
 	if err != nil {
 		return err
 	}
-	if !strings.EqualFold(expected, actual) {
-		return fmt.Errorf("checksum mismatch for %s: got %s, expected %s", asset, actual, expected)
+	if err := e.withRetries("downloading "+url, func() error {
+		actual, err := e.download(url, outPath, "download")
+		if err != nil {
+			return err
+		}
+		if !strings.EqualFold(expected, actual) {
+			return fmt.Errorf("checksum mismatch for %s: got %s, expected %s", asset, actual, expected)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	e.log("checksum OK")
 	e.assetName = asset
 	e.localTar = outPath
 	e.note = asset
 	return nil
+}
+
+func (e *Engine) withRetries(what string, fn func() error) error {
+	for attempt := 1; ; attempt++ {
+		e.log("%s (attempt %d/%d)", what, attempt, downloadAttempts)
+		err := fn()
+		if err == nil || e.ctx.Err() != nil {
+			return err
+		}
+		if attempt == downloadAttempts {
+			e.log("attempt %d/%d failed: %v", attempt, downloadAttempts, err)
+			return err
+		}
+		e.log("attempt %d/%d failed: %v, retrying in %s", attempt, downloadAttempts, err, downloadRetryWait)
+		if err := e.sleep(downloadRetryWait); err != nil {
+			return err
+		}
+	}
 }
 
 func (e *Engine) download(url, dest, stepID string) (string, error) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,8 @@ BASELINE_TIMEOUT=30
 REBOOT_SETTLE=15
 REBOOT_TIMEOUT=300
 START_TIMEOUT=120
+DOWNLOAD_ATTEMPTS=3
+DOWNLOAD_RETRY_WAIT=3
 
 # ---- args ------------------------------------------------------------------
 DRY_RUN=0
@@ -551,7 +553,7 @@ install_container_package() {
   out_dir="${TMPDIR:-/tmp}/nasnet-panel-installer"
   mkdir -p "$out_dir"
   local_npk="${out_dir}/${name}"
-  if ! curl -fL --progress-bar "$url" -o "$local_npk"; then
+  if ! with_retries "  downloading ${name}" curl -fL --progress-bar "$url" -o "$local_npk"; then
     err "could not download the container package for RouterOS ${version} (${ROUTEROS_ARCH}): ${url}"
     err "install it via WebFig/Winbox 'System > Packages' instead"
     return 1
@@ -833,6 +835,33 @@ asset_suffix() {
   esac
 }
 
+with_retries() {
+  local what="$1" attempt; shift
+  for (( attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++ )); do
+    log "${what} (attempt ${attempt}/${DOWNLOAD_ATTEMPTS})"
+    if "$@"; then
+      return 0
+    fi
+    if (( attempt < DOWNLOAD_ATTEMPTS )); then
+      log "  attempt ${attempt}/${DOWNLOAD_ATTEMPTS} failed, retrying in ${DOWNLOAD_RETRY_WAIT}s"
+      sleep "$DOWNLOAD_RETRY_WAIT"
+    else
+      log "  attempt ${attempt}/${DOWNLOAD_ATTEMPTS} failed"
+    fi
+  done
+  return 1
+}
+
+fetch_verified() {
+  local url="$1" out="$2" expected="$3" actual
+  curl -fL --progress-bar "$url" -o "$out" || return 1
+  actual="$($SHA256_BIN "$out" | awk '{print $1}')"
+  if [[ "$expected" != "$actual" ]]; then
+    err "checksum mismatch for $(basename "$out"): got ${actual}, expected ${expected}"
+    return 1
+  fi
+}
+
 download_asset() {
   local arch="$1" release channel suffix asset url sha_url out_dir out sha
   if [[ -n "$VERSION" ]]; then
@@ -849,16 +878,12 @@ download_asset() {
   out="${out_dir}/${asset}"
   sha="${out}.sha256"
 
-  log "Downloading ${asset} ..."
-  curl -fL --progress-bar "$url"     -o "$out" || { err "download failed: $url"; exit 1; }
-  curl -fsSL              "$sha_url" -o "$sha" || { err "checksum download failed: $sha_url"; exit 1; }
+  curl -fsSL "$sha_url" -o "$sha" || { err "checksum download failed: $sha_url"; exit 1; }
 
-  local expected actual
+  local expected
   expected="$(awk '{print $1; exit}' "$sha")"
-  actual="$($SHA256_BIN "$out" | awk '{print $1}')"
-  if [[ "$expected" != "$actual" ]]; then
-    err "checksum mismatch for ${asset}: got ${actual}, expected ${expected}"; exit 1
-  fi
+  with_retries "Downloading ${asset}" fetch_verified "$url" "$out" "$expected" \
+    || { err "download failed: $url"; exit 1; }
   log "  checksum OK"
   ASSET_NAME="$asset"
   LOCAL_TAR="$out"


### PR DESCRIPTION
Closes #732

- Graphical installer and install.sh retry the image and container package downloads up to 3 times, 3s apart, logging each attempt
- A checksum mismatch counts as a failed attempt and triggers a re-download