### PR TITLE
feat(be): Autogen name for l2tp if not supplied, added comment for add/edit l2tp client

### DIFF
--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -303,11 +303,16 @@ func HandleAddL2TPClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
 	}
 
-	if req.Name == "" || req.ConnectTo == "" || req.User == "" || req.Password == "" {
-		return ErrorResponse(c, http.StatusBadRequest, "name, connectTo, user, and password are required", nil)
+	if req.ConnectTo == "" || req.User == "" || req.Password == "" {
+		return ErrorResponse(c, http.StatusBadRequest, "connectTo, user, and password are required", nil)
 	}
 
-	_, err = client.GetVPNClient(req.Name)
+	name := req.Name
+	if name == "" {
+		name = utils.GenerateName(2, "-", utils.LowerCase)
+	}
+
+	_, err = client.GetVPNClient(name)
 	if err == nil {
 		return ErrorResponse(c, http.StatusConflict, "L2TP client with this name already exists", nil)
 	}
@@ -326,12 +331,22 @@ func HandleAddL2TPClient(c echo.Context) error {
 		disabled = *req.Disabled
 	}
 
-	interfaceName := req.Name
+	interfaceName := name
 	if !strings.HasSuffix(interfaceName, "-l2tp-client") {
 		interfaceName += "-l2tp-client"
 	}
 
-	if err := client.AddL2TPClient(interfaceName, req.ConnectTo, req.User, req.Password, profileName, ipsecSecret, useIPsec, disabled); err != nil {
+	if err := client.AddL2TPClient(routeros.AddL2TPClientConfig{
+		Name:        interfaceName,
+		ConnectTo:   req.ConnectTo,
+		User:        req.User,
+		Password:    req.Password,
+		ProfileName: profileName,
+		IPsecSecret: ipsecSecret,
+		Comment:     req.Comment,
+		UseIPsec:    useIPsec,
+		Disabled:    disabled,
+	}); err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to add L2TP client", err)
 	}
 
@@ -419,7 +434,15 @@ func HandleUpdateL2TPClient(c echo.Context) error {
 
 	useIPsecValue := req.IPsecSecret != nil && *req.IPsecSecret != ""
 
-	if err := client.UpdateL2TPClient(nameOrID, req.ConnectTo, req.User, req.Password, req.Disabled, req.IPsecSecret, &useIPsecValue); err != nil {
+	if err := client.UpdateL2TPClient(nameOrID, routeros.UpdateL2TPClientConfig{
+		ConnectTo:   req.ConnectTo,
+		User:        req.User,
+		Password:    req.Password,
+		Disabled:    req.Disabled,
+		IPsecSecret: req.IPsecSecret,
+		Comment:     req.Comment,
+		UseIPsec:    &useIPsecValue,
+	}); err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update L2TP client", err)
 	}
 

--- a/backend/internal/handler/vpn.go
+++ b/backend/internal/handler/vpn.go
@@ -312,7 +312,12 @@ func HandleAddL2TPClient(c echo.Context) error {
 		name = utils.GenerateName(2, "-", utils.LowerCase)
 	}
 
-	_, err = client.GetVPNClient(name)
+	interfaceName := name
+	if !strings.HasSuffix(interfaceName, "-l2tp-client") {
+		interfaceName += "-l2tp-client"
+	}
+
+	_, err = client.GetVPNClient(interfaceName)
 	if err == nil {
 		return ErrorResponse(c, http.StatusConflict, "L2TP client with this name already exists", nil)
 	}
@@ -329,11 +334,6 @@ func HandleAddL2TPClient(c echo.Context) error {
 	disabled := false
 	if req.Disabled != nil {
 		disabled = *req.Disabled
-	}
-
-	interfaceName := name
-	if !strings.HasSuffix(interfaceName, "-l2tp-client") {
-		interfaceName += "-l2tp-client"
 	}
 
 	if err := client.AddL2TPClient(routeros.AddL2TPClientConfig{
@@ -432,7 +432,11 @@ func HandleUpdateL2TPClient(c echo.Context) error {
 		return ErrorResponse(c, http.StatusNotFound, "L2TP client not found", err)
 	}
 
-	useIPsecValue := req.IPsecSecret != nil && *req.IPsecSecret != ""
+	var useIPsec *bool
+	if req.IPsecSecret != nil {
+		useIPsecValue := *req.IPsecSecret != ""
+		useIPsec = &useIPsecValue
+	}
 
 	if err := client.UpdateL2TPClient(nameOrID, routeros.UpdateL2TPClientConfig{
 		ConnectTo:   req.ConnectTo,
@@ -441,7 +445,7 @@ func HandleUpdateL2TPClient(c echo.Context) error {
 		Disabled:    req.Disabled,
 		IPsecSecret: req.IPsecSecret,
 		Comment:     req.Comment,
-		UseIPsec:    &useIPsecValue,
+		UseIPsec:    useIPsec,
 	}); err != nil {
 		return ErrorResponse(c, http.StatusInternalServerError, "Failed to update L2TP client", err)
 	}

--- a/backend/internal/handler/vpn_dto.go
+++ b/backend/internal/handler/vpn_dto.go
@@ -33,7 +33,8 @@ type UpdateVPNClientRequest struct {
 	Comment  *string `json:"comment" example:"Updated comment"`
 }
 
-// AddL2TPClientRequest represents a request to add an L2TP client.
+// AddL2TPClientRequest represents a request to add an L2TP client. If Name
+// is empty, a random two-word lowercase name is generated for it.
 type AddL2TPClientRequest struct {
 	Name        string  `json:"name" example:"my-l2tp/client"`
 	ConnectTo   string  `json:"connectTo" example:"192.168.1.1"`
@@ -41,6 +42,7 @@ type AddL2TPClientRequest struct {
 	Password    string  `json:"password" example:"password123"`
 	Disabled    *bool   `json:"disabled" example:"false"`
 	IPsecSecret *string `json:"ipsecSecret" example:"secretpassphrase123"`
+	Comment     string  `json:"comment,omitempty" example:"Office L2TP client"`
 }
 
 // UpdateL2TPClientRequest represents a request to update an L2TP client.
@@ -52,6 +54,7 @@ type UpdateL2TPClientRequest struct {
 	Password    *string `json:"password" example:"newpassword123"`
 	Disabled    *bool   `json:"disabled" example:"true"`
 	IPsecSecret *string `json:"ipsecSecret" example:"newupdasecretpassphrase123"`
+	Comment     *string `json:"comment" example:"Office L2TP client"`
 }
 
 // L2TPClientResponse represents L2TP client details in the API response.

--- a/backend/internal/template/l2tp_client.tmpl
+++ b/backend/internal/template/l2tp_client.tmpl
@@ -2,7 +2,7 @@
 add name="LANBridgeVPN-L2TP-Client" comment="VPN-L2TP-Client"
 
 /interface l2tp-client
-add name="l2tp-client-L2TP-Client" connect-to="{{ .L2tpClient.ConnectTo }}" comment="L2TP-Client L2TP" \
+add name="wizard-l2tp-client" connect-to="{{ .L2tpClient.ConnectTo }}" comment="L2TP-Client L2TP" \
 random-source-port=yes user="{{ .L2tpClient.User }}" password="{{ .L2tpClient.Password }}" \
 {{ if .L2tpClient.IPsecSecret }}use-ipsec=yes ipsec-secret={{.L2tpClient.IPsecSecret}}{{ else }}use-ipsec=no{{ end }} allow-fast-path=yes allow=mschap2,mschap1 \
 l2tp-proto-version=l2tpv2 dial-on-demand=no disabled=no
@@ -28,8 +28,8 @@ add action=lookup-only-in-table comment="Routing the VPN-L2TP-Client SRC Address
 add action=lookup-only-in-table comment="Routing the VPN-L2TP-Client Routing Mark" disabled=no routing-mark="to-VPN-Client" table="to-VPN-Client"
 
 /interface list member
-add interface="l2tp-client-L2TP-Client" list="WAN" comment="VPN-l2tp-client-L2TP-Client"
-add interface="l2tp-client-L2TP-Client" list="VPN-WAN" comment="VPN-l2tp-client-L2TP-Client"
+add interface="wizard-l2tp-client" list="WAN" comment="VPN-wizard-l2tp-client"
+add interface="wizard-l2tp-client" list="VPN-WAN" comment="VPN-wizard-l2tp-client"
 add interface="LANBridgeVPN-L2TP-Client" list="LAN" comment="VPN-L2TP-Client"
 add interface="LANBridgeVPN-L2TP-Client" list="VPN-L2TP-Client-LAN" comment="VPN-L2TP-Client"
 
@@ -37,7 +37,7 @@ add interface="LANBridgeVPN-L2TP-Client" list="VPN-L2TP-Client-LAN" comment="VPN
 add address="192.168.41.1/24" interface="LANBridgeVPN-L2TP-Client" network="192.168.41.0" comment="VPN-L2TP-Client"
 
 /ip firewall address-list
-add address="{{ .L2tpClient.ConnectTo }}" list=VPNE comment="VPN-L2TP-Client Interface:l2tp-client-L2TP-Client WanInterface:Foreign-Foreign Link Endpoint:{{ .L2tpClient.ConnectTo }} - Endpoint for routing"
+add address="{{ .L2tpClient.ConnectTo }}" list=VPNE comment="VPN-L2TP-Client Interface:wizard-l2tp-client WanInterface:Foreign-Foreign Link Endpoint:{{ .L2tpClient.ConnectTo }} - Endpoint for routing"
 add address="192.168.41.0/24" list="VPN-L2TP-Client-LAN" comment="VPN-L2TP-Client"
 
 /ip firewall mangle
@@ -51,13 +51,13 @@ add action=dst-nat chain=dstnat comment="DNS VPN-L2TP-Client" disabled=yes dst-p
 add interface="LANBridgeVPN-L2TP-Client" type=internal
 
 /ip route
-add dst-address="0.0.0.0/0" gateway="l2tp-client-L2TP-Client" routing-table="to-VPN-Client" scope=30 target-scope=10  comment="Route-to-VPN-Client"
-add check-gateway=ping dst-address="1.0.0.1" gateway="l2tp-client-L2TP-Client" routing-table="to-VPN-Client" \
+add dst-address="0.0.0.0/0" gateway="wizard-l2tp-client" routing-table="to-VPN-Client" scope=30 target-scope=10  comment="Route-to-VPN-Client"
+add check-gateway=ping dst-address="1.0.0.1" gateway="wizard-l2tp-client" routing-table="to-VPN-Client" \
 distance=1 target-scope="11" comment="Route-to-VPN-Client"
-add dst-address="0.0.0.0/0" gateway="l2tp-client-L2TP-Client" routing-table="to-VPN" distance=1 comment="Route-to-VPN-Client"
-add check-gateway=ping dst-address="1.0.0.1" gateway="l2tp-client-L2TP-Client" routing-table="to-VPN" \
+add dst-address="0.0.0.0/0" gateway="wizard-l2tp-client" routing-table="to-VPN" distance=1 comment="Route-to-VPN-Client"
+add check-gateway=ping dst-address="1.0.0.1" gateway="wizard-l2tp-client" routing-table="to-VPN" \
 distance=1 target-scope="11" comment="Route-to-VPN-Client"
-add dst-address="1.0.0.1" gateway="l2tp-client-L2TP-Client" routing-table="main" scope="10" comment="Route-to-VPN-Client"
+add dst-address="1.0.0.1" gateway="wizard-l2tp-client" routing-table="main" scope="10" comment="Route-to-VPN-Client"
 add check-gateway=ping dst-address="0.0.0.0/0" gateway="1.0.0.1" routing-table="main" \
 distance="1" target-scope="11" comment="CheckIP-Route-to-VPN-Client"
 add comment=Blackhole blackhole disabled=no distance=99 dst-address=0.0.0.0/0 gateway="" routing-table="to-VPN-Client"

--- a/backend/pkg/routeros/vpn.go
+++ b/backend/pkg/routeros/vpn.go
@@ -66,6 +66,32 @@ type L2TPClientInfo struct {
 	RemoteIPv6Address string
 }
 
+// AddL2TPClientConfig represents the parameters for adding a new L2TP client.
+type AddL2TPClientConfig struct {
+	Name        string
+	ConnectTo   string
+	User        string
+	Password    string
+	ProfileName string
+	IPsecSecret string
+	Comment     string
+	UseIPsec    bool
+	Disabled    bool
+}
+
+// UpdateL2TPClientConfig represents every field that can be changed on an
+// existing L2TP client via UpdateL2TPClient. Only non-nil fields are
+// applied; everything else on the client is left as it was.
+type UpdateL2TPClientConfig struct {
+	ConnectTo   *string
+	User        *string
+	Password    *string
+	Disabled    *bool
+	IPsecSecret *string
+	Comment     *string
+	UseIPsec    *bool
+}
+
 // OvpnServerInfo represents an OpenVPN server configuration.
 type OvpnServerInfo struct {
 	ID                string
@@ -1320,32 +1346,35 @@ func (c *Client) CreateVPNProfile(profileName string) error {
 	return nil
 }
 
-// AddL2TPClient adds a new L2TP client with the given parameters.
-func (c *Client) AddL2TPClient(name, connectTo, user, password, profileName, ipsecSecret string, useIPsec, disabled bool) error {
+// AddL2TPClient adds a new L2TP client with the given configuration.
+func (c *Client) AddL2TPClient(config AddL2TPClientConfig) error {
 	args := []string{
-		"=name=" + name,
-		"=connect-to=" + connectTo,
-		"=user=" + user,
-		"=password=" + password,
-		"=profile=" + profileName,
-		"=use-ipsec=" + utils.ToYesNo(useIPsec),
-		"=disabled=" + utils.ToYesNo(disabled),
+		"=name=" + config.Name,
+		"=connect-to=" + config.ConnectTo,
+		"=user=" + config.User,
+		"=password=" + config.Password,
+		"=profile=" + config.ProfileName,
+		"=use-ipsec=" + utils.ToYesNo(config.UseIPsec),
+		"=disabled=" + utils.ToYesNo(config.Disabled),
 	}
 
-	if useIPsec && ipsecSecret != "" {
-		args = append(args, "=ipsec-secret="+ipsecSecret)
+	if config.UseIPsec && config.IPsecSecret != "" {
+		args = append(args, "=ipsec-secret="+config.IPsecSecret)
+	}
+	if config.Comment != "" {
+		args = append(args, "=comment="+config.Comment)
 	}
 
 	_, err := c.Add("/interface/l2tp-client", args...)
 	if err != nil {
-		return fmt.Errorf("failed to add L2TP client %s: %w", name, err)
+		return fmt.Errorf("failed to add L2TP client %s: %w", config.Name, err)
 	}
 
 	return nil
 }
 
 // UpdateL2TPClient updates L2TP client settings.
-func (c *Client) UpdateL2TPClient(nameOrID string, connectTo, user, password *string, disabled *bool, ipsecSecret *string, useIPsec *bool) error {
+func (c *Client) UpdateL2TPClient(nameOrID string, config UpdateL2TPClientConfig) error {
 	// Get the L2TP client to find its ID
 	vpnClient, err := c.GetVPNClient(nameOrID)
 	if err != nil {
@@ -1354,28 +1383,32 @@ func (c *Client) UpdateL2TPClient(nameOrID string, connectTo, user, password *st
 
 	args := []string{"=.id=" + vpnClient.ID}
 
-	if connectTo != nil && *connectTo != "" {
-		args = append(args, "=connect-to="+*connectTo)
+	if config.ConnectTo != nil && *config.ConnectTo != "" {
+		args = append(args, "=connect-to="+*config.ConnectTo)
 	}
 
-	if user != nil && *user != "" {
-		args = append(args, "=user="+*user)
+	if config.User != nil && *config.User != "" {
+		args = append(args, "=user="+*config.User)
 	}
 
-	if password != nil && *password != "" {
-		args = append(args, "=password="+*password)
+	if config.Password != nil && *config.Password != "" {
+		args = append(args, "=password="+*config.Password)
 	}
 
-	if disabled != nil {
-		args = append(args, "=disabled="+utils.ToYesNo(*disabled))
+	if config.Disabled != nil {
+		args = append(args, "=disabled="+utils.ToYesNo(*config.Disabled))
 	}
 
-	if useIPsec != nil {
-		args = append(args, "=use-ipsec="+utils.ToYesNo(*useIPsec))
+	if config.UseIPsec != nil {
+		args = append(args, "=use-ipsec="+utils.ToYesNo(*config.UseIPsec))
 	}
 
-	if ipsecSecret != nil && *ipsecSecret != "" {
-		args = append(args, "=ipsec-secret="+*ipsecSecret)
+	if config.IPsecSecret != nil && *config.IPsecSecret != "" {
+		args = append(args, "=ipsec-secret="+*config.IPsecSecret)
+	}
+
+	if config.Comment != nil {
+		args = append(args, "=comment="+*config.Comment)
 	}
 
 	// If only the ID is provided, nothing to update


### PR DESCRIPTION
* Closes #722
## Summary

Adds an optional comment to L2TP client creation/updates and cleans up the client method signatures.

- `POST /api/vpn/l2tp/client`: added `comment`, and `name` is now optional — when omitted, a random two-word lowercase name is generated (e.g. `stone-warrior`), which then flows through the existing `-l2tp-client` suffixing logic unchanged.
- `PUT /api/vpn/l2tp/client/{nameOrID}`: added `comment` (nil leaves the existing comment untouched, matching the other optional fields).
- Refactored `routeros.Client.AddL2TPClient` and `UpdateL2TPClient` to take a single config struct (`AddL2TPClientConfig` / `UpdateL2TPClientConfig`) instead of a long positional-parameter list, matching the existing `AddOvpnServerConfig`/`OvpnServerUpdateConfig` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * L2TP VPN clients can now be created without specifying a name; a name is generated automatically.
  * Added support for comments when creating or updating L2TP VPN clients.
  * L2TP client settings now support more consistent configuration updates, including partial updates.

* **Improvements**
  * IPsec secrets are handled according to whether IPsec is enabled, improving VPN configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->