### PR TITLE
fix(fe): show finished state on updates page when nothing to install

### DIFF
--- a/frontend/src/routes/UpdatesPage.module.scss
+++ b/frontend/src/routes/UpdatesPage.module.scss
@@ -163,9 +163,26 @@
     box-shadow 160ms ease;
 }
 
-.versionStopMatched {
-  border-color: rgba(62, 194, 141, 0.35);
-  background: rgba(62, 194, 141, 0.05);
+.upToDate {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.upToDateIcon {
+  flex-shrink: 0;
+  color: var(--color-success);
+}
+
+.upToDateBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
 }
 
 .versionStopHighlight {

--- a/frontend/src/routes/UpdatesPage.tsx
+++ b/frontend/src/routes/UpdatesPage.tsx
@@ -338,37 +338,43 @@ function AppUpdateCard() {
                   ) : null}
                 </div>
 
-                <div className={styles.versionTrack}>
-                  <div className={styles.versionStop}>
-                    <span className={styles.versionStopLabel}>
-                      <Tag size={12} aria-hidden /> Current
-                    </span>
-                    <span className={styles.versionStopValue} data-testid="app-current-version">
-                      {check.appVersion}
-                    </span>
+                {check.updateAvailable ? (
+                  <div className={styles.versionTrack}>
+                    <div className={styles.versionStop}>
+                      <span className={styles.versionStopLabel}>
+                        <Tag size={12} aria-hidden /> Current
+                      </span>
+                      <span className={styles.versionStopValue} data-testid="app-current-version">
+                        {check.appVersion}
+                      </span>
+                    </div>
+                    <ArrowRight
+                      size={20}
+                      aria-hidden
+                      className={`${styles.versionArrow} ${styles.versionArrowActive}`}
+                    />
+                    <div className={`${styles.versionStop} ${styles.versionStopHighlight}`}>
+                      <span className={styles.versionStopLabel}>
+                        <Sparkles size={12} aria-hidden /> Latest
+                      </span>
+                      <span className={styles.versionStopValue} data-testid="app-latest-version">
+                        {check.latestVersion}
+                      </span>
+                    </div>
                   </div>
-                  <ArrowRight
-                    size={20}
-                    aria-hidden
-                    className={`${styles.versionArrow} ${
-                      check.updateAvailable ? styles.versionArrowActive : ''
-                    }`}
-                  />
-                  <div
-                    className={`${styles.versionStop} ${
-                      check.updateAvailable
-                        ? styles.versionStopHighlight
-                        : styles.versionStopMatched
-                    }`}
-                  >
-                    <span className={styles.versionStopLabel}>
-                      <Sparkles size={12} aria-hidden /> Latest
-                    </span>
-                    <span className={styles.versionStopValue} data-testid="app-latest-version">
-                      {check.latestVersion}
-                    </span>
+                ) : (
+                  <div className={styles.upToDate}>
+                    <CheckCircle2 size={22} aria-hidden className={styles.upToDateIcon} />
+                    <div className={styles.upToDateBody}>
+                      <span className={styles.versionStopLabel}>
+                        <Tag size={12} aria-hidden /> Current
+                      </span>
+                      <span className={styles.versionStopValue} data-testid="app-current-version">
+                        {check.appVersion}
+                      </span>
+                    </div>
                   </div>
-                </div>
+                )}
               </>
             ) : null}
 
@@ -523,6 +529,7 @@ function FirmwareUpdateCard() {
   };
 
   const channel = meta?.channel || check?.channel;
+  const downloaded = /^downloaded/i.test(check?.status ?? '');
 
   return (
     <Card>
@@ -592,44 +599,56 @@ function FirmwareUpdateCard() {
                   ) : null}
                 </div>
 
-                <div className={styles.versionTrack}>
-                  <div className={styles.versionStop}>
-                    <span className={styles.versionStopLabel}>
-                      <Tag size={12} aria-hidden /> Current
-                    </span>
-                    <span className={styles.versionStopValue}>{check.installedVersion || '—'}</span>
+                {check.updateAvailable ? (
+                  <div className={styles.versionTrack}>
+                    <div className={styles.versionStop}>
+                      <span className={styles.versionStopLabel}>
+                        <Tag size={12} aria-hidden /> Current
+                      </span>
+                      <span className={styles.versionStopValue}>
+                        {check.installedVersion || '—'}
+                      </span>
+                    </div>
+                    <ArrowRight
+                      size={20}
+                      aria-hidden
+                      className={`${styles.versionArrow} ${styles.versionArrowActive}`}
+                    />
+                    <div className={`${styles.versionStop} ${styles.versionStopHighlight}`}>
+                      <span className={styles.versionStopLabel}>
+                        <Sparkles size={12} aria-hidden /> Latest
+                      </span>
+                      <span className={styles.versionStopValue}>{check.latestVersion || '—'}</span>
+                    </div>
                   </div>
-                  <ArrowRight
-                    size={20}
-                    aria-hidden
-                    className={`${styles.versionArrow} ${
-                      check.updateAvailable ? styles.versionArrowActive : ''
-                    }`}
-                  />
-                  <div
-                    className={`${styles.versionStop} ${
-                      check.updateAvailable
-                        ? styles.versionStopHighlight
-                        : styles.versionStopMatched
-                    }`}
-                  >
-                    <span className={styles.versionStopLabel}>
-                      <Sparkles size={12} aria-hidden /> Latest
-                    </span>
-                    <span className={styles.versionStopValue}>{check.latestVersion || '—'}</span>
+                ) : (
+                  <div className={styles.upToDate}>
+                    <CheckCircle2 size={22} aria-hidden className={styles.upToDateIcon} />
+                    <div className={styles.upToDateBody}>
+                      <span className={styles.versionStopLabel}>
+                        <Tag size={12} aria-hidden /> Current
+                      </span>
+                      <span className={styles.versionStopValue}>
+                        {check.installedVersion || '—'}
+                      </span>
+                    </div>
                   </div>
-                </div>
+                )}
               </>
             ) : null}
 
-            {check?.updateAvailable ? (
+            {check?.updateAvailable || downloaded ? (
               <div className={styles.actions}>
-                <Button variant="success" onClick={() => setConfirming(true)} disabled={installing}>
+                <Button
+                  variant="success"
+                  onClick={() => setConfirming(true)}
+                  disabled={installing || downloaded}
+                >
                   {installing ? (
                     <>
                       <Loader2 size={14} aria-hidden /> Installing…
                     </>
-                  ) : complete ? (
+                  ) : complete || downloaded ? (
                     <>
                       <CheckCircle2 size={14} aria-hidden /> Done
                     </>


### PR DESCRIPTION
Closes #739

## Summary
- Up to date cards show a checkmark with the installed version instead of the current to latest track
- Firmware card shows a disabled Done button once RouterOS reports the update as downloaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer update status cards for apps and firmware when devices are already up to date.
  * Update cards now distinguish between available updates and current versions.
  * Firmware cards indicate when an update has already been downloaded.

* **UI Improvements**
  * Updated action labels to “Update app” and “Update firmware.”
  * Added success styling and check icons for up-to-date status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->