### PR TITLE
fix(fe): show full uplink and DHCP addresses on overview

### DIFF
--- a/frontend/src/routes/OverviewTab.module.scss
+++ b/frontend/src/routes/OverviewTab.module.scss
@@ -314,15 +314,19 @@
   }
 }
 
-.vpnName,
-.vpnAddress {
+.addressRow {
+  flex-wrap: wrap;
+
+  .vpnName {
+    flex: 1 1 0;
+  }
+}
+
+.vpnName {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.vpnName {
   font-weight: var(--weight-medium);
   flex: 0 1 auto;
 }
@@ -349,7 +353,9 @@
 }
 
 .vpnAddress {
-  flex: 1 1 auto;
+  flex: 0 0 100%;
+  padding-left: calc(8px + var(--space-sm));
+  overflow-wrap: anywhere;
   color: var(--color-text-muted);
   font-size: var(--font-sm);
 }

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -549,7 +549,7 @@ export function OverviewTab() {
             ) : (
               <div className={styles.vpnList}>
                 {dhcpLeaseList.map((l) => (
-                  <div key={l.id} className={styles.vpnRow}>
+                  <div key={l.id} className={cx(styles.vpnRow, styles.addressRow)}>
                     <StatusDot $status="online" className={styles.vpnDot} aria-hidden />
                     <span className={styles.vpnName} title={l.hostName || l.macAddress}>
                       {l.hostName || l.macAddress}
@@ -590,7 +590,10 @@ export function OverviewTab() {
             ) : (
               <div className={styles.vpnList}>
                 {vpnClients.map((c) => (
-                  <div key={`${c.protocol}-${c.id}`} className={styles.vpnRow}>
+                  <div
+                    key={`${c.protocol}-${c.id}`}
+                    className={cx(styles.vpnRow, styles.addressRow)}
+                  >
                     <StatusDot $status="online" className={styles.vpnDot} aria-hidden />
                     <span className={styles.vpnName} title={c.name}>
                       {c.name}

--- a/frontend/src/routes/overview-panel/OverviewPanel.module.scss
+++ b/frontend/src/routes/overview-panel/OverviewPanel.module.scss
@@ -239,6 +239,7 @@
 
 .uplinkRow {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-sm);
 }
@@ -248,18 +249,20 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 120px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .uplinkIps {
   display: flex;
-  flex-wrap: wrap;
+  flex: 0 0 100%;
+  flex-direction: column;
   gap: var(--space-xs);
-  margin-left: auto;
-  justify-content: flex-end;
+  padding-left: calc(8px + var(--space-sm));
 }
 
 .uplinkIp {
+  overflow-wrap: anywhere;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--font-xs);
   color: var(--color-text-muted);


### PR DESCRIPTION
Closes #736

- Addresses in the DHCP, VPN client and uplink cards move to their own line under the name and badge
- Long names truncate instead of the address
- Connectivity card layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network overview layouts for VPN clients, DHCP leases, and uplink information.
  - Long names, addresses, and IP strings now wrap or truncate cleanly instead of overflowing.
  - Related address details display on full-width lines with clearer indentation.
  - Updated responsive behavior helps rows remain readable across narrower screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->