### PR TITLE
feat(fe): show link speed in LAN port popover

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -150,6 +150,7 @@ export interface EthernetInterfaceResponse {
   disabled?: boolean;
   status?: string;
   rate?: string;
+  fullDuplex?: boolean;
 }
 
 export async function fetchEthernetInterfaces(

--- a/frontend/src/routes/DHCPPage.tsx
+++ b/frontend/src/routes/DHCPPage.tsx
@@ -31,6 +31,7 @@ import {
 import { useSession } from '../state/SessionContext';
 import { useRouter } from '../state/RouterStoreContext';
 import { RouterPortDiagramCard } from './overview-panel/RouterPortDiagramCard';
+import type { IfaceLink } from './overview-panel/types';
 import { BridgePortsCard } from './lan/BridgePortsCard';
 
 interface SectionState<T> {
@@ -63,7 +64,7 @@ export function DHCPPage() {
   const [clients, setClients] = useState<SectionState<DhcpClient>>(initial<DhcpClient>());
   const [model, setModel] = useState<string | null>(null);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
-  const [ethernetRates, setEthernetRates] = useState<Record<string, string>>({});
+  const [ethernetRates, setEthernetRates] = useState<Record<string, IfaceLink>>({});
   const [busyMac, setBusyMac] = useState<string | null>(null);
   const [leaseToRemove, setLeaseToRemove] = useState<DhcpLease | null>(null);
   const [leaseToMakeStatic, setLeaseToMakeStatic] = useState<DhcpLease | null>(null);
@@ -109,7 +110,9 @@ export function DHCPPage() {
         setEthernetRates(
           Object.fromEntries(
             eResult.value.flatMap((e) =>
-              e.name && e.rate ? [[e.name.toLowerCase(), e.rate] as const] : [],
+              e.name && e.rate
+                ? [[e.name.toLowerCase(), { rate: e.rate, fullDuplex: e.fullDuplex }] as const]
+                : [],
             ),
           ),
         );

--- a/frontend/src/routes/OverviewTab.tsx
+++ b/frontend/src/routes/OverviewTab.tsx
@@ -59,6 +59,7 @@ import { ConnectivityCard } from './overview-panel/ConnectivityCard';
 import { RouterPortDiagramCard } from './overview-panel/RouterPortDiagramCard';
 import { UplinkIpCard } from './overview-panel/UplinkIpCard';
 import { resolveModelStrict } from './overview-panel/resolveModel';
+import type { IfaceLink } from './overview-panel/types';
 import styles from './OverviewTab.module.scss';
 
 const cx = (...parts: Array<string | undefined | false>) => parts.filter(Boolean).join(' ');
@@ -117,7 +118,7 @@ export function OverviewTab() {
   const [vpnClients, setVpnClients] = useState<VPNActiveClient[]>([]);
   const [dhcpLeaseList, setDhcpLeaseList] = useState<DHCPLeaseResponse[]>([]);
   const [interfaces, setInterfaces] = useState<InterfaceResponse[]>([]);
-  const [ethernetRates, setEthernetRates] = useState<Record<string, string>>({});
+  const [ethernetRates, setEthernetRates] = useState<Record<string, IfaceLink>>({});
   const [dhcpClients, setDhcpClients] = useState<DhcpClient[]>([]);
   const [selectedIface, setSelectedIface] = useState<string>(DEFAULT_TRAFFIC_INTERFACE);
   const ifaceDefaultApplied = useRef(false);
@@ -217,7 +218,9 @@ export function OverviewTab() {
         setEthernetRates(
           Object.fromEntries(
             ethernets.flatMap((e) =>
-              e.name && e.rate ? [[e.name.toLowerCase(), e.rate] as const] : [],
+              e.name && e.rate
+                ? [[e.name.toLowerCase(), { rate: e.rate, fullDuplex: e.fullDuplex }] as const]
+                : [],
             ),
           ),
         );

--- a/frontend/src/routes/overview-panel/PortSlot.tsx
+++ b/frontend/src/routes/overview-panel/PortSlot.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Antenna,
   ArrowDown,
+  ArrowLeftRight,
   ArrowUp,
   Cable,
   EthernetPort,
@@ -90,6 +91,12 @@ export const PortSlot: React.FC<PortSlotProps> = ({ slot, onActivate }) => {
             {STATUS_LABEL[slot.status]}
             {slot.mtu ? ` · ${slot.mtu} MTU` : ''}
           </span>
+          {slot.linkSpeed ? (
+            <span className={styles.hoverRow}>
+              <ArrowLeftRight size={13} aria-hidden />
+              {slot.linkSpeed}
+            </span>
+          ) : null}
           {slot.rxLabel ? (
             <span className={cx(styles.hoverRow, styles.rxRow)}>
               <ArrowDown size={13} aria-hidden />

--- a/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
+++ b/frontend/src/routes/overview-panel/RouterPortDiagramCard.tsx
@@ -3,7 +3,7 @@ import type { InterfaceResponse } from '../../api';
 import { PANEL_REGISTRY } from './panels';
 import { POWER_ACTION, type PowerAction, mapPorts } from './mapPorts';
 import { resolveModelStrict } from './resolveModel';
-import type { ResolvedSlot } from './types';
+import type { IfaceLink, ResolvedSlot } from './types';
 import styles from './OverviewPanel.module.scss';
 
 export interface RouterPortDiagramCardProps {
@@ -12,7 +12,7 @@ export interface RouterPortDiagramCardProps {
   onPower?: (action: PowerAction) => void;
   onPortSelect?: (ifaceName: string) => void;
   showPowerControls?: boolean;
-  ifaceRates?: Readonly<Record<string, string>>;
+  ifaceRates?: Readonly<Record<string, IfaceLink>>;
 }
 
 export const RouterPortDiagramCard: React.FC<RouterPortDiagramCardProps> = React.memo(

--- a/frontend/src/routes/overview-panel/mapPorts.ts
+++ b/frontend/src/routes/overview-panel/mapPorts.ts
@@ -1,5 +1,5 @@
 import type { InterfaceResponse } from '../../api';
-import type { PortSlot, PortStatus, RateTone, ResolvedSlot, SlotKind } from './types';
+import type { IfaceLink, PortSlot, PortStatus, RateTone, ResolvedSlot, SlotKind } from './types';
 
 const PORT_KINDS: SlotKind[] = ['ethernet', 'sfp'];
 
@@ -51,6 +51,12 @@ const deriveRateTone = (
   return actual >= nominal / 10 ? 'degraded' : 'bad';
 };
 
+const formatLinkSpeed = (link: IfaceLink | undefined): string | undefined => {
+  if (!link) return undefined;
+  if (link.fullDuplex === undefined) return link.rate;
+  return `${link.rate} ${link.fullDuplex ? 'full' : 'half'} duplex`;
+};
+
 const deriveStatus = (iface: InterfaceResponse | undefined): PortStatus => {
   if (!iface) return 'absent';
   if (iface.disabled) return 'disabled';
@@ -60,7 +66,7 @@ const deriveStatus = (iface: InterfaceResponse | undefined): PortStatus => {
 export function mapPorts(
   slots: PortSlot[],
   interfaces: InterfaceResponse[],
-  ifaceRates?: Readonly<Record<string, string>>,
+  ifaceRates?: Readonly<Record<string, IfaceLink>>,
 ): ResolvedSlot[] {
   return slots.map((slot) => {
     if (!PORT_KINDS.includes(slot.kind)) {
@@ -79,14 +85,16 @@ export function mapPorts(
     const rxLabel = iface?.rx;
     const txLabel = iface?.tx;
     const mtu = iface?.actualMtu;
-    const rate = status === 'up' ? ifaceRates?.[name.toLowerCase()] : undefined;
+    const link = status === 'up' ? ifaceRates?.[name.toLowerCase()] : undefined;
+    const rate = link?.rate;
+    const linkSpeed = formatLinkSpeed(link);
     const rateTone = deriveRateTone(rate, slot.nominalSpeed);
     let tooltip: string;
     if (status === 'absent') {
       tooltip = `${name} · not detected`;
     } else {
       const parts = [name, STATUS_LABEL[status]];
-      if (rate) parts.push(rate);
+      if (linkSpeed) parts.push(linkSpeed);
       if (rxLabel) parts.push(`↓ ${rxLabel}`);
       if (txLabel) parts.push(`↑ ${txLabel}`);
       if (mtu) parts.push(`${mtu} MTU`);
@@ -101,6 +109,7 @@ export function mapPorts(
       txLabel,
       mtu,
       rate,
+      linkSpeed,
       rateTone,
     };
   });

--- a/frontend/src/routes/overview-panel/types.ts
+++ b/frontend/src/routes/overview-panel/types.ts
@@ -4,6 +4,11 @@ export type PortStatus = 'up' | 'down' | 'disabled' | 'absent';
 
 export type RateTone = 'ok' | 'degraded' | 'bad';
 
+export interface IfaceLink {
+  rate: string;
+  fullDuplex?: boolean;
+}
+
 export interface PortSlot {
   id: string;
   kind: SlotKind;
@@ -35,6 +40,7 @@ export interface ResolvedSlot extends PortSlot {
   txLabel?: string;
   mtu?: number;
   rate?: string;
+  linkSpeed?: string;
   rateTone?: RateTone;
 }
 


### PR DESCRIPTION
Closes #742

- Show negotiated link speed and duplex in the port popover
- Use the duplex flag the backend already returns with each port rate
- Shows on both the LAN page and Overview tab port diagrams