### PR TITLE
feat(installer): Set a default DNS for the nasnet-panel container

### DIFF
--- a/graphical-installer/internal/install/engine.go
+++ b/graphical-installer/internal/install/engine.go
@@ -48,6 +48,7 @@ const (
 	deviceModeTimeout = 120 * time.Second
 	updateTimeout     = 10 * time.Minute
 	startTimeout      = 120 * time.Second
+	stopTimeout       = 60 * time.Second
 	baselineTimeout   = 30 * time.Second
 	rebootSettle      = 15 * time.Second
 	rebootTimeout     = 5 * time.Minute

--- a/graphical-installer/internal/install/steps.go
+++ b/graphical-installer/internal/install/steps.go
@@ -84,9 +84,35 @@ func (e *Engine) stepCheck() error {
 	if err := e.verifyStorageWritable(st); err != nil {
 		return err
 	}
+	if err := e.removeExistingContainer(); err != nil {
+		return err
+	}
 	e.removeContainerFiles(true)
 
 	e.note = fmt.Sprintf("%s, RouterOS %s, %d MB free, storage %s", e.sys.Arch, e.sys.Version, e.sys.FreeMB, st.label())
+	return nil
+}
+
+func (e *Engine) removeExistingContainer() error {
+	if !e.exists("/container", "name="+containerName) {
+		return nil
+	}
+	if e.opts.DryRun {
+		e.log("[dry-run] would stop and remove the existing container %s", containerName)
+		return nil
+	}
+	e.log("stopping and removing the existing container %s", containerName)
+	_, _ = e.cl.RunRaw(fmt.Sprintf("/container/stop [find name=%s]", containerName), 30*time.Second)
+	deadline := time.Now().Add(stopTimeout)
+	for e.exists("/container", "name="+containerName) {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("could not stop and remove the existing container %s within %s. Remove it from the router, then run the installer again", containerName, stopTimeout)
+		}
+		if err := e.sleep(2 * time.Second); err != nil {
+			return err
+		}
+		_, _ = e.cl.RunRaw(fmt.Sprintf("/container/remove [find name=%s]", containerName), 30*time.Second)
+	}
 	return nil
 }
 
@@ -822,8 +848,8 @@ func (e *Engine) stepContainer() error {
 		return nil
 	}
 	e.log("extracting tar and adding container %s (this can take a few minutes)", containerName)
-	if out, err := e.cl.RunChecked(fmt.Sprintf("/container/add file=%q interface=%s root-dir=%q name=%s start-on-boot=yes logging=yes",
-		e.remoteTar, vethName, e.storage.path(containerImagesDir), containerName), 5*time.Minute); err != nil {
+	if out, err := e.cl.RunChecked(fmt.Sprintf("/container/add file=%q interface=%s root-dir=%q name=%s dns=%s start-on-boot=yes logging=yes",
+		e.remoteTar, vethName, e.storage.path(containerImagesDir), containerName, fallbackDNSServers), 5*time.Minute); err != nil {
 		return fmt.Errorf("failed to add container: %w (%s)", err, strings.TrimSpace(out))
 	}
 	e.pushRollback(func() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,7 @@ BASELINE_TIMEOUT=30
 REBOOT_SETTLE=15
 REBOOT_TIMEOUT=300
 START_TIMEOUT=120
+STOP_TIMEOUT=60
 
 # ---- args ------------------------------------------------------------------
 DRY_RUN=0
@@ -990,6 +991,28 @@ configure_network() {
   ros_move_to_top /ip/firewall/filter "comment=\"${COMMENT_TAG}-forward-https\""
 }
 
+remove_existing_container() {
+  ros_exists /container "name=${CONTAINER_NAME}" || return 0
+  log ""
+  log "Removing existing container ${CONTAINER_NAME} ..."
+  if (( DRY_RUN )); then
+    printf '  - container %s (would stop and remove)\n' "$CONTAINER_NAME"
+    return 0
+  fi
+  ros_cmd "/container/stop [find name=${CONTAINER_NAME}]" >/dev/null 2>&1 || true
+  local waited=0
+  while ros_exists /container "name=${CONTAINER_NAME}"; do
+    if (( waited >= STOP_TIMEOUT )); then
+      err "could not stop and remove the existing container ${CONTAINER_NAME} within ${STOP_TIMEOUT}s"
+      exit 1
+    fi
+    sleep 2
+    waited=$(( waited + 2 ))
+    ros_cmd "/container/remove [find name=${CONTAINER_NAME}]" >/dev/null 2>&1 || true
+  done
+  printf '  \033[32m✓\033[0m container %s removed\n' "$CONTAINER_NAME"
+}
+
 deploy_container() {
   log ""
   log "Configuring container ..."
@@ -1002,7 +1025,7 @@ deploy_container() {
     return 0
   fi
   if ! spin "extracting tar and adding container ${CONTAINER_NAME}" \
-       ros_cmd "/container/add file=${REMOTE_TAR} interface=${VETH_NAME} root-dir=${CONTAINER_ROOT_DIR} name=${CONTAINER_NAME} start-on-boot=yes logging=yes"; then
+       ros_cmd "/container/add file=${REMOTE_TAR} interface=${VETH_NAME} root-dir=${CONTAINER_ROOT_DIR} name=${CONTAINER_NAME} dns=${FALLBACK_DNS_SERVERS} start-on-boot=yes logging=yes"; then
     err "failed to add container"; exit 1
   fi
   push_rollback "ros_cmd '/container/remove [find name=${CONTAINER_NAME}]' >/dev/null 2>&1 || true"
@@ -1225,6 +1248,7 @@ main() {
     return 0
   fi
 
+  remove_existing_container
   ensure_container_support
   detect_storage
 


### PR DESCRIPTION
Closes #731

## Summary

- Panel container is created with 1.1.1.1 and 1.0.0.1 as its DNS servers
- Reinstall stops and removes an existing panel container during the initial checks, so it is recreated with the new DNS
- Applies to both the graphical installer and the shell installer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Existing containers are now stopped and removed before installation continues.
  * Container cleanup retries until completion and reports an error if it exceeds the timeout.
  * Fallback DNS servers are now applied when creating containers.
  * Dry-run mode skips container cleanup without making changes.
  * Uninstallation now removes associated container DNS and routing rules.
  * Stale installation files are cleaned up more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->