### PR TITLE
feat(fe): add user guide link to router section pages

### DIFF
--- a/frontend/src/routes/RouterDashboard.module.scss
+++ b/frontend/src/routes/RouterDashboard.module.scss
@@ -52,3 +52,20 @@
   font-size: var(--font-lg);
   color: var(--color-text);
 }
+
+.guideFooter {
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  font-size: var(--font-sm);
+}
+
+.guideLink {
+  color: var(--color-primary);
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+}

--- a/frontend/src/routes/RouterDashboard.tsx
+++ b/frontend/src/routes/RouterDashboard.tsx
@@ -7,6 +7,7 @@ import { useWizardGate } from '../state/WizardGateContext';
 import { useInstalledPlugins } from '../state/InstalledPluginsContext';
 import { routerSectionsWithPlugins } from '../layout/routerSections';
 import { RouterCredentialsDialog } from './RouterCredentialsDialog';
+import { USER_GUIDE_SECTIONS, USER_GUIDE_URL } from './help/links';
 import styles from './RouterDashboard.module.scss';
 
 export function RouterDashboard() {
@@ -43,6 +44,9 @@ export function RouterDashboard() {
   const wizardStatus = statusFor(router.id);
 
   const onWizard = location.pathname.startsWith(`/router/${router.id}/config`);
+  const guideSection = USER_GUIDE_SECTIONS.get(
+    location.pathname.slice(`/router/${router.id}`.length).split('/')[1] ?? '',
+  );
 
   const activeTab = onWizard
     ? 'diagnostics'
@@ -92,6 +96,18 @@ export function RouterDashboard() {
       ) : null}
       <div className={styles.contentShell}>
         <Outlet />
+        {guideSection ? (
+          <footer className={styles.guideFooter}>
+            <a
+              className={styles.guideLink}
+              href={`${USER_GUIDE_URL}/${guideSection}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Read the user guide for this section
+            </a>
+          </footer>
+        ) : null}
       </div>
     </>
   );

--- a/frontend/src/routes/help/links.ts
+++ b/frontend/src/routes/help/links.ts
@@ -3,3 +3,20 @@ export const GITHUB_ISSUES_URL = 'https://github.com/nasnet-community/nasnet-pan
 export const TELEGRAM_SUPPORT_URL = 'https://t.me/joinNASNETGroup';
 
 export const KNOWLEDGE_BASE_URL = 'https://docs.s4i.co/hc/nasnet/fa';
+
+export const USER_GUIDE_URL = 'https://www.joinnasnet.com/en/guides/nasnet-panel';
+
+export const USER_GUIDE_SECTIONS = new Map<string, string>([
+  ['', 'overview'],
+  ['internet', 'internet'],
+  ['wan', 'wan'],
+  ['lan', 'lan'],
+  ['dns', 'lan/dns'],
+  ['firewall', 'lan/firewall'],
+  ['wireless', 'wifi'],
+  ['vpn', 'vpn-server'],
+  ['plugins', 'plugins'],
+  ['diagnostics', 'diagnostics'],
+  ['logs', 'logs'],
+  ['help', 'help'],
+]);


### PR DESCRIPTION
Closes #741

- Text link at the bottom of each router section page, opening its own page in the user guide
- Covers Logs and Firewall too, not the Easy Config wizard