### PR TITLE
fix(fe): refresh installed plugins menu on login and install

### DIFF
--- a/frontend/src/api/plugins.ts
+++ b/frontend/src/api/plugins.ts
@@ -116,7 +116,7 @@ export async function fetchPluginInstallStatus(
   signal?: AbortSignal,
 ): Promise<PluginInstallStatusResponse> {
   return apiRequest<PluginInstallStatusResponse>(
-    `/api/plugin/status/${encodeURIComponent(pluginId)}`,
+    `/api/plugin/install/status/${encodeURIComponent(pluginId)}`,
     {
       method: 'GET',
       headers: authHeaders(creds),

--- a/frontend/src/state/InstalledPluginsContext.tsx
+++ b/frontend/src/state/InstalledPluginsContext.tsx
@@ -23,17 +23,17 @@ export const InstalledPluginsProvider: React.FC<{ children: React.ReactNode }> =
   const { activeRouterId, getCredentials } = useSession();
   const router = useRouter(activeRouterId ?? undefined);
   const host = router?.host;
+  const creds = activeRouterId ? getCredentials(activeRouterId) : undefined;
   const [plugins, setPlugins] = useState<InstalledPluginResponse[]>([]);
   const loadedRef = useRef<string | null>(null);
   const mutationRef = useRef(0);
 
   useEffect(() => {
-    if (!activeRouterId || !host) return;
-    if (loadedRef.current === activeRouterId) return;
-    const creds = getCredentials(activeRouterId);
-    if (!creds) return;
-    if (loadedRef.current !== null) setPlugins([]);
-    loadedRef.current = activeRouterId;
+    if (!activeRouterId || !host || !creds) return;
+    if (loadedRef.current !== activeRouterId) {
+      if (loadedRef.current !== null) setPlugins([]);
+      loadedRef.current = activeRouterId;
+    }
     const mutation = mutationRef.current;
     const controller = new AbortController();
     void fetchInstalledPlugins({ host, ...creds }, controller.signal)
@@ -41,11 +41,9 @@ export const InstalledPluginsProvider: React.FC<{ children: React.ReactNode }> =
         if (controller.signal.aborted || mutation !== mutationRef.current) return;
         setPlugins(installed);
       })
-      .catch(() => {
-        if (!controller.signal.aborted) loadedRef.current = null;
-      });
+      .catch(() => {});
     return () => controller.abort();
-  }, [activeRouterId, host, getCredentials]);
+  }, [activeRouterId, host, creds]);
 
   const markInstalled = useCallback((plugin: InstalledPluginResponse) => {
     mutationRef.current += 1;

--- a/frontend/tests/e2e/26-plugins-page.spec.ts
+++ b/frontend/tests/e2e/26-plugins-page.spec.ts
@@ -126,7 +126,7 @@ test.describe('Plugins page', () => {
       });
     });
 
-    await context.route('**/api/plugin/status/*', async (route) => {
+    await context.route('**/api/plugin/install/status/*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -187,7 +187,7 @@ test.describe('Plugins page', () => {
       });
     });
 
-    await context.route('**/api/plugin/status/*', async (route) => {
+    await context.route('**/api/plugin/install/status/*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',


### PR DESCRIPTION
Closes #720

## Summary
- Poll install progress on the relocated status route so finished installs show up in the plugins menu
- Refetch installed plugins whenever a router session starts or its credentials change