### PR TITLE
fix(installer): remove baseline rules on uninstall and update LAN wording

### DIFF
--- a/graphical-installer/frontend/dist/index.html
+++ b/graphical-installer/frontend/dist/index.html
@@ -120,7 +120,7 @@
             </fieldset>
             <label class="check">
               <input type="checkbox" id="skipLanBaseline" />
-              <span>Skip LAN baseline (LANBridgeSplit, 192.168.10.0/24)</span>
+              <span>Skip LAN baseline (192.168.10.1/24 on the existing LAN bridge)</span>
             </label>
             <label class="check">
               <input type="checkbox" id="dryRun" />

--- a/graphical-installer/internal/install/uninstall.go
+++ b/graphical-installer/internal/install/uninstall.go
@@ -59,6 +59,7 @@ func (e *Engine) stepRemoveNetwork() error {
 	e.removeObj("nat "+commentTag+"-container-dns-udp", "/ip/firewall/nat", fmt.Sprintf("comment=%q", commentTag+"-container-dns-udp"))
 	e.removeObj("filter forward", "/ip/firewall/filter", fmt.Sprintf("comment=%q", commentTag+"-forward"))
 	e.removeObj("filter forward-https", "/ip/firewall/filter", fmt.Sprintf("comment=%q", commentTag+"-forward-https"))
+	e.removeObj("filter nasnet-panel-baseline-container-router", "/ip/firewall/filter", fmt.Sprintf("comment=%q", "nasnet-panel-baseline-container-router"))
 	e.removeObj("bridge port "+vethName, "/interface/bridge/port", "interface="+vethName)
 	e.removeObj("bridge port "+legacyVethName, "/interface/bridge/port", "interface="+legacyVethName)
 	e.removeObj("ip "+bridgeIPCIDR, "/ip/address", fmt.Sprintf("address=%q", bridgeIPCIDR))

--- a/scripts/INSTALL.md
+++ b/scripts/INSTALL.md
@@ -89,7 +89,7 @@ SSHPASS=secret bash install.sh --config router.env
 
 ### The baseline LAN
 
-As its final step, the script moves the router's LAN onto the same bridge the setup wizard uses (`LANBridgeSplit`, `192.168.10.1/24`, with DHCP for `192.168.10.2-254`). This keeps you connected while the wizard later reconfigures the router: the wizard preserves this bridge, so your connection to the panel survives the process. The change runs as a detached RouterOS job, so it completes even though it briefly interrupts your session. Interfaces acting as WAN uplinks (DHCP client or PPPoE) are left out of the bridge. On a device in AP/bridge mode (all ports on one uplink bridge) the bridge is created but has no member ports, so the panel remains at the router's current address until the wizard runs.
+As its final step, the script prepares the router for the panel and moves the default LAN to `192.168.10.1/24`. It keeps your existing LAN bridge and its ports, adds `192.168.10.1/24` to that bridge, and switches its DHCP server to hand out `192.168.10.2-254`. The old `192.168.88.1` address stays on the bridge for clients that have not renewed yet. It also enables NTP, sets fallback DNS servers when the router has none, and adds the container DNS and container-to-router firewall rules. The change runs as a detached RouterOS job, so it completes even though it briefly interrupts your session. The LAN move needs the default `192.168.88.1/24` LAN with one DHCP server and no static leases; a router that already has `192.168.10.1/24` keeps its LAN as it is.
 
 The RouterOS commands live in `scripts/nasnet-lan-baseline.rsc`. The script uploads the copy sitting next to `install.sh`; if you downloaded `install.sh` on its own, the file is fetched from the repository automatically.
 
@@ -107,7 +107,7 @@ To remove the panel later:
 bash install.sh --uninstall --config router.env
 ```
 
-This removes the container, its networking, the installer firewall rules, and the uploaded files. It does not restore your original LAN: the baseline bridge (`LANBridgeSplit`, `192.168.10.1/24`) and its DHCP server stay in place, since that is now the router's LAN.
+This removes the container, its networking, the installer firewall rules, and the uploaded files. It does not restore your original LAN: `192.168.10.1/24` and its DHCP pool stay on your LAN bridge, since that is now the router's LAN.
 
 ## Route 2: Manual installation via Winbox or terminal
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,7 +76,7 @@ Usage: install.sh [options]
   --storage <name>     Router storage for the container (disk slot name, or "internal").
   --lan-port <port>    LAN port for dstnat to panel HTTP (default: 8080).
   --https-lan-port <port>  LAN port for dstnat to panel HTTPS (default: 8443).
-  --no-lan-baseline    Skip the baseline LAN setup (LANBridgeSplit, 192.168.10.0/24).
+  --no-lan-baseline    Skip the baseline LAN setup (192.168.10.1/24 on the existing LAN bridge).
   --no-rollback        Do not undo partial state on failure.
   -v, --verbose        Verbose output.
   -h, --help           This help.
@@ -1192,8 +1192,11 @@ uninstall_path() {
   ros_remove "nat ${COMMENT_TAG}-srcnat"       /ip/firewall/nat    "comment=\"${COMMENT_TAG}-srcnat\""
   ros_remove "nat ${COMMENT_TAG}-dstnat"       /ip/firewall/nat    "comment=\"${COMMENT_TAG}-dstnat\""
   ros_remove "nat ${COMMENT_TAG}-dstnat-https" /ip/firewall/nat    "comment=\"${COMMENT_TAG}-dstnat-https\""
+  ros_remove "nat ${COMMENT_TAG}-container-dns-tcp" /ip/firewall/nat "comment=\"${COMMENT_TAG}-container-dns-tcp\""
+  ros_remove "nat ${COMMENT_TAG}-container-dns-udp" /ip/firewall/nat "comment=\"${COMMENT_TAG}-container-dns-udp\""
   ros_remove "filter forward"                  /ip/firewall/filter "comment=\"${COMMENT_TAG}-forward\""
   ros_remove "filter forward-https"            /ip/firewall/filter "comment=\"${COMMENT_TAG}-forward-https\""
+  ros_remove "filter nasnet-panel-baseline-container-router" /ip/firewall/filter "comment=\"nasnet-panel-baseline-container-router\""
   ros_remove "bridge port ${VETH_NAME}"   /interface/bridge/port "interface=${VETH_NAME}"
   ros_remove "bridge port ${LEGACY_VETH_NAME}" /interface/bridge/port "interface=${LEGACY_VETH_NAME}"
   ros_remove "ip ${BRIDGE_IP_CIDR}"       /ip/address          "address=\"${BRIDGE_IP_CIDR}\""


### PR DESCRIPTION
Closes #744

- Uninstall removes the container-to-router filter rule the baseline adds
- Shell uninstall also removes the container DNS NAT rules
- Skip label, CLI help and install docs describe the new LAN baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Uninstall now fully removes container DNS and router firewall rules created by the baseline network setup.
  - Network baseline configuration now applies to the existing LAN bridge, preserving connected ports and supporting the updated LAN address and DHCP range.

- **Documentation**
  - Updated installation guidance and command help to reflect the existing LAN bridge configuration.
  - Clarified retained legacy client addressing, NTP and DNS setup, and container networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->