### PR TITLE
feat(be): Added endpoint for connected vpn user

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -179,6 +179,70 @@ func HandleListVPNClients(c echo.Context) error {
 	return SuccessResponse(c, http.StatusOK, "VPN clients retrieved successfully", response)
 }
 
+// HandleListActiveVPNConnections lists every currently active VPN connection
+// @Summary List Active VPN Connections
+// @Description Returns every currently active (connected) VPN connection across all VPN
+// @Description types: PPP-based sessions (PPTP, L2TP, SSTP, OVPN, PPPoE) from /ppp/active,
+// @Description and WireGuard peers that have completed at least one handshake.
+// @Tags VPN
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Produce json
+// @Success 200 {object} Response{data=ActiveVPNConnectionsResponse}
+// @Failure 500 {object} Response
+// @Router /api/vpn/active [get].
+func HandleListActiveVPNConnections(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	sessions, err := client.GetPPPActiveSessions()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve active PPP sessions", err)
+	}
+
+	peers, err := client.ListAllWireGuardPeers()
+	if err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve WireGuard peers", err)
+	}
+
+	response := ToActiveVPNConnectionsResponse(sessions, peers)
+
+	return SuccessResponse(c, http.StatusOK, "Active VPN connections retrieved successfully", response)
+}
+
+// HandleRemovePPPActiveSession disconnects an active PPP-based VPN session
+// @Summary Remove Active VPN Connection
+// @Description Disconnects an active PPP-based VPN session (PPTP, L2TP, SSTP, OVPN or PPPoE),
+// @Description identified by its /ppp/active id, without touching its underlying PPP secret.
+// @Tags VPN
+// @Security BasicAuth
+// @Param X-RouterOS-Host header string true "RouterOS host address"
+// @Param id path string true "Active PPP session id"
+// @Produce json
+// @Success 200 {object} Response
+// @Failure 400 {object} Response
+// @Failure 500 {object} Response
+// @Router /api/vpn/active/{id} [delete].
+func HandleRemovePPPActiveSession(c echo.Context) error {
+	client, err := GetRouterOSClient(c)
+	if err != nil {
+		return err
+	}
+
+	id := c.Param("id")
+	if id == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "active session id is required", nil)
+	}
+
+	if err := client.RemovePPPActiveSession(id); err != nil {
+		return ErrorResponse(c, http.StatusInternalServerError, "Failed to remove active PPP session", err)
+	}
+
+	return SuccessResponse(c, http.StatusOK, "Active VPN connection removed successfully", nil)
+}
+
 // HandleGetVPNClient gets a specific VPN client by name or ID
 // @Summary Get VPN Client
 // @Description Get details of a specific VPN client interface

--- a/backend/internal/handler/vpn_dto.go
+++ b/backend/internal/handler/vpn_dto.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"strings"
+
 	"nasnet-panel/pkg/utils"
 
 	"nasnet-panel/pkg/routeros"
@@ -612,6 +614,124 @@ type UpdateVPNUserByIDRequest struct {
 	LimitBytesIn  *int64  `json:"limitBytesIn,omitempty"`
 	LimitBytesOut *int64  `json:"limitBytesOut,omitempty"`
 	Comment       *string `json:"comment,omitempty"`
+}
+
+// PPPActiveSessionResponse represents one active (connected) PPP-based VPN
+// session in the API response — PPTP, L2TP, SSTP, OVPN and PPPoE all
+// authenticate through PPP and are reported here, distinguished by service.
+type PPPActiveSessionResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Service   string `json:"service" example:"sstp"`
+	Address   string `json:"address,omitempty"`
+	CallerID  string `json:"callerID,omitempty"`
+	Uptime    string `json:"uptime"`
+	Encoding  string `json:"encoding,omitempty"`
+	SessionID string `json:"sessionID,omitempty"`
+}
+
+// ActiveVPNConnectionsResponse represents every currently active VPN
+// connection across all VPN types: PPPSessions covers PPP-based VPN types
+// (PPTP, L2TP, SSTP, OVPN, PPPoE) from /ppp/active, and WireGuardPeers
+// covers WireGuard peers that have completed at least one handshake.
+type ActiveVPNConnectionsResponse struct {
+	PPPSessions    []PPPActiveSessionResponse    `json:"pppSessions"`
+	WireGuardPeers []ActiveWireGuardPeerResponse `json:"wireguardPeers"`
+}
+
+// ActiveWireGuardPeerResponse represents one active WireGuard peer in the
+// GET /api/vpn/active response — a reduced field set compared to
+// WireGuardPeerResponse, scoped to what's relevant for an active-connection
+// listing.
+type ActiveWireGuardPeerResponse struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	InterfaceName    string `json:"interfaceName"`
+	PublicKey        string `json:"publicKey"`
+	AllowedAddresses string `json:"allowedAddresses"`
+	ClientAddress    string `json:"clientAddress"`
+	LastHandshake    string `json:"lastHandshake" example:"1d 12:12:12"`
+	RxBytes          int64  `json:"rxBytes"`
+	TxBytes          int64  `json:"txBytes"`
+	Rx               string `json:"rx"`
+	Tx               string `json:"tx"`
+	Dynamic          bool   `json:"dynamic"`
+	Disabled         bool   `json:"disabled"`
+}
+
+// ToPPPActiveSessionResponse converts a RouterOS PPPActiveSessionInfo to API PPPActiveSessionResponse.
+func ToPPPActiveSessionResponse(session *routeros.PPPActiveSessionInfo) PPPActiveSessionResponse {
+	return PPPActiveSessionResponse{
+		ID:        session.ID,
+		Name:      session.Name,
+		Service:   session.Service,
+		Address:   session.Address,
+		CallerID:  session.CallerID,
+		Uptime:    session.Uptime,
+		Encoding:  session.Encoding,
+		SessionID: session.SessionID,
+	}
+}
+
+// ToPPPActiveSessionResponseList converts a list of RouterOS PPPActiveSessionInfo to API responses.
+func ToPPPActiveSessionResponseList(sessions []routeros.PPPActiveSessionInfo) []PPPActiveSessionResponse {
+	response := make([]PPPActiveSessionResponse, len(sessions))
+	for i := range sessions {
+		response[i] = ToPPPActiveSessionResponse(&sessions[i])
+	}
+	return response
+}
+
+// ToActiveWireGuardPeerResponse converts a RouterOS WireGuardPeerInfo to API ActiveWireGuardPeerResponse.
+func ToActiveWireGuardPeerResponse(peer *routeros.WireGuardPeerInfo) ActiveWireGuardPeerResponse {
+	return ActiveWireGuardPeerResponse{
+		ID:               peer.ID,
+		Name:             peer.Name,
+		InterfaceName:    peer.InterfaceName,
+		PublicKey:        peer.PublicKey,
+		AllowedAddresses: peer.AllowedAddresses,
+		LastHandshake:    utils.FormatRouterOSDuration(peer.LastHandshake),
+		RxBytes:          peer.RxBytes,
+		TxBytes:          peer.TxBytes,
+		Rx:               utils.BytesToSizeString(peer.RxBytes),
+		Tx:               utils.BytesToSizeString(peer.TxBytes),
+		Dynamic:          peer.Dynamic,
+		Disabled:         peer.Disabled,
+		ClientAddress:    peer.ClientAddress,
+	}
+}
+
+// activeWireGuardPeerHandshakeMaxAgeSeconds bounds how stale a WireGuard
+// peer's last handshake may be for ToActiveVPNConnectionsResponse to still
+// consider it actively connected.
+const activeWireGuardPeerHandshakeMaxAgeSeconds = 5 * 60
+
+// ToActiveVPNConnectionsResponse converts active PPP sessions and all
+// WireGuard peers into an ActiveVPNConnectionsResponse. A WireGuard peer is
+// included only if its interface name ends in "-server" (a server-side
+// interface accepting incoming peers, matching the PPP side's "incoming
+// connections only" semantics) and its last handshake is no older than
+// activeWireGuardPeerHandshakeMaxAgeSeconds — a peer with no handshake yet,
+// or whose handshake is stale, isn't actively connected right now.
+func ToActiveVPNConnectionsResponse(sessions []routeros.PPPActiveSessionInfo, peers []routeros.WireGuardPeerInfo) ActiveVPNConnectionsResponse {
+	activePeers := make([]ActiveWireGuardPeerResponse, 0, len(peers))
+	for i := range peers {
+		if !strings.HasSuffix(peers[i].InterfaceName, "-server") {
+			continue
+		}
+		if peers[i].LastHandshake == "" {
+			continue
+		}
+		if utils.RouterOSDurationSeconds(peers[i].LastHandshake) > activeWireGuardPeerHandshakeMaxAgeSeconds {
+			continue
+		}
+		activePeers = append(activePeers, ToActiveWireGuardPeerResponse(&peers[i]))
+	}
+
+	return ActiveVPNConnectionsResponse{
+		PPPSessions:    ToPPPActiveSessionResponseList(sessions),
+		WireGuardPeers: activePeers,
+	}
 }
 
 // VPNProfileResponse represents a PPP profile in the API response.

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -116,6 +116,8 @@ func RegisterRoutes(e *echo.Echo) {
 
 	vpnGroup := e.Group("/api/vpn")
 	vpnGroup.Use(middleware.RouterOSAuth)
+	vpnGroup.GET("/active", handler.HandleListActiveVPNConnections)
+	vpnGroup.DELETE("/active/:id", handler.HandleRemovePPPActiveSession)
 	vpnGroup.GET("/clients", handler.HandleListVPNClients)
 	vpnGroup.GET("/clients/:name", handler.HandleGetVPNClient)
 	vpnGroup.PUT("/clients/:name", handler.HandleUpdateVPNClient)

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -350,6 +350,21 @@ type PingResult struct {
 	Loss     float64
 }
 
+// PPPActiveSessionInfo represents one active (connected) PPP-based VPN
+// session, as reported by /ppp/active — this single table covers every VPN
+// type that authenticates through PPP (PPTP, L2TP, SSTP, OVPN and PPPoE),
+// distinguished by Service.
+type PPPActiveSessionInfo struct {
+	ID        string
+	Name      string
+	Service   string // async | isdn | l2tp | pppoe | pptp | ovpn | sstp
+	Address   string
+	CallerID  string
+	Uptime    string
+	Encoding  string
+	SessionID string
+}
+
 // VPN client interface types.
 const (
 	VPNTypeL2TPOut   = "l2tp-out"
@@ -870,6 +885,47 @@ func (c *Client) SetSstpServer(config SstpServerConfig) error {
 	_, err := c.Set("/interface/sstp-server/server", args...)
 	if err != nil {
 		return fmt.Errorf("failed to configure SSTP server: %w", err)
+	}
+
+	return nil
+}
+
+// GetPPPActiveSessions returns every currently active (connected) PPP-based
+// VPN session. PPTP, L2TP, SSTP, OVPN and PPPoE all authenticate through PPP
+// and share this one table, distinguished by each session's Service.
+func (c *Client) GetPPPActiveSessions() ([]PPPActiveSessionInfo, error) {
+	results, err := c.GetAll("/ppp/active")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list active PPP sessions: %w", err)
+	}
+
+	sessions := make([]PPPActiveSessionInfo, 0)
+	for _, result := range results {
+		sessions = append(sessions, PPPActiveSessionInfo{
+			ID:        result[".id"],
+			Name:      result["name"],
+			Service:   result["service"],
+			Address:   result["address"],
+			CallerID:  result["caller-id"],
+			Uptime:    utils.FormatRouterOSDuration(result["uptime"]),
+			Encoding:  result["encoding"],
+			SessionID: result["session-id"],
+		})
+	}
+
+	return sessions, nil
+}
+
+// RemovePPPActiveSession disconnects an active PPP-based VPN session (PPTP,
+// L2TP, SSTP, OVPN or PPPoE) identified by its /ppp/active .id, dropping
+// that client's connection without touching its underlying PPP secret.
+func (c *Client) RemovePPPActiveSession(id string) error {
+	if id == "" {
+		return fmt.Errorf("active session id is required")
+	}
+
+	if _, err := c.Remove("/ppp/active", "=.id="+id); err != nil {
+		return fmt.Errorf("failed to remove active PPP session %s: %w", id, err)
 	}
 
 	return nil
@@ -1637,6 +1693,26 @@ func (c *Client) GetWireGuardPeers(interfaceName string) ([]WireGuardPeerInfo, e
 			Disabled:               disabled,
 			Comment:                result["comment"],
 		})
+	}
+
+	return peers, nil
+}
+
+// ListAllWireGuardPeers returns every WireGuard peer across every WireGuard
+// interface, unlike GetWireGuardPeers which is scoped to one interface.
+func (c *Client) ListAllWireGuardPeers() ([]WireGuardPeerInfo, error) {
+	interfaces, err := c.ListWireGuards()
+	if err != nil {
+		return nil, err
+	}
+
+	peers := make([]WireGuardPeerInfo, 0)
+	for _, iface := range interfaces {
+		ifacePeers, err := c.GetWireGuardPeers(iface.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get WireGuard peers for interface %s: %w", iface.Name, err)
+		}
+		peers = append(peers, ifacePeers...)
 	}
 
 	return peers, nil

--- a/backend/pkg/utils/format.go
+++ b/backend/pkg/utils/format.go
@@ -119,19 +119,10 @@ func isTimeFormat(s string) bool {
 	return true
 }
 
-// FormatRouterOSDuration converts RouterOS duration format (e.g., "1d12h30m") to human-readable format.
-func FormatRouterOSDuration(routerOSTime string) string {
-	routerOSTime = strings.TrimSpace(routerOSTime)
-	if routerOSTime == "" {
-		return ""
-	}
-
-	days := 0
-	hours := 0
-	minutes := 0
-	seconds := 0
-	milliseconds := 0
-
+// parseRouterOSDurationParts breaks a RouterOS duration string (e.g.,
+// "1d12h30m", "12s", "500ms") into its component parts, shared by
+// FormatRouterOSDuration and RouterOSDurationSeconds.
+func parseRouterOSDurationParts(routerOSTime string) (days, hours, minutes, seconds, milliseconds int) {
 	if strings.Contains(routerOSTime, "w") {
 		weeksPattern := regexp.MustCompile(`(\d+)w`)
 		if match := weeksPattern.FindStringSubmatch(routerOSTime); len(match) > 1 {
@@ -180,12 +171,38 @@ func FormatRouterOSDuration(routerOSTime string) string {
 		}
 	}
 
+	return days, hours, minutes, seconds, milliseconds
+}
+
+// FormatRouterOSDuration converts RouterOS duration format (e.g., "1d12h30m") to human-readable format.
+func FormatRouterOSDuration(routerOSTime string) string {
+	routerOSTime = strings.TrimSpace(routerOSTime)
+	if routerOSTime == "" {
+		return ""
+	}
+
+	days, hours, minutes, seconds, milliseconds := parseRouterOSDurationParts(routerOSTime)
+
 	hasOtherParts := days > 0 || hours > 0 || minutes > 0 || seconds > 0
 	if !hasOtherParts && milliseconds > 0 {
 		return fmt.Sprintf("%.2f", float64(milliseconds)/1000.0)
 	}
 
 	return formatDaysAndTime(days, hours, minutes, seconds)
+}
+
+// RouterOSDurationSeconds converts a RouterOS duration string (e.g.,
+// "1d12h30m", "12s") to its total length in whole seconds. An empty or
+// unparsable string returns 0.
+func RouterOSDurationSeconds(routerOSTime string) int64 {
+	routerOSTime = strings.TrimSpace(routerOSTime)
+	if routerOSTime == "" {
+		return 0
+	}
+
+	days, hours, minutes, seconds, _ := parseRouterOSDurationParts(routerOSTime)
+
+	return int64(days)*86400 + int64(hours)*3600 + int64(minutes)*60 + int64(seconds)
 }
 
 // ToYesNo converts a boolean to RouterOS yes/no format.


### PR DESCRIPTION
* Closes #690

## Summary

Adds visibility into and control over currently active VPN connections.

- `GET /api/vpn/active`: returns currently active VPN connections — PPP-based sessions (PPTP, L2TP, SSTP, OVPN, PPPoE) from `/ppp/active`, plus WireGuard peers on server-side (`-server`-suffixed) interfaces that have handshaked within the last 5 minutes. Stale or never-handshaked WireGuard peers are excluded.
- `DELETE /api/vpn/active/{id}`: disconnects an active PPP-based session by its `/ppp/active` id, without touching the underlying PPP secret.
- New `pkg/routeros` client methods: `GetPPPActiveSessions`, `RemovePPPActiveSession`, `ListAllWireGuardPeers`, and `RouterOSDurationSeconds` (parses a RouterOS duration string into total seconds, shared with the existing `FormatRouterOSDuration`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to view currently active VPN connections, including PPP-based sessions and recently active WireGuard peers.
  * Added the ability to disconnect active PPP VPN sessions.
  * Active connections now include details such as service type, address, uptime, and session information.
  * Added duration handling for VPN session activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->