### PR TITLE
feat(installer): enable DHCP snooping on the LAN bridge

### DIFF
--- a/scripts/nasnet-lan-baseline.rsc
+++ b/scripts/nasnet-lan-baseline.rsc
@@ -235,6 +235,7 @@
         :if ([/ip/dhcp-server get $dhcpID address-pool] != $poolName) do={
             :error "nasnet-panel: DHCP pool switch verification failed"
         }
+        /interface/bridge set [find name=$lanIface] dhcp-snooping=yes
 
         # Last disruptive operation. Only currently enabled members of this LAN.
         # Do not touch WAN interfaces, move ports, or delete the original bridge.


### PR DESCRIPTION
Closes #717

## Summary
- Turn on DHCP snooping on the LAN bridge during the baseline LAN migration
- Stops a modem or router plugged into a LAN port from handing out addresses
- Routers already on 192.168.10.1 are left unchanged